### PR TITLE
Trivial: Comment on wop.Hash being unnecessary in bloom filter generation.

### DIFF
--- a/uspv/txstore.go
+++ b/uspv/txstore.go
@@ -112,7 +112,7 @@ func (t *TxStore) GimmeFilter() (*bloom.Filter, error) {
 	// or no...?
 	for _, wop := range allWatchOP {
 		//	 aha, add HASH here, not the outpoint! (txid of fund tx)
-		f.AddHash(&wop.Hash)
+		f.AddHash(&wop.Hash) // this is probably not needed, as only the prevout is added, not prevout.hash (bloom.cpp#182-199)
 		// also add outpoint...?  wouldn't the hash be enough?
 		// not sure why I have to do both of these, but seems like close txs get
 		// ignored without the outpoint, and fund txs get ignored without the


### PR DESCRIPTION
The wop.Hash addition to the local bloom filter is probably useless, so adding a comment about this. Someone else should verify whether this is the case and/or (preferably) make tests to ensure it and then remove this line.