### PR TITLE
[bug-fix] Same peer listed multiple times in autocomplete for closed peers

### DIFF
--- a/cmd/lit-af/autocomplete.go
+++ b/cmd/lit-af/autocomplete.go
@@ -44,7 +44,7 @@ func (lc *litAfClient) completeClosedPeers(line string) []string {
 	for _, c := range cReply.Channels {
 		var peerid = fmt.Sprint(c.PeerIdx)
 		var found = false
-		for _, v := range connectedpeers {
+		for _, v := range append(connectedpeers, channelpeers...) {
 			if v == peerid {
 				found = true
 				break


### PR DESCRIPTION
Fixes bug where the same peer would be listed multiple times in autocomplete for closed peers.