### PR TITLE
help <cmd> | <cmd> -h

### DIFF
--- a/cmd/lit-af/chancmds.go
+++ b/cmd/lit-af/chancmds.go
@@ -8,6 +8,14 @@ import (
 )
 
 func (lc *litAfClient) FundChannel(textArgs []string) error {
+	if len(textArgs) > 0 && textArgs[0] == "-h" {
+		fmt.Printf("Syntax: fund <peer> <capacity> <initialSend>\n")
+		fmt.Printf("Establish and fund a new lightning channel with the given peer.\n")
+		fmt.Printf("The capacity is the amount of satoshi we insert into the channel,\n")
+		fmt.Printf("and initialSend is the amount we initially hand over to the other party.\n")
+		return nil
+	}
+
 	args := new(litrpc.FundArgs)
 	reply := new(litrpc.StatusReply)
 
@@ -42,6 +50,14 @@ func (lc *litAfClient) FundChannel(textArgs []string) error {
 
 // Request close of a channel.  Need to pass in peer, channel index
 func (lc *litAfClient) CloseChannel(textArgs []string) error {
+	if len(textArgs) > 0 && textArgs[0] == "-h" {
+		fmt.Printf("Syntax: close <channel idx>\n")
+		fmt.Printf("Cooperatively close the channel with the given index by asking\n")
+		fmt.Printf("the other party to finalize the channel pay-out.\n")
+		fmt.Printf("See also: break\n")
+		return nil
+	}
+
 	args := new(litrpc.ChanArgs)
 	reply := new(litrpc.StatusReply)
 
@@ -68,6 +84,14 @@ func (lc *litAfClient) CloseChannel(textArgs []string) error {
 
 // Almost exactly the same as CloseChannel.  Maybe make "break" a bool...?
 func (lc *litAfClient) BreakChannel(textArgs []string) error {
+	if len(textArgs) > 0 && textArgs[0] == "-h" {
+		fmt.Printf("Syntax: break <channel idx>\n")
+		fmt.Printf("Forcibly break the given channel. Note that we need to wait\n")
+		fmt.Printf("a set number of blocks before we can use the money.\n")
+		fmt.Printf("See also: stop\n")
+		return nil
+	}
+
 	args := new(litrpc.ChanArgs)
 	reply := new(litrpc.StatusReply)
 
@@ -94,6 +118,13 @@ func (lc *litAfClient) BreakChannel(textArgs []string) error {
 
 // Push is the shell command which calls PushChannel
 func (lc *litAfClient) Push(textArgs []string) error {
+	if len(textArgs) > 0 && textArgs[0] == "-h" {
+		fmt.Printf("Syntax: push <channel idx> <amount> [<times>]\n")
+		fmt.Printf("Push the given amount (in satoshis) to the other party on the given channel.\n")
+		fmt.Printf("Optionally, the push operation can be repeated <times> number of times.\n")
+		return nil
+	}
+
 	args := new(litrpc.PushArgs)
 	reply := new(litrpc.PushReply)
 

--- a/cmd/lit-af/netcmds.go
+++ b/cmd/lit-af/netcmds.go
@@ -28,6 +28,13 @@ func (lc *litAfClient) RequestAsync() {
 
 // Lis starts listening.  Takes args of port to listen on.
 func (lc *litAfClient) Lis(textArgs []string) error {
+	if len(textArgs) > 0 && textArgs[0] == "-h" {
+		fmt.Printf("Syntax: lis [<port>]\n")
+		fmt.Printf("Start listening for incoming connections.\n")
+		fmt.Printf("The port number, if omitted, defaults to 2448.\n")
+		return nil
+	}
+
 	args := new(litrpc.ListenArgs)
 	reply := new(litrpc.StatusReply)
 
@@ -46,6 +53,14 @@ func (lc *litAfClient) Lis(textArgs []string) error {
 }
 
 func (lc *litAfClient) Connect(textArgs []string) error {
+	if len(textArgs) > 0 && textArgs[0] == "-h" {
+		fmt.Printf("Syntax: con <pubkeyhash>@<hostname>[:<port>]\n")
+		fmt.Printf("Make a connection to another host by connecting to their pubkeyhash\n")
+		fmt.Printf("(printed when listening using the lis command), on the given host.\n")
+		fmt.Printf("A port may be provided; if omitted, 2448 is used.\n")
+		return nil
+	}
+
 	args := new(litrpc.ConnectArgs)
 	reply := new(litrpc.StatusReply)
 
@@ -65,6 +80,12 @@ func (lc *litAfClient) Connect(textArgs []string) error {
 }
 
 func (lc *litAfClient) Say(textArgs []string) error {
+	if len(textArgs) > 0 && textArgs[0] == "-h" {
+		fmt.Printf("Syntax: say <peer> <message>\n")
+		fmt.Printf("Send a message to a peer.\n")
+		return nil
+	}
+
 	args := new(litrpc.SayArgs)
 	reply := new(litrpc.StatusReply)
 

--- a/cmd/lit-af/walletcmds.go
+++ b/cmd/lit-af/walletcmds.go
@@ -9,6 +9,12 @@ import (
 
 // Send sends coins somewhere
 func (lc *litAfClient) Send(textArgs []string) error {
+	if len(textArgs) > 0 && textArgs[0] == "-h" {
+		fmt.Printf("Syntax: send <addr> <amount>\n")
+		fmt.Printf("Send the given amount of satoshis to the given address.\n")
+		return nil
+	}
+
 	args := new(litrpc.SendArgs)
 	reply := new(litrpc.TxidsReply)
 
@@ -46,6 +52,13 @@ func (lc *litAfClient) Send(textArgs []string) error {
 
 // Sweep moves utxos with many 1-in-1-out txs
 func (lc *litAfClient) Sweep(textArgs []string) error {
+	if len(textArgs) > 0 && textArgs[0] == "-h" {
+		fmt.Printf("Syntax: sweep <addr> <howmany> [<drop>]\n")
+		fmt.Printf("Move UTXOs with many 1-in-1-out txs.\n")
+		// TODO: Make this more clear.
+		return nil
+	}
+
 	args := new(litrpc.SweepArgs)
 	reply := new(litrpc.TxidsReply)
 
@@ -85,6 +98,12 @@ func (lc *litAfClient) Sweep(textArgs []string) error {
 //}
 
 func (lc *litAfClient) Fan(textArgs []string) error {
+	if len(textArgs) > 0 && textArgs[0] == "-h" {
+		fmt.Printf("Syntax: fan <addr> <howmany> <howmuch>\n")
+		// TODO: Add description.
+		return nil
+	}
+
 	args := new(litrpc.FanArgs)
 	reply := new(litrpc.TxidsReply)
 	if len(textArgs) < 3 {
@@ -119,6 +138,13 @@ func (lc *litAfClient) Fan(textArgs []string) error {
 
 // Adr makes new addresses
 func (lc *litAfClient) Adr(textArgs []string) error {
+	if len(textArgs) > 0 && textArgs[0] == "-h" {
+		fmt.Printf("Syntax: adr\n")
+		fmt.Printf("Makes a new address.\n")
+		// TODO: Make this more clear.
+		return nil
+	}
+
 	args := new(litrpc.AdrArgs)
 	args.NumToMake = 1
 	reply := new(litrpc.AdrReply)


### PR DESCRIPTION
Added `help <cmd>` | `<cmd> -h` support, with some TODO entries for commands I don't fully understand myself.