### PR TITLE
Switch to websocket based RPC connection

### DIFF
--- a/cmd/lit-af/lit-af.go
+++ b/cmd/lit-af/lit-af.go
@@ -4,12 +4,13 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"net"
 	"net/rpc"
 	"net/rpc/jsonrpc"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"golang.org/x/net/websocket"
 
 	"github.com/chzyer/readline"
 	"github.com/fatih/color"
@@ -55,7 +56,7 @@ type litAfClient struct {
 
 func setConfig(lc *litAfClient) {
 	hostptr := flag.String("node", "127.0.0.1", "host to connect to")
-	portptr := flag.Int("p", 9750, "port to connect to")
+	portptr := flag.Int("p", 8001, "port to connect to")
 	dirptr := flag.String("dir", filepath.Join(os.Getenv("HOME"), litHomeDirName), "directory to save settings")
 
 	flag.Parse()
@@ -71,15 +72,27 @@ func main() {
 	lc := new(litAfClient)
 	setConfig(lc)
 
-	dialString := fmt.Sprintf("%s:%d", lc.remote, lc.port)
+	//	dialString := fmt.Sprintf("%s:%d", lc.remote, lc.port)
 
-	client, err := net.Dial("tcp", dialString)
+	/*
+		client, err := net.Dial("tcp", dialString)
+		if err != nil {
+			log.Fatal("dialing:", err)
+		}
+		defer client.Close()
+	*/
+
+	//	dialString := fmt.Sprintf("%s:%d", lc.remote, lc.port)
+	origin := "http://127.0.0.1/"
+	urlString := fmt.Sprintf("ws://%s:%d/ws", lc.remote, lc.port)
+	//	url := "ws://127.0.0.1:8000/ws"
+	wsConn, err := websocket.Dial(urlString, "", origin)
 	if err != nil {
-		log.Fatal("dialing:", err)
+		log.Fatal(err)
 	}
-	defer client.Close()
+	defer wsConn.Close()
 
-	lc.rpccon = jsonrpc.NewClient(client)
+	lc.rpccon = jsonrpc.NewClient(wsConn)
 
 	go lc.RequestAsync()
 

--- a/cmd/lit-af/lit-af.go
+++ b/cmd/lit-af/lit-af.go
@@ -10,9 +10,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/chzyer/readline"
 	"github.com/fatih/color"
 	"github.com/mit-dci/lit/lnutil"
-	"github.com/chzyer/readline"
 )
 
 /*
@@ -45,9 +46,10 @@ const (
 )
 
 type litAfClient struct {
-	remote     string
-	port       uint16
-	rpccon     *rpc.Client
+	remote string
+	port   uint16
+	rpccon *rpc.Client
+	//httpcon
 	litHomeDir string
 }
 
@@ -104,8 +106,8 @@ func main() {
 		}
 		rl.SaveHistory(msg)
 
-		cmdslice := strings.Fields(msg)          // chop input up on whitespace
-		fmt.Fprintf(color.Output,"entered command: %s\n", msg) // immediate feedback
+		cmdslice := strings.Fields(msg)                         // chop input up on whitespace
+		fmt.Fprintf(color.Output, "entered command: %s\n", msg) // immediate feedback
 		err = lc.Shellparse(cmdslice)
 		if err != nil { // only error should be user exit
 			log.Fatal(err)

--- a/cmd/lit-af/shell.go
+++ b/cmd/lit-af/shell.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+
 	"github.com/fatih/color"
-	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/litrpc"
+	"github.com/mit-dci/lit/lnutil"
 )
 
 // Shellparse parses user input and hands it to command functions if matching
@@ -22,7 +26,7 @@ func (lc *litAfClient) Shellparse(cmdslice []string) error {
 	if cmd == "help" {
 		err = lc.Help(args)
 		if err != nil {
-			fmt.Fprintf(color.Output,"help error: %s\n", err)
+			fmt.Fprintf(color.Output, "help error: %s\n", err)
 		}
 		return nil
 	}
@@ -30,16 +34,25 @@ func (lc *litAfClient) Shellparse(cmdslice []string) error {
 	if cmd == "adr" {
 		err = lc.Adr(args)
 		if err != nil {
-			fmt.Fprintf(color.Output,"adr error: %s\n", err)
+			fmt.Fprintf(color.Output, "adr error: %s\n", err)
 		}
 		return nil
 	}
 
-	// bal shows the current set of utxos, addresses and score
+	// ls shows the current set of utxos, addresses and score
 	if cmd == "ls" {
 		err = lc.Ls(args)
 		if err != nil {
-			fmt.Fprintf(color.Output,"ls error: %s\n", err)
+			fmt.Fprintf(color.Output, "ls error: %s\n", err)
+		}
+		return nil
+	}
+
+	// ls shows the current set of utxos, addresses and score
+	if cmd == "ls2" {
+		err = lc.Ls2(args)
+		if err != nil {
+			fmt.Fprintf(color.Output, "ls2 error: %s\n", err)
 		}
 		return nil
 	}
@@ -48,7 +61,7 @@ func (lc *litAfClient) Shellparse(cmdslice []string) error {
 	if cmd == "send" {
 		err = lc.Send(args)
 		if err != nil {
-			fmt.Fprintf(color.Output,"send error: %s\n", err)
+			fmt.Fprintf(color.Output, "send error: %s\n", err)
 		}
 		return nil
 	}
@@ -56,7 +69,7 @@ func (lc *litAfClient) Shellparse(cmdslice []string) error {
 	if cmd == "lis" { // listen for lnd peers
 		err = lc.Lis(args)
 		if err != nil {
-			fmt.Fprintf(color.Output,"lis error: %s\n", err)
+			fmt.Fprintf(color.Output, "lis error: %s\n", err)
 		}
 		return nil
 	}
@@ -69,7 +82,7 @@ func (lc *litAfClient) Shellparse(cmdslice []string) error {
 	if cmd == "sweep" { // make lots of 1-in 1-out txs
 		err = lc.Sweep(args)
 		if err != nil {
-			fmt.Fprintf(color.Output,"sweep error: %s\n", err)
+			fmt.Fprintf(color.Output, "sweep error: %s\n", err)
 		}
 		return nil
 	}
@@ -78,7 +91,7 @@ func (lc *litAfClient) Shellparse(cmdslice []string) error {
 	if cmd == "push" {
 		err = lc.Push(args)
 		if err != nil {
-			fmt.Fprintf(color.Output,"push error: %s\n", err)
+			fmt.Fprintf(color.Output, "push error: %s\n", err)
 		}
 		return nil
 	}
@@ -86,7 +99,7 @@ func (lc *litAfClient) Shellparse(cmdslice []string) error {
 	if cmd == "con" { // connect to lnd host
 		err = lc.Connect(args)
 		if err != nil {
-			fmt.Fprintf(color.Output,"con error: %s\n", err)
+			fmt.Fprintf(color.Output, "con error: %s\n", err)
 		}
 		return nil
 	}
@@ -94,7 +107,7 @@ func (lc *litAfClient) Shellparse(cmdslice []string) error {
 	if cmd == "fund" {
 		err = lc.FundChannel(args)
 		if err != nil {
-			fmt.Fprintf(color.Output,"fund error: %s\n", err)
+			fmt.Fprintf(color.Output, "fund error: %s\n", err)
 		}
 		return nil
 	}
@@ -103,21 +116,21 @@ func (lc *litAfClient) Shellparse(cmdslice []string) error {
 	if cmd == "close" {
 		err = lc.CloseChannel(args)
 		if err != nil {
-			fmt.Fprintf(color.Output,"close error: %s\n", err)
+			fmt.Fprintf(color.Output, "close error: %s\n", err)
 		}
 		return nil
 	}
 	if cmd == "break" {
 		err = lc.BreakChannel(args)
 		if err != nil {
-			fmt.Fprintf(color.Output,"break error: %s\n", err)
+			fmt.Fprintf(color.Output, "break error: %s\n", err)
 		}
 		return nil
 	}
 	if cmd == "say" {
 		err = lc.Say(args)
 		if err != nil {
-			fmt.Fprintf(color.Output,"say error: %s\n", err)
+			fmt.Fprintf(color.Output, "say error: %s\n", err)
 		}
 		return nil
 	}
@@ -125,100 +138,49 @@ func (lc *litAfClient) Shellparse(cmdslice []string) error {
 	if cmd == "fan" { // fan-out tx
 		err = lc.Fan(args)
 		if err != nil {
-			fmt.Fprintf(color.Output,"fan error: %s\n", err)
+			fmt.Fprintf(color.Output, "fan error: %s\n", err)
 		}
 		return nil
 	}
 
-	/*
-		if cmd == "msend" {
-			err = MSend(args)
-			if err != nil {
-				fmt.Fprintf(color.Output,"Msend error: %s\n", err)
-			}
-			return nil
-		}
-		if cmd == "rsend" {
-			err = RSend(args)
-			if err != nil {
-				fmt.Fprintf(color.Output,"Rsend error: %s\n", err)
-			}
-			return nil
-		}
-		if cmd == "nsend" {
-			err = NSend(args)
-			if err != nil {
-				fmt.Fprintf(color.Output,"Nsend error: %s\n", err)
-			}
-			return nil
-		}
-
-
-		if cmd == "txs" { // show all txs
-			err = Txs(args)
-			if err != nil {
-				fmt.Fprintf(color.Output,"txs error: %s\n", err)
-			}
-			return nil
-		}
-
-		if cmd == "wcon" { // connect to watch tower
-			err = WCon(args)
-			if err != nil {
-				fmt.Fprintf(color.Output,"wcon error: %s\n", err)
-			}
-			return nil
-		}
-
-		if cmd == "watch" { // connect to watch tower
-			err = Watch(args)
-			if err != nil {
-				fmt.Fprintf(color.Output,"watch error: %s\n", err)
-			}
-			return nil
-		}
-
-
-
-		// Peer to peer actions
-		// send text message
-		if cmd == "say" {
-			err = Say(args)
-			if err != nil {
-				fmt.Fprintf(color.Output,"say error: %s\n", err)
-			}
-			return nil
-		}
-
-		if cmd == "fix" {
-			err = Resume(args)
-			if err != nil {
-				fmt.Fprintf(color.Output,"fix error: %s\n", err)
-			}
-			return nil
-		}
-	*/
-	fmt.Fprintf(color.Output,"Command not recognized. type help for command list.\n")
+	fmt.Fprintf(color.Output, "Command not recognized. type help for command list.\n")
 	return nil
 }
 
 func (lc *litAfClient) Exit(textArgs []string) error {
 	if len(textArgs) > 0 {
 		if len(textArgs) == 1 && textArgs[0] == "-h" {
-			fmt.Fprintf(color.Output,lnutil.White("exit") + "\nAlias: quit\nExit the interactive shell.\n")
+			fmt.Fprintf(color.Output, lnutil.White("exit")+"\nAlias: quit\nExit the interactive shell.\n")
 			return nil
 		}
-		fmt.Fprintf(color.Output,"Unexpected argument: " + textArgs[0])
+		fmt.Fprintf(color.Output, "Unexpected argument: "+textArgs[0])
 		return nil
 	}
 	return fmt.Errorf("User exit")
 }
 
+func (lc *litAfClient) Ls2(textArgs []string) error {
+	resp, err := http.Post("http://127.0.0.1:9750/lit",
+		"application/json",
+		bytes.NewBufferString(
+			`{"jsonrpc":"2.0","id":1,"method":"LitRPC.TxoList","params":[]}`))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("JSON over HTTP response: %s\n", string(b))
+	return nil
+}
+
 func (lc *litAfClient) Ls(textArgs []string) error {
 	if len(textArgs) > 0 && textArgs[0] == "-h" {
-		fmt.Fprintf(color.Output,lnutil.White("ls\n"))
-		fmt.Fprintf(color.Output,"Show various information about our current state, such as connections,\n")
-		fmt.Fprintf(color.Output,"addresses, UTXO's, balances, etc.\n")
+		fmt.Fprintf(color.Output, lnutil.White("ls\n"))
+		fmt.Fprintf(color.Output, "Show various information about our current state, such as connections,\n")
+		fmt.Fprintf(color.Output, "addresses, UTXO's, balances, etc.\n")
 		return nil
 	}
 
@@ -235,9 +197,9 @@ func (lc *litAfClient) Ls(textArgs []string) error {
 		return err
 	}
 	if len(pReply.Connections) > 0 {
-		fmt.Fprintf(color.Output,"\t%s\n", lnutil.Header("Peers:"))
+		fmt.Fprintf(color.Output, "\t%s\n", lnutil.Header("Peers:"))
 		for _, peer := range pReply.Connections {
-			fmt.Fprintf(color.Output,"%s %s\n", lnutil.White(peer.PeerNumber), peer.RemoteHost)
+			fmt.Fprintf(color.Output, "%s %s\n", lnutil.White(peer.PeerNumber), peer.RemoteHost)
 		}
 	}
 
@@ -246,16 +208,16 @@ func (lc *litAfClient) Ls(textArgs []string) error {
 		return err
 	}
 	if len(cReply.Channels) > 0 {
-		fmt.Fprintf(color.Output,"\t%s\n", lnutil.Header("Channels:"))
+		fmt.Fprintf(color.Output, "\t%s\n", lnutil.Header("Channels:"))
 	}
 
 	for _, c := range cReply.Channels {
 		if c.Closed {
-			fmt.Fprintf(color.Output,lnutil.Red("Closed  "))
+			fmt.Fprintf(color.Output, lnutil.Red("Closed  "))
 		} else {
-			fmt.Fprintf(color.Output,lnutil.Green("Channel "))
+			fmt.Fprintf(color.Output, lnutil.Green("Channel "))
 		}
-		fmt.Fprintf(color.Output,"%s (peer %d) %s\n\t cap: %s bal: %s h: %d state: %d\n",
+		fmt.Fprintf(color.Output, "%s (peer %d) %s\n\t cap: %s bal: %s h: %d state: %d\n",
 			lnutil.White(c.CIdx), c.PeerIdx, lnutil.OutPoint(c.OutPoint),
 			lnutil.SatoshiColor(c.Capacity), lnutil.SatoshiColor(c.MyBalance), c.Height, c.StateNum)
 	}
@@ -265,18 +227,18 @@ func (lc *litAfClient) Ls(textArgs []string) error {
 		return err
 	}
 	if len(tReply.Txos) > 0 {
-		fmt.Fprintf(color.Output,lnutil.Header("\tTxos:\n"))
+		fmt.Fprintf(color.Output, lnutil.Header("\tTxos:\n"))
 	}
 	for i, t := range tReply.Txos {
-		fmt.Fprintf(color.Output,"%d %s h:%d amt:%s %s",
+		fmt.Fprintf(color.Output, "%d %s h:%d amt:%s %s",
 			i, lnutil.OutPoint(t.OutPoint), t.Height, lnutil.SatoshiColor(t.Amt), t.KeyPath)
 		if t.Delay != 0 {
-			fmt.Fprintf(color.Output," delay: %d", t.Delay)
+			fmt.Fprintf(color.Output, " delay: %d", t.Delay)
 		}
 		if !t.Witty {
-			fmt.Fprintf(color.Output," non-witness")
+			fmt.Fprintf(color.Output, " non-witness")
 		}
-		fmt.Fprintf(color.Output,"\n")
+		fmt.Fprintf(color.Output, "\n")
 	}
 
 	err = lc.rpccon.Call("LitRPC.GetListeningPorts", nil, lReply)
@@ -285,39 +247,38 @@ func (lc *litAfClient) Ls(textArgs []string) error {
 	}
 	if len(lReply.LisIpPorts) > 0 {
 		fmt.Fprintf(color.Output, "\t%s\n", lnutil.Header("Listening Ports:"))
-		fmt.Fprintf(color.Output,"Listening for connections on port(s) %v with key %s\n", lnutil.White(lReply.LisIpPorts), lReply.Adr)
+		fmt.Fprintf(color.Output, "Listening for connections on port(s) %v with key %s\n", lnutil.White(lReply.LisIpPorts), lReply.Adr)
 	}
-
 
 	err = lc.rpccon.Call("LitRPC.Address", nil, aReply)
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(color.Output,lnutil.Header("\tAddresses:\n"))
+	fmt.Fprintf(color.Output, lnutil.Header("\tAddresses:\n"))
 	for i, a := range aReply.WitAddresses {
-		fmt.Fprintf(color.Output,"%d %s (%s)\n", i, lnutil.Address(a), lnutil.Address(aReply.LegacyAddresses[i]))
+		fmt.Fprintf(color.Output, "%d %s (%s)\n", i, lnutil.Address(a), lnutil.Address(aReply.LegacyAddresses[i]))
 	}
 	err = lc.rpccon.Call("LitRPC.Bal", nil, bReply)
 	if err != nil {
 		return err
 	}
 
-	fmt.Fprintf(color.Output,"\t%s %s %s %s %s %s\n",
+	fmt.Fprintf(color.Output, "\t%s %s %s %s %s %s\n",
 		lnutil.Header("Utxo:"), lnutil.SatoshiColor(bReply.TxoTotal), lnutil.Header("Conf:"), lnutil.SatoshiColor(bReply.Mature), lnutil.Header("Channel:"), lnutil.SatoshiColor(bReply.ChanTotal))
 
 	err = lc.rpccon.Call("LitRPC.SyncHeight", nil, sReply)
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(color.Output,"%s %d\n", lnutil.Header("Sync Height:"), sReply.SyncHeight)
+	fmt.Fprintf(color.Output, "%s %d\n", lnutil.Header("Sync Height:"), sReply.SyncHeight)
 
 	return nil
 }
 
 func (lc *litAfClient) Stop(textArgs []string) error {
 	if len(textArgs) > 0 && textArgs[0] == "-h" {
-		fmt.Fprintf(color.Output,lnutil.White("stop\n"))
-		fmt.Fprintf(color.Output,"Shut down the lit node.\n")
+		fmt.Fprintf(color.Output, lnutil.White("stop\n"))
+		fmt.Fprintf(color.Output, "Shut down the lit node.\n")
 		return nil
 	}
 
@@ -328,7 +289,7 @@ func (lc *litAfClient) Stop(textArgs []string) error {
 		return err
 	}
 
-	fmt.Fprintf(color.Output,"%s\n", reply.Status)
+	fmt.Fprintf(color.Output, "%s\n", reply.Status)
 
 	lc.rpccon.Close()
 	return fmt.Errorf("stopped remote lit node")
@@ -336,13 +297,13 @@ func (lc *litAfClient) Stop(textArgs []string) error {
 
 func (lc *litAfClient) Help(textArgs []string) error {
 	if len(textArgs) == 0 {
-		fmt.Fprintf(color.Output,"commands:\n")
-		fmt.Fprintf(color.Output,"help say ls adr send fan sweep lis con fund push close break stop exit\n")
+		fmt.Fprintf(color.Output, "commands:\n")
+		fmt.Fprintf(color.Output, "help say ls adr send fan sweep lis con fund push close break stop exit\n")
 		return nil
 	}
 	if textArgs[0] == "help" || textArgs[0] == "-h" {
-		fmt.Fprintf(color.Output,"%s%s\n", lnutil.White("help"), lnutil.OptColor("command"))
-		fmt.Fprintf(color.Output,"Show information about a given command\n")
+		fmt.Fprintf(color.Output, "%s%s\n", lnutil.White("help"), lnutil.OptColor("command"))
+		fmt.Fprintf(color.Output, "Show information about a given command\n")
 		return nil
 	}
 	res := make([]string, 0)

--- a/lit.go
+++ b/lit.go
@@ -49,7 +49,7 @@ func setConfig(lc *LitConfig) {
 	bc2ptr := flag.Bool("bc2", false, "use bc2 network (not testnet3)")
 	resyncprt := flag.Bool("resync", false, "force resync from given tip")
 
-	rpcportptr := flag.Int("rpcport", 9750, "port to listen for RPC")
+	rpcportptr := flag.Int("rpcport", 8001, "port to listen for RPC")
 
 	litHomeDir := flag.String("dir", filepath.Join(os.Getenv("HOME"), litHomeDirName), "lit home directory")
 

--- a/litrpc/listener.go
+++ b/litrpc/listener.go
@@ -2,13 +2,14 @@ package litrpc
 
 import (
 	"fmt"
-	"io"
 	"log"
 	"net"
 	"net/http"
 	"net/rpc"
 	"net/rpc/jsonrpc"
 	"time"
+
+	"golang.org/x/net/websocket"
 
 	"github.com/mit-dci/lit/qln"
 )
@@ -24,13 +25,14 @@ It ends up being the root of ~everything in the executable.
 // A LitRPC is the user I/O interface; it owns and initialized a SPVCon and LitNode
 // and listens and responds on RPC
 
-var GlobalServer *rpc.Server
+//var GlobalServer *rpc.Server
 
 type LitRPC struct {
 	Node      *qln.LitNode
 	OffButton chan bool
 }
 
+/*
 type HttpConn struct {
 	in  io.Reader
 	out io.Writer
@@ -39,7 +41,8 @@ type HttpConn struct {
 func (c *HttpConn) Read(p []byte) (n int, err error)  { return c.in.Read(p) }
 func (c *HttpConn) Write(d []byte) (n int, err error) { return c.out.Write(d) }
 func (c *HttpConn) Close() error                      { return nil }
-
+*/
+/*
 func JSONRPCoverHTTPHandler(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path == "/lit" { // all RPC calls have path /lit
 		serverCodec :=
@@ -55,6 +58,10 @@ func JSONRPCoverHTTPHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+} */
+
+func serveWS(ws *websocket.Conn) {
+	jsonrpc.ServeConn(ws)
 }
 
 func RpcListen(node *qln.LitNode, port uint16) {
@@ -62,10 +69,13 @@ func RpcListen(node *qln.LitNode, port uint16) {
 	rpcl.Node = node
 	rpcl.OffButton = make(chan bool, 1)
 
-	GlobalServer = rpc.NewServer()
-	GlobalServer.Register(rpcl)
+	server := rpc.NewServer()
+	server.Register(rpcl)
 
 	//	server.HandleHTTP(rpc.DefaultRPCPath, rpc.DefaultDebugPath)
+
+	http.Handle("/ws", websocket.Handler(serveWS))
+	go http.ListenAndServe("localhost:8000", nil)
 
 	portString := fmt.Sprintf(":%d", port)
 	listener, err := net.Listen("tcp", portString)
@@ -75,22 +85,19 @@ func RpcListen(node *qln.LitNode, port uint16) {
 	}
 	defer listener.Close()
 
-	go http.Serve(listener, http.HandlerFunc(JSONRPCoverHTTPHandler))
+	//	go http.Serve(listener, http.HandlerFunc(JSONRPCoverHTTPHandler))
 
-	/*
-		go func() {
-			for {
-				conn, err := listener.Accept()
-				if err != nil {
-					log.Printf("listener error: " + err.Error())
-				} else {
-					log.Printf("new connection from %s\n", conn.RemoteAddr().String())
-					go server.ServeCodec(jsonrpc.NewServerCodec(conn))
-				}
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				log.Printf("listener error: " + err.Error())
+			} else {
+				log.Printf("new connection from %s\n", conn.RemoteAddr().String())
+				go server.ServeCodec(jsonrpc.NewServerCodec(conn))
 			}
-		}()
-
-	*/
+		}
+	}()
 
 	// ugly; add real synchronization here
 	<-rpcl.OffButton

--- a/litrpc/listener.go
+++ b/litrpc/listener.go
@@ -2,8 +2,10 @@ package litrpc
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"net"
+	"net/http"
 	"net/rpc"
 	"net/rpc/jsonrpc"
 	"time"
@@ -21,9 +23,38 @@ It ends up being the root of ~everything in the executable.
 
 // A LitRPC is the user I/O interface; it owns and initialized a SPVCon and LitNode
 // and listens and responds on RPC
+
+var GlobalServer *rpc.Server
+
 type LitRPC struct {
 	Node      *qln.LitNode
 	OffButton chan bool
+}
+
+type HttpConn struct {
+	in  io.Reader
+	out io.Writer
+}
+
+func (c *HttpConn) Read(p []byte) (n int, err error)  { return c.in.Read(p) }
+func (c *HttpConn) Write(d []byte) (n int, err error) { return c.out.Write(d) }
+func (c *HttpConn) Close() error                      { return nil }
+
+func JSONRPCoverHTTPHandler(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path == "/lit" { // all RPC calls have path /lit
+		serverCodec :=
+			jsonrpc.NewServerCodec(&HttpConn{in: r.Body, out: w})
+		w.Header().Set("Content-type", "application/json")
+		w.WriteHeader(200)
+		// this is super ugly; find a better way to do this.
+		// maybe try a different struct with a ServeHTTP method.
+		err := GlobalServer.ServeRequest(serverCodec)
+		if err != nil {
+			log.Printf("JSON-RPC request serving error: %v", err)
+			http.Error(w, "JSON-RPC request error", 500)
+			return
+		}
+	}
 }
 
 func RpcListen(node *qln.LitNode, port uint16) {
@@ -31,9 +62,10 @@ func RpcListen(node *qln.LitNode, port uint16) {
 	rpcl.Node = node
 	rpcl.OffButton = make(chan bool, 1)
 
-	server := rpc.NewServer()
-	server.Register(rpcl)
-	server.HandleHTTP(rpc.DefaultRPCPath, rpc.DefaultDebugPath)
+	GlobalServer = rpc.NewServer()
+	GlobalServer.Register(rpcl)
+
+	//	server.HandleHTTP(rpc.DefaultRPCPath, rpc.DefaultDebugPath)
 
 	portString := fmt.Sprintf(":%d", port)
 	listener, err := net.Listen("tcp", portString)
@@ -41,18 +73,24 @@ func RpcListen(node *qln.LitNode, port uint16) {
 		fmt.Printf(err.Error())
 		return
 	}
+	defer listener.Close()
 
-	go func() {
-		for {
-			conn, err := listener.Accept()
-			if err != nil {
-				log.Printf("listener error: " + err.Error())
-			} else {
-				log.Printf("new connection from %s\n", conn.RemoteAddr().String())
-				go server.ServeCodec(jsonrpc.NewServerCodec(conn))
+	http.Serve(listener, http.HandlerFunc(JSONRPCoverHTTPHandler))
+
+	/*
+		go func() {
+			for {
+				conn, err := listener.Accept()
+				if err != nil {
+					log.Printf("listener error: " + err.Error())
+				} else {
+					log.Printf("new connection from %s\n", conn.RemoteAddr().String())
+					go server.ServeCodec(jsonrpc.NewServerCodec(conn))
+				}
 			}
-		}
-	}()
+		}()
+
+	*/
 
 	// ugly; add real synchronization here
 	<-rpcl.OffButton

--- a/litrpc/listener.go
+++ b/litrpc/listener.go
@@ -75,7 +75,7 @@ func RpcListen(node *qln.LitNode, port uint16) {
 	}
 	defer listener.Close()
 
-	http.Serve(listener, http.HandlerFunc(JSONRPCoverHTTPHandler))
+	go http.Serve(listener, http.HandlerFunc(JSONRPCoverHTTPHandler))
 
 	/*
 		go func() {

--- a/litrpc/listener.go
+++ b/litrpc/listener.go
@@ -17,46 +17,15 @@ Remote Procedure Calls
 RPCs are how people tell the lit node what to do.
 It ends up being the root of ~everything in the executable.
 
-
 */
 
 // A LitRPC is the user I/O interface; it owns and initialized a SPVCon and LitNode
 // and listens and responds on RPC
 
-//var GlobalServer *rpc.Server
-
 type LitRPC struct {
 	Node      *qln.LitNode
 	OffButton chan bool
 }
-
-/*
-type HttpConn struct {
-	in  io.Reader
-	out io.Writer
-}
-
-func (c *HttpConn) Read(p []byte) (n int, err error)  { return c.in.Read(p) }
-func (c *HttpConn) Write(d []byte) (n int, err error) { return c.out.Write(d) }
-func (c *HttpConn) Close() error                      { return nil }
-*/
-/*
-func JSONRPCoverHTTPHandler(w http.ResponseWriter, r *http.Request) {
-	if r.URL.Path == "/lit" { // all RPC calls have path /lit
-		serverCodec :=
-			jsonrpc.NewServerCodec(&HttpConn{in: r.Body, out: w})
-		w.Header().Set("Content-type", "application/json")
-		w.WriteHeader(200)
-		// this is super ugly; find a better way to do this.
-		// maybe try a different struct with a ServeHTTP method.
-		err := GlobalServer.ServeRequest(serverCodec)
-		if err != nil {
-			log.Printf("JSON-RPC request serving error: %v", err)
-			http.Error(w, "JSON-RPC request error", 500)
-			return
-		}
-	}
-} */
 
 func serveWS(ws *websocket.Conn) {
 	jsonrpc.ServeConn(ws)
@@ -67,39 +36,12 @@ func RpcListen(node *qln.LitNode, port uint16) {
 	rpcl.Node = node
 	rpcl.OffButton = make(chan bool, 1)
 
-	//	server := rpc.NewServer()
 	rpc.Register(rpcl)
 
-	//	server.HandleHTTP(rpc.DefaultRPCPath, rpc.DefaultDebugPath)
+	listenString := fmt.Sprintf("0.0.0.0:%d", port)
 
-	go func() {
-		for {
-			http.Handle("/ws", websocket.Handler(serveWS))
-			http.ListenAndServe("localhost:8001", nil)
-		}
-	}()
-
-	/*
-				portString := fmt.Sprintf(":%d", port)
-				listener, err := net.Listen("tcp", portString)
-				if err != nil {
-					fmt.Printf(err.Error())
-					return
-				}
-				defer listener.Close()
-
-		go func() {
-				for {
-					conn, err := listener.Accept()
-					if err != nil {
-						log.Printf("listener error: " + err.Error())
-					} else {
-						log.Printf("new connection from %s\n", conn.RemoteAddr().String())
-						go server.ServeCodec(jsonrpc.NewServerCodec(conn))
-					}
-				}
-			}()
-	*/
+	http.Handle("/ws", websocket.Handler(serveWS))
+	go http.ListenAndServe(listenString, nil)
 
 	// ugly; add real synchronization here
 	<-rpcl.OffButton

--- a/litrpc/listener.go
+++ b/litrpc/listener.go
@@ -75,7 +75,6 @@ func RpcListen(node *qln.LitNode, port uint16) {
 	//	server.HandleHTTP(rpc.DefaultRPCPath, rpc.DefaultDebugPath)
 
 	http.Handle("/ws", websocket.Handler(serveWS))
-	go http.ListenAndServe("localhost:8000", nil)
 
 	portString := fmt.Sprintf(":%d", port)
 	listener, err := net.Listen("tcp", portString)
@@ -86,6 +85,12 @@ func RpcListen(node *qln.LitNode, port uint16) {
 	defer listener.Close()
 
 	//	go http.Serve(listener, http.HandlerFunc(JSONRPCoverHTTPHandler))
+
+	go func() {
+		for {
+			http.ListenAndServe("localhost:8000", nil)
+		}
+	}()
 
 	go func() {
 		for {


### PR DESCRIPTION
previously, the RPC was json-rpc over a regular TCP connection.

This is nice and simple, but the problem is that browsers and web stuff generally can't make TCP connections.  They can make websocket connections though, which as far as I can tell are pretty much the same as TCP in that it's just bi-directional data.

This PR changes litrpc and lit-af so that they both use websockets.  It's acutally a bit of overhead in that it's a TCP connection, then an HTTP connection, then a websockets connection, THEN the json-rpc goes back and forth.  In practice the code is minimal though and libraries are in "x" which hopefully won't change, and maybe get put into the standard library.

Could also use some HTTP / websocket based auth methods in the future.  (still no RPC auth at all)