### PR TITLE
Add minimal Travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: go
+go:
+  - 1.8
+sudo: false
+script:
+  - go get -v ./...
+  - go test ./...


### PR DESCRIPTION
This PR adds Travis support. Currently, all Travis will do is build lit and run the unit tests. Future PRs should:

- add integration tests to be run by Travis
- add code coverage
- etc

@adiabat - to get this to run, you'll need to open an mit-dci travis account (free for open source projects), and then update the settings to do CI on the lit project. You'll also need to enable Travis on the github side from the mit-dci/lit repository settings → Integration and services → services if you want Travis to run on PRs.

Travis runs currently fail the unit tests due to #44 