### PR TITLE
Lit connection dispatcher

### DIFF
--- a/cmd/litpy/litrpc.py
+++ b/cmd/litpy/litrpc.py
@@ -38,7 +38,7 @@ class LitConnection():
         self.msg_id = self.msg_id + 1 % 10000
         return json.loads(self.ws.recv())
 
-    def newAddr(self):
+    def new_address(self):
         """Add a new wallit address"""
         return self.send_message("Address", {"NumToMake": 1})
 
@@ -58,5 +58,5 @@ if __name__ == '__main__':
     """Test litrpc.py. lit instance must be running and available on 127.0.0.1:8001"""
     litConn = LitConnection("127.0.0.1", "8001")
     litConn.connect()
-    print(litConn.newAddr())
+    print(litConn.new_address())
     print(litConn.balance())

--- a/cmd/litpy/litrpc.py
+++ b/cmd/litpy/litrpc.py
@@ -38,6 +38,12 @@ class LitConnection():
         self.msg_id = self.msg_id + 1 % 10000
         return json.loads(self.ws.recv())
 
+    def __getattr__(self, name):
+        """Dispatches any unrecognised messages to the websocket connection"""
+        def dispatcher(params=[]):
+            return self.send_message(name, params)
+        return dispatcher
+
     def new_address(self):
         """Add a new wallit address"""
         return self.send_message("Address", {"NumToMake": 1})

--- a/cmd/litpy/litrpc.py
+++ b/cmd/litpy/litrpc.py
@@ -30,7 +30,7 @@ class LitConnection():
         """Sends a websocket message to the lit node"""
         if params != []:
             params = [params]
-        self.ws.send(json.dumps({"method": method,
+        self.ws.send(json.dumps({"method": "LitRPC.%s" % method,
                                  "params": params,
                                  "jsonrpc": "2.0",
                                  "id": str(self.msg_id)}))
@@ -40,56 +40,19 @@ class LitConnection():
 
     def newAddr(self):
         """Add a new wallit address"""
-        rpcCmd = {
-            "method": "LitRPC.Address",
-            "params": [{"NumToMake": 0}]
-        }
-
-        rid = random.randint(0, 9999)
-        rpcCmd.update({"jsonrpc": "2.0", "id": str(rid)})
-
-        self.ws.send(json.dumps(rpcCmd))
-        resp = json.loads(self.ws.recv())
-        return resp["result"]["WitAddresses"][0]
+        return self.send_message("Address", {"NumToMake": 1})
 
     def balance(self):
         """Get wallit balance"""
-        rpcCmd = {
-            "method": "LitRPC.Bal",
-            "params": []
-        }
-        rpcCmd.update({"jsonrpc": "2.0", "id": "92"})
-
-        self.ws.send(json.dumps(rpcCmd))
-        return json.loads(self.ws.recv())
+        return self.send_message("Bal")
 
     def send(self, adr, amt):
         """Send amt to adr"""
-        rpcCmd = {
-            "method": "LitRPC.Send",
-            "params": [
-                {"DestAddrs": adr, "Amts": amt},
-            ]
-        }
-
-        rid = random.randint(0, 9999)
-        rpcCmd.update({"jsonrpc": "2.0", "id": str(rid)})
-        self.ws.send(json.dumps(rpcCmd))
-        resp = json.loads(self.ws.recv())
-        return resp
+        return self.send_message("Send", {"DestAddrs": adr, "Amts": amt})
 
     def stop(self):
         """Stop lit"""
-        rpcCmd = {
-            "method": "LitRPC.Stop",
-            "params": []
-        }
-
-        rid = random.randint(0, 9999)
-        rpcCmd.update({"jsonrpc": "2.0", "id": str(rid)})
-        self.ws.send(json.dumps(rpcCmd))
-        resp = json.loads(self.ws.recv())
-        return resp
+        return self.send_message("Stop")
 
 if __name__ == '__main__':
     """Test litrpc.py. lit instance must be running and available on 127.0.0.1:8001"""

--- a/cmd/litpy/litrpc.py
+++ b/cmd/litpy/litrpc.py
@@ -26,12 +26,10 @@ class LitConnection():
                 break
         self.msg_id = random.randint(0, 9999)
 
-    def send_message(self, method, params=[]):
+    def send_message(self, method, params):
         """Sends a websocket message to the lit node"""
-        if params != []:
-            params = [params]
         self.ws.send(json.dumps({"method": "LitRPC.%s" % method,
-                                 "params": params,
+                                 "params": [params],
                                  "jsonrpc": "2.0",
                                  "id": str(self.msg_id)}))
 
@@ -40,13 +38,13 @@ class LitConnection():
 
     def __getattr__(self, name):
         """Dispatches any unrecognised messages to the websocket connection"""
-        def dispatcher(params=[]):
-            return self.send_message(name, params)
+        def dispatcher(**kwargs):
+            return self.send_message(name, kwargs)
         return dispatcher
 
     def new_address(self):
         """Add a new wallit address"""
-        return self.Address({"NumToMake": 1})
+        return self.Address(NumToMake=1)
 
     def balance(self):
         """Get wallit balance"""

--- a/cmd/litpy/litrpc.py
+++ b/cmd/litpy/litrpc.py
@@ -24,6 +24,19 @@ class LitConnection():
             else:
                 # No exception - we're connected!
                 break
+        self.msg_id = random.randint(0, 9999)
+
+    def send_message(self, method, params=[]):
+        """Sends a websocket message to the lit node"""
+        if params != []:
+            params = [params]
+        self.ws.send(json.dumps({"method": method,
+                                 "params": params,
+                                 "jsonrpc": "2.0",
+                                 "id": str(self.msg_id)}))
+
+        self.msg_id = self.msg_id + 1 % 10000
+        return json.loads(self.ws.recv())
 
     def newAddr(self):
         """Add a new wallit address"""

--- a/cmd/litpy/litrpc.py
+++ b/cmd/litpy/litrpc.py
@@ -46,19 +46,11 @@ class LitConnection():
 
     def new_address(self):
         """Add a new wallit address"""
-        return self.send_message("Address", {"NumToMake": 1})
+        return self.Address({"NumToMake": 1})
 
     def balance(self):
         """Get wallit balance"""
-        return self.send_message("Bal")
-
-    def send(self, adr, amt):
-        """Send amt to adr"""
-        return self.send_message("Send", {"DestAddrs": adr, "Amts": amt})
-
-    def stop(self):
-        """Stop lit"""
-        return self.send_message("Stop")
+        return self.Bal()
 
 if __name__ == '__main__':
     """Test litrpc.py. lit instance must be running and available on 127.0.0.1:8001"""

--- a/cmd/litpy/test_lit.py
+++ b/cmd/litpy/test_lit.py
@@ -26,7 +26,7 @@ def testLit():
 
     litConn = litrpc.LitConnection("127.0.0.1", "8001")
     litConn.connect()
-    litConn.newAddr()
+    litConn.new_address()
     litConn.balance()
     litConn.stop()
 

--- a/cmd/litpy/test_lit.py
+++ b/cmd/litpy/test_lit.py
@@ -27,8 +27,8 @@ def testLit():
     litConn = litrpc.LitConnection("127.0.0.1", "8001")
     litConn.connect()
     litConn.new_address()
-    litConn.balance()
-    litConn.stop()
+    litConn.Bal()
+    litConn.Stop()
 
     print("Test succeeds!")
 


### PR DESCRIPTION
Adds a `__getattr__()` method to LitConnection, which
returns a closure on `send_message()`. Lit RPC commands can now be called
directly on LitConnection, without the need to add methods for each new
RPC.