### PR TITLE
Use adiabat packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,32 +12,8 @@ Under development, not for use with real money.
 
 3. Download the lit project: `go get github.com/mit-dci/lit`
 
-4. The `go get` will fail. 
-  * Lit uses btcd libraries, and btcd does not yet have segwit support in master.  This will hopefully be merged soon, before segwit activates on mainnet.
-  * I have a fork of btcd from roasbeef/segwit, and could make it go-gettable by changing all the imports, but hopefully it will be merged in soon.
-  * To make it work, switch to the adiabat/btcd libraries:  
+4. Run lit: 
 ```
-# github.com/mit-dci/lit/uspv
-uspv/eight333.go:406: undefined: wire.InvTypeWitnessBlock
-... other errors.
-
-user@host:~/go/src/github.com/mit-dci/lit$ cd ../../btcsuite/btcd/
-
-user@host:~/go/src/github.com/btcsuite/btcd$ git remote add adiabat https://github.com/adiabat/btcd
-user@host:~/go/src/github.com/btcsuite/btcd$ git fetch adiabat
-user@host:~/go/src/github.com/btcsuite/btcd$ git checkout adiabat/bc2
-
-user@host:~/go/src/github.com/btcsuite/btcd$ cd ../btcutil
-
-user@host:~/go/src/github.com/btcsuite/btcutil$ git remote add adiabat https://github.com/adiabat/btcutil
-user@host:~/go/src/github.com/btcsuite/btcutil$ git fetch adiabat
-user@host:~/go/src/github.com/btcsuite/btcutil$ git checkout adiabat/master
-```
-
-5. compile lit, then run it: 
-```
-user@host:~/go/src/github.com/btcsuite/btcutil$ cd ../../mit-dci/lit
-user@host:~/go/src/github.com/mit-dci/lit$ go build -v
 user@host:~/go/src/github.com/mit-dci/lit$ ./lit -spv my.testnet.node.tld
 ```
 

--- a/elkrem/elkrem.go
+++ b/elkrem/elkrem.go
@@ -3,7 +3,7 @@ package elkrem
 import (
 	"fmt"
 
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/adiabat/btcd/chaincfg/chainhash"
 )
 
 /* elkrem is a simpler alternative to the 64 dimensional sha-chain.

--- a/elkrem/elkrem_test.go
+++ b/elkrem/elkrem_test.go
@@ -3,7 +3,7 @@ package elkrem
 import (
 	"testing"
 
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/adiabat/btcd/chaincfg/chainhash"
 )
 
 // TestElkremBig tries 10K hashes

--- a/elkrem/serdes.go
+++ b/elkrem/serdes.go
@@ -5,7 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/adiabat/btcd/chaincfg/chainhash"
 )
 
 /* Serialization and Deserialization methods for the Elkrem structs.

--- a/lit.go
+++ b/lit.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/adiabat/btcd/chaincfg"
 	"github.com/mit-dci/lit/litbamf"
 	"github.com/mit-dci/lit/litrpc"
 	"github.com/mit-dci/lit/lnutil"

--- a/litrpc/walletcmds.go
+++ b/litrpc/walletcmds.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 
 	"github.com/adiabat/bech32"
-	"github.com/btcsuite/btcd/chaincfg"
-	"github.com/btcsuite/btcd/txscript"
-	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcutil"
+	"github.com/adiabat/btcd/chaincfg"
+	"github.com/adiabat/btcd/txscript"
+	"github.com/adiabat/btcd/wire"
+	"github.com/adiabat/btcutil"
 	"github.com/mit-dci/lit/portxo"
 )
 

--- a/lndc/conn.go
+++ b/lndc/conn.go
@@ -9,7 +9,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/btcsuite/btcd/btcec"
+	"github.com/adiabat/btcd/btcec"
 	"github.com/btcsuite/fastsha256"
 	"github.com/codahale/chacha20poly1305"
 	"github.com/mit-dci/lit/lnutil"

--- a/lndc/listener.go
+++ b/lndc/listener.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/btcsuite/btcd/btcec"
+	"github.com/adiabat/btcd/btcec"
 	"github.com/btcsuite/fastsha256"
 	"github.com/codahale/chacha20poly1305"
 )

--- a/lndc/lnadr.go
+++ b/lndc/lnadr.go
@@ -8,9 +8,9 @@ import (
 	"net"
 	"strings"
 
-	"github.com/btcsuite/btcd/btcec"
-	"github.com/btcsuite/btcd/chaincfg"
-	"github.com/btcsuite/btcutil"
+	"github.com/adiabat/btcd/btcec"
+	"github.com/adiabat/btcd/chaincfg"
+	"github.com/adiabat/btcutil"
 )
 
 // lnAddr...

--- a/lndc/lndc_test.go
+++ b/lndc/lndc_test.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/btcsuite/btcd/btcec"
+	"github.com/adiabat/btcd/btcec"
 )
 
 func TestConnectionCorrectness(t *testing.T) {

--- a/lnutil/btclib.go
+++ b/lnutil/btclib.go
@@ -5,10 +5,10 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"github.com/btcsuite/btcd/blockchain"
-	"github.com/btcsuite/btcd/txscript"
-	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcutil"
+	"github.com/adiabat/btcd/blockchain"
+	"github.com/adiabat/btcd/txscript"
+	"github.com/adiabat/btcd/wire"
+	"github.com/adiabat/btcutil"
 	"github.com/btcsuite/fastsha256"
 )
 

--- a/lnutil/btclib_test.go
+++ b/lnutil/btclib_test.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/wire"
+	"github.com/adiabat/btcd/chaincfg/chainhash"
+	"github.com/adiabat/btcd/wire"
 )
 
 // OutPointsEqual
@@ -152,7 +152,7 @@ func TestOutPointToBytes(t *testing.T) {
 
 // OutPointFromBytes
 // test some bytes arrays of 36 byte long
-// this depends on a test of NewOutPoint() in btcsuite/btcd/wire/msgtx.go
+// this depends on a test of NewOutPoint() in adiabat/btcd/wire/msgtx.go
 // and OutPointsEqual() in this file
 func TestOutPointFromBytes(t *testing.T) {
 	// test for a normal situation
@@ -218,7 +218,7 @@ func TestP2WSHify(t *testing.T) {
 
 // DirectWPKHScript
 // test some public keys
-// this depends on a test of Hash160() in btcsuite/btcutil
+// this depends on a test of Hash160() in adiabat/btcutil
 func TestDirectWPKHScript(t *testing.T) {
 	// test for a normal situation(blackbox test)
 	// input: inB33, [33]bytes array, public key

--- a/lnutil/curvelib.go
+++ b/lnutil/curvelib.go
@@ -6,8 +6,8 @@ import (
 	"math/big"
 	"sort"
 
-	"github.com/btcsuite/btcd/btcec"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/adiabat/btcd/btcec"
+	"github.com/adiabat/btcd/chaincfg/chainhash"
 )
 
 // PrivKeyAddBytes adds bytes to a private key.

--- a/lnutil/curvelib_test.go
+++ b/lnutil/curvelib_test.go
@@ -3,8 +3,8 @@ package lnutil
 import (
 	"testing"
 
-	"github.com/btcsuite/btcd/btcec"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/adiabat/btcd/btcec"
+	"github.com/adiabat/btcd/chaincfg/chainhash"
 )
 
 var (

--- a/lnutil/litadr_test.go
+++ b/lnutil/litadr_test.go
@@ -4,7 +4,7 @@ import (
 	"crypto/rand"
 	"testing"
 
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/adiabat/btcd/chaincfg/chainhash"
 )
 
 func TestAdr(t *testing.T) {

--- a/lnutil/lnlib.go
+++ b/lnutil/lnlib.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/btcsuite/btcd/txscript"
-	"github.com/btcsuite/btcd/wire"
+	"github.com/adiabat/btcd/txscript"
+	"github.com/adiabat/btcd/wire"
 )
 
 // CommitScript is the script for 0.13.1: OP_CHECKSIG turned into OP_CHECSIGVERIFY

--- a/lnutil/msglib.go
+++ b/lnutil/msglib.go
@@ -1,8 +1,8 @@
 package lnutil
 
 import (
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/wire"
+	"github.com/adiabat/btcd/chaincfg/chainhash"
+	"github.com/adiabat/btcd/wire"
 )
 
 // all the messages to and from peers look like this internally

--- a/portxo/addwif.go
+++ b/portxo/addwif.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/btcsuite/btcd/chaincfg"
-	"github.com/btcsuite/btcutil"
+	"github.com/adiabat/btcd/chaincfg"
+	"github.com/adiabat/btcutil"
 )
 
 func (u *PorTxo) AddWIF(w btcutil.WIF) error {

--- a/portxo/derive.go
+++ b/portxo/derive.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/btcsuite/btcd/btcec"
-	"github.com/btcsuite/btcutil/hdkeychain"
+	"github.com/adiabat/btcd/btcec"
+	"github.com/adiabat/btcutil/hdkeychain"
 )
 
 // DerivePrivateKey returns the private key for a utxo based on a master key

--- a/portxo/fromtx.go
+++ b/portxo/fromtx.go
@@ -3,7 +3,7 @@ package portxo
 import (
 	"fmt"
 
-	"github.com/btcsuite/btcd/wire"
+	"github.com/adiabat/btcd/wire"
 )
 
 // ExtractFromTx returns a portxo from a tx and index.

--- a/portxo/portxo.go
+++ b/portxo/portxo.go
@@ -5,7 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"github.com/btcsuite/btcd/wire"
+	"github.com/adiabat/btcd/wire"
 )
 
 type TxoMode uint8

--- a/portxo/portxo_test.go
+++ b/portxo/portxo_test.go
@@ -3,7 +3,7 @@ package portxo
 import (
 	"testing"
 
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/adiabat/btcd/chaincfg/chainhash"
 )
 
 // TestHardCoded tests serializing / deserializing a portxo

--- a/portxo/sort.go
+++ b/portxo/sort.go
@@ -3,7 +3,7 @@ package portxo
 import (
 	"bytes"
 
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/adiabat/btcd/chaincfg/chainhash"
 )
 
 // txoSliceByBip69 is a sortable txo slice - same algo as txsort / BIP69

--- a/powless/powless.go
+++ b/powless/powless.go
@@ -13,9 +13,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/btcsuite/btcd/chaincfg"
-	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcutil"
+	"github.com/adiabat/btcd/chaincfg"
+	"github.com/adiabat/btcd/wire"
+	"github.com/adiabat/btcutil"
 	"github.com/mit-dci/lit/lnutil"
 )
 

--- a/qln/basewallet.go
+++ b/qln/basewallet.go
@@ -1,10 +1,10 @@
 package qln
 
 import (
-	"github.com/btcsuite/btcd/btcec"
-	"github.com/btcsuite/btcd/chaincfg"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/wire"
+	"github.com/adiabat/btcd/btcec"
+	"github.com/adiabat/btcd/chaincfg"
+	"github.com/adiabat/btcd/chaincfg/chainhash"
+	"github.com/adiabat/btcd/wire"
 	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/portxo"
 )

--- a/qln/buildtx.go
+++ b/qln/buildtx.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/mit-dci/lit/lnutil"
 
-	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcutil/txsort"
+	"github.com/adiabat/btcd/wire"
+	"github.com/adiabat/btcutil/txsort"
 )
 
 // GetStateIdxFromTx returns the state index from a commitment transaction.

--- a/qln/close.go
+++ b/qln/close.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/wire"
+	"github.com/adiabat/btcd/chaincfg/chainhash"
+	"github.com/adiabat/btcd/wire"
 	"github.com/btcsuite/fastsha256"
 	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/portxo"

--- a/qln/elkpoints.go
+++ b/qln/elkpoints.go
@@ -3,7 +3,7 @@ package qln
 import (
 	"fmt"
 
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/adiabat/btcd/chaincfg/chainhash"
 	"github.com/mit-dci/lit/lnutil"
 )
 

--- a/qln/fund.go
+++ b/qln/fund.go
@@ -3,8 +3,8 @@ package qln
 import (
 	"fmt"
 
-	"github.com/btcsuite/btcd/btcec"
-	"github.com/btcsuite/btcd/wire"
+	"github.com/adiabat/btcd/btcec"
+	"github.com/adiabat/btcd/wire"
 	"github.com/mit-dci/lit/elkrem"
 	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/portxo"

--- a/qln/init.go
+++ b/qln/init.go
@@ -5,9 +5,9 @@ import (
 	"path/filepath"
 
 	"github.com/boltdb/bolt"
-	"github.com/btcsuite/btcd/chaincfg"
-	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcutil/hdkeychain"
+	"github.com/adiabat/btcd/chaincfg"
+	"github.com/adiabat/btcd/wire"
+	"github.com/adiabat/btcutil/hdkeychain"
 	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/wallit"
 )

--- a/qln/justicetx.go
+++ b/qln/justicetx.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	"github.com/boltdb/bolt"
-	"github.com/btcsuite/btcd/txscript"
-	"github.com/btcsuite/btcd/wire"
+	"github.com/adiabat/btcd/txscript"
+	"github.com/adiabat/btcd/wire"
 	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/sig64"
 	"github.com/mit-dci/lit/watchtower"

--- a/qln/lnchannels.go
+++ b/qln/lnchannels.go
@@ -8,8 +8,8 @@ import (
 	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/portxo"
 
-	"github.com/btcsuite/btcd/btcec"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/adiabat/btcd/btcec"
+	"github.com/adiabat/btcd/chaincfg/chainhash"
 )
 
 // Uhh, quick channel.  For now.  Once you get greater spire it upgrades to

--- a/qln/lndb.go
+++ b/qln/lndb.go
@@ -5,9 +5,9 @@ import (
 	"sync"
 
 	"github.com/boltdb/bolt"
-	"github.com/btcsuite/btcd/btcec"
-	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcutil"
+	"github.com/adiabat/btcd/btcec"
+	"github.com/adiabat/btcd/wire"
+	"github.com/adiabat/btcutil"
 	"github.com/mit-dci/lit/elkrem"
 	"github.com/mit-dci/lit/lndc"
 	"github.com/mit-dci/lit/lnutil"

--- a/qln/magicnums.go
+++ b/qln/magicnums.go
@@ -1,6 +1,6 @@
 package qln
 
-import "github.com/btcsuite/btcutil/hdkeychain"
+import "github.com/adiabat/btcutil/hdkeychain"
 
 const (
 	UseWallet             = 0 | hdkeychain.HardenedKeyStart

--- a/qln/netio.go
+++ b/qln/netio.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/btcsuite/btcd/btcec"
+	"github.com/adiabat/btcd/btcec"
 	"github.com/mit-dci/lit/lndc"
 	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/portxo"

--- a/qln/pushpull.go
+++ b/qln/pushpull.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/mit-dci/lit/lnutil"
 
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/wire"
+	"github.com/adiabat/btcd/chaincfg/chainhash"
+	"github.com/adiabat/btcd/wire"
 )
 
 const minBal = 10000 // channels have to have 10K sat in them; can make variable later.

--- a/qln/serdes.go
+++ b/qln/serdes.go
@@ -5,7 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/adiabat/btcd/chaincfg/chainhash"
 	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/portxo"
 )

--- a/qln/signtx.go
+++ b/qln/signtx.go
@@ -3,9 +3,9 @@ package qln
 import (
 	"fmt"
 
-	"github.com/btcsuite/btcd/btcec"
-	"github.com/btcsuite/btcd/txscript"
-	"github.com/btcsuite/btcd/wire"
+	"github.com/adiabat/btcd/btcec"
+	"github.com/adiabat/btcd/txscript"
+	"github.com/adiabat/btcd/wire"
 	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/sig64"
 )

--- a/sig64/sigcompress_test.go
+++ b/sig64/sigcompress_test.go
@@ -5,8 +5,8 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/btcsuite/btcd/btcec"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/adiabat/btcd/btcec"
+	"github.com/adiabat/btcd/chaincfg/chainhash"
 )
 
 var (

--- a/uspv/chainhook.go
+++ b/uspv/chainhook.go
@@ -3,9 +3,9 @@ package uspv
 import (
 	"path/filepath"
 
-	"github.com/btcsuite/btcd/chaincfg"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/wire"
+	"github.com/adiabat/btcd/chaincfg"
+	"github.com/adiabat/btcd/chaincfg/chainhash"
+	"github.com/adiabat/btcd/wire"
 	"github.com/mit-dci/lit/lnutil"
 )
 

--- a/uspv/eight333.go
+++ b/uspv/eight333.go
@@ -5,9 +5,9 @@ import (
 	"log"
 	"os"
 
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcutil/bloom"
+	"github.com/adiabat/btcd/chaincfg/chainhash"
+	"github.com/adiabat/btcd/wire"
+	"github.com/adiabat/btcutil/bloom"
 	"github.com/mit-dci/lit/lnutil"
 )
 

--- a/uspv/hardmode.go
+++ b/uspv/hardmode.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"log"
 
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcutil/bloom"
+	"github.com/adiabat/btcd/chaincfg/chainhash"
+	"github.com/adiabat/btcd/wire"
+	"github.com/adiabat/btcutil/bloom"
 	"github.com/mit-dci/lit/lnutil"
 )
 

--- a/uspv/header.go
+++ b/uspv/header.go
@@ -12,9 +12,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/btcsuite/btcd/blockchain"
-	"github.com/btcsuite/btcd/chaincfg"
-	"github.com/btcsuite/btcd/wire"
+	"github.com/adiabat/btcd/blockchain"
+	"github.com/adiabat/btcd/chaincfg"
+	"github.com/adiabat/btcd/wire"
 )
 
 // blockchain settings.  These are kindof bitcoin specific, but not contained in

--- a/uspv/init.go
+++ b/uspv/init.go
@@ -8,7 +8,7 @@ import (
 	"net"
 	"os"
 
-	"github.com/btcsuite/btcd/wire"
+	"github.com/adiabat/btcd/wire"
 )
 
 // Connect dials out and connects to full nodes.

--- a/uspv/mblock.go
+++ b/uspv/mblock.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/wire"
+	"github.com/adiabat/btcd/chaincfg/chainhash"
+	"github.com/adiabat/btcd/wire"
 )
 
 func MakeMerkleParent(left, right *chainhash.Hash) *chainhash.Hash {

--- a/uspv/msghandler.go
+++ b/uspv/msghandler.go
@@ -3,8 +3,8 @@ package uspv
 import (
 	"log"
 
-	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcutil/bloom"
+	"github.com/adiabat/btcd/wire"
+	"github.com/adiabat/btcutil/bloom"
 	"github.com/mit-dci/lit/lnutil"
 )
 

--- a/uspv/spvcon.go
+++ b/uspv/spvcon.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"sync"
 
-	"github.com/btcsuite/btcd/chaincfg"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/wire"
+	"github.com/adiabat/btcd/chaincfg"
+	"github.com/adiabat/btcd/chaincfg/chainhash"
+	"github.com/adiabat/btcd/wire"
 	"github.com/mit-dci/lit/lnutil"
 )
 

--- a/wallit/basewalletif.go
+++ b/wallit/basewalletif.go
@@ -4,10 +4,10 @@ import (
 	"log"
 	"sort"
 
-	"github.com/btcsuite/btcd/btcec"
-	"github.com/btcsuite/btcd/chaincfg"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/wire"
+	"github.com/adiabat/btcd/btcec"
+	"github.com/adiabat/btcd/chaincfg"
+	"github.com/adiabat/btcd/chaincfg/chainhash"
+	"github.com/adiabat/btcd/wire"
 	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/portxo"
 )

--- a/wallit/chainhook.go
+++ b/wallit/chainhook.go
@@ -1,8 +1,8 @@
 package wallit
 
 import (
-	"github.com/btcsuite/btcd/chaincfg"
-	"github.com/btcsuite/btcd/wire"
+	"github.com/adiabat/btcd/chaincfg"
+	"github.com/adiabat/btcd/wire"
 	"github.com/mit-dci/lit/lnutil"
 )
 

--- a/wallit/dbio.go
+++ b/wallit/dbio.go
@@ -7,11 +7,11 @@ import (
 	"log"
 
 	"github.com/boltdb/bolt"
-	"github.com/btcsuite/btcd/blockchain"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/txscript"
-	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcutil"
+	"github.com/adiabat/btcd/blockchain"
+	"github.com/adiabat/btcd/chaincfg/chainhash"
+	"github.com/adiabat/btcd/txscript"
+	"github.com/adiabat/btcd/wire"
+	"github.com/adiabat/btcutil"
 	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/portxo"
 )

--- a/wallit/init.go
+++ b/wallit/init.go
@@ -6,9 +6,9 @@ import (
 	"path/filepath"
 
 	"github.com/boltdb/bolt"
-	"github.com/btcsuite/btcd/chaincfg"
-	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcutil/hdkeychain"
+	"github.com/adiabat/btcd/chaincfg"
+	"github.com/adiabat/btcd/wire"
+	"github.com/adiabat/btcutil/hdkeychain"
 	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/uspv"
 )

--- a/wallit/keyderiv.go
+++ b/wallit/keyderiv.go
@@ -3,8 +3,8 @@ package wallit
 import (
 	"fmt"
 
-	"github.com/btcsuite/btcd/btcec"
-	"github.com/btcsuite/btcutil"
+	"github.com/adiabat/btcd/btcec"
+	"github.com/adiabat/btcutil"
 	"github.com/mit-dci/lit/portxo"
 )
 

--- a/wallit/signsend.go
+++ b/wallit/signsend.go
@@ -6,10 +6,10 @@ import (
 	"log"
 	"sort"
 
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/txscript"
-	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcutil/txsort"
+	"github.com/adiabat/btcd/chaincfg/chainhash"
+	"github.com/adiabat/btcd/txscript"
+	"github.com/adiabat/btcd/wire"
+	"github.com/adiabat/btcutil/txsort"
 	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/portxo"
 )

--- a/wallit/wallit.go
+++ b/wallit/wallit.go
@@ -8,12 +8,12 @@ import (
 	"sync"
 
 	"github.com/boltdb/bolt"
-	"github.com/btcsuite/btcd/blockchain"
-	"github.com/btcsuite/btcd/chaincfg"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcutil"
-	"github.com/btcsuite/btcutil/hdkeychain"
+	"github.com/adiabat/btcd/blockchain"
+	"github.com/adiabat/btcd/chaincfg"
+	"github.com/adiabat/btcd/chaincfg/chainhash"
+	"github.com/adiabat/btcd/wire"
+	"github.com/adiabat/btcutil"
+	"github.com/adiabat/btcutil/hdkeychain"
 	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/portxo"
 )

--- a/watchtower/justice.go
+++ b/watchtower/justice.go
@@ -6,8 +6,8 @@ import (
 	"log"
 
 	"github.com/boltdb/bolt"
-	"github.com/btcsuite/btcd/txscript"
-	"github.com/btcsuite/btcd/wire"
+	"github.com/adiabat/btcd/txscript"
+	"github.com/adiabat/btcd/wire"
 	"github.com/mit-dci/lit/elkrem"
 	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/sig64"

--- a/watchtower/watchdb.go
+++ b/watchtower/watchdb.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/wire"
+	"github.com/adiabat/btcd/chaincfg/chainhash"
+	"github.com/adiabat/btcd/wire"
 	"github.com/mit-dci/lit/elkrem"
 	"github.com/mit-dci/lit/lnutil"
 

--- a/watchtower/watchtower.go
+++ b/watchtower/watchtower.go
@@ -4,8 +4,8 @@ import (
 	"log"
 
 	"github.com/boltdb/bolt"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/wire"
+	"github.com/adiabat/btcd/chaincfg/chainhash"
+	"github.com/adiabat/btcd/wire"
 	"github.com/mit-dci/lit/lnutil"
 )
 


### PR DESCRIPTION
This PR removes the btcsuite/btcd and btcsuite/btcutil imports and replaces them with imports from adiabat/btcd and adiabat/btcutil.

btcsuite does not currently support segwit. Once segwit support is merged (https://github.com/btcsuite/btcd/pull/656) we can revert the imports to btcsuite so we pick up the latest version.

README also updated since it's no longer required to add new git remotes to get lit to build.