### PR TITLE
[tests] test Listen and Connect RPCs 

### DIFF
--- a/cmd/litpy/test_lit.py
+++ b/cmd/litpy/test_lit.py
@@ -26,21 +26,48 @@ class LitNode():
 
 
 def testLit():
-    """starts a lit process and tests basic functionality:
+    """starts two lit processes and tests basic functionality:
 
     - connect over websocket
     - create new address
     - get balance
+    - listen on node0
+    - connect from node1 to node0
     - stop"""
 
-    node = LitNode(1)
-    node.start_node()
+    # Start lit node 0 and open websocket connection
+    node0 = LitNode(0)
+    node0.start_node()
 
-    litConn = litrpc.LitConnection("127.0.0.1", "8001")
-    litConn.connect()
-    litConn.new_address()
-    litConn.Bal()
-    litConn.Stop()
+    litConn0 = litrpc.LitConnection("127.0.0.1", "8001")
+    litConn0.connect()
+    litConn0.new_address()
+    litConn0.Bal()
+
+    # Start lit node 1 and open websocket connection
+    node1 = LitNode(1)
+    node1.args.extend(["-rpcport", "8002"])
+    node1.start_node()
+
+    litConn1 = litrpc.LitConnection("127.0.0.1", "8002")
+    litConn1.connect()
+    litConn1.new_address()
+    litConn1.Bal()
+
+    # Listen on lit node0 and connect from lit node1
+    res = litConn0.Listen(Port="127.0.0.1:10001")["result"]
+    node0.lit_address = res["Status"].split(' ')[5] + '@' + res["Status"].split(' ')[2]
+
+    res = litConn1.Connect(LNAddr=node0.lit_address)
+    assert not res['error']
+
+    # Check that node0 and node1 are connected
+    assert len(litConn0.ListConnections()['result']['Connections']) == 1
+    assert len(litConn1.ListConnections()['result']['Connections']) == 1
+
+    # Stop lit nodes
+    litConn0.Stop()
+    litConn1.Stop()
 
     print("Test succeeds!")
 

--- a/cmd/litpy/test_lit.py
+++ b/cmd/litpy/test_lit.py
@@ -6,6 +6,25 @@ import tempfile
 
 import litrpc
 
+TMP_DIR = tempfile.mkdtemp(prefix="test")
+LIT_BIN = "%s/../../lit" % os.path.abspath(os.path.dirname(__file__))
+
+class LitNode():
+    """A class representing a Lit node"""
+    def __init__(self, i):
+        self.data_dir = TMP_DIR + "litnode%s" % i
+        os.makedirs(self.data_dir)
+
+        # Write a hexkey to the hexkey file
+        with open(self.data_dir + "/testkey.hex", 'w+') as f:
+            f.write("1" * 64 + "\n")
+
+        self.args = ["-dir", self.data_dir]
+
+    def start_node(self):
+        subprocess.Popen([LIT_BIN] + self.args)
+
+
 def testLit():
     """starts a lit process and tests basic functionality:
 
@@ -14,15 +33,8 @@ def testLit():
     - get balance
     - stop"""
 
-    DATA_DIR = tempfile.mkdtemp(prefix="test") + "/.lit"
-    os.makedirs(DATA_DIR)
-    LIT_BIN = "%s/../../lit" % os.path.abspath(os.path.dirname(__file__))
-
-    # Write a hexkey to the hexkey file
-    with open(DATA_DIR + "/testkey.hex", 'w+') as f:
-        f.write("1" * 64 + "\n")
-
-    subprocess.Popen([LIT_BIN, "-dir", DATA_DIR])
+    node = LitNode(1)
+    node.start_node()
 
     litConn = litrpc.LitConnection("127.0.0.1", "8001")
     litConn.connect()


### PR DESCRIPTION
test_lit.py now starts two nodes and tests the Listen() and Connect() RPCs.

Also adds a LitNode class to test_lit.py.

Builds on #52 - only the _[tests] add LitNode class to test_lit.py_ and _[tests] test Listen and Connect_ commits are for review in this PR.