### PR TITLE
Fix and improve tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,18 @@ go:
 sudo: required
 install:
   - sudo apt-get update
-  - sudo apt-get install python3 python3-pip python3-requests
-  - sudo apt-get install bitcoind
+  - sudo apt-get install python3 python3-pip
+  # Download bitcoind and add it to the path
+  - wget https://bitcoin.org/bin/bitcoin-core-0.14.1/bitcoin-0.14.1-x86_64-linux-gnu.tar.gz
+  - tar xvf bitcoin-0.14.1-x86_64-linux-gnu.tar.gz
+  - PATH=$PATH:$PWD/bitcoin-0.14.1/bin
+  # Download bitcoind and add it to the path
   - wget https://download.litecoin.org/litecoin-0.13.2/linux/litecoin-0.13.2-x86_64-linux-gnu.tar.gz
   - tar xvf litecoin-0.13.2-x86_64-linux-gnu.tar.gz
   - PATH=$PATH:$PWD/litecoin-0.13.2/bin
-  - sudo pip3 install --upgrade pip
-  - sudo pip3 install websocket-client
+  - pip3 install --upgrade pip
+  - pip3 install requests
+  - pip3 install websocket-client
 script:
   - go get -v ./...
   - go test ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,18 @@ language: go
 go:
   - 1.8
 sudo: required
+cache:
+  directories:
+  - bitcoin-0.14.1
+  - litecoin-0.13.2
 install:
   - sudo apt-get update
   - sudo apt-get install python3 python3-pip
   # Download bitcoind and add it to the path
-  - wget https://bitcoin.org/bin/bitcoin-core-0.14.1/bitcoin-0.14.1-x86_64-linux-gnu.tar.gz
-  - tar xvf bitcoin-0.14.1-x86_64-linux-gnu.tar.gz
+  - ls bitcoin-0.14.1/bin/bitcoind || (wget https://bitcoin.org/bin/bitcoin-core-0.14.1/bitcoin-0.14.1-x86_64-linux-gnu.tar.gz && tar xvf bitcoin-0.14.1-x86_64-linux-gnu.tar.gz)
   - PATH=$PATH:$PWD/bitcoin-0.14.1/bin
   # Download bitcoind and add it to the path
-  - wget https://download.litecoin.org/litecoin-0.13.2/linux/litecoin-0.13.2-x86_64-linux-gnu.tar.gz
-  - tar xvf litecoin-0.13.2-x86_64-linux-gnu.tar.gz
+  - ls litecoin-0.13.2/bin/litecoind || (wget https://download.litecoin.org/litecoin-0.13.2/linux/litecoin-0.13.2-x86_64-linux-gnu.tar.gz && tar xvf litecoin-0.13.2-x86_64-linux-gnu.tar.gz)
   - PATH=$PATH:$PWD/litecoin-0.13.2/bin
   - pip3 install --upgrade pip
   - pip3 install requests

--- a/cmd/litpy/litrpc.py
+++ b/cmd/litpy/litrpc.py
@@ -1,4 +1,7 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
+# Copyright (c) 2017 The lit developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 """Python interface to lit"""
 
 import json

--- a/test/bcnode.py
+++ b/test/bcnode.py
@@ -43,6 +43,9 @@ class BCNode():
                 raise Exception('%s exited with status %i during initialization' % (self.__class__.bin_name, self.process.returncode))
             try:
                 resp = self.getinfo()
+                if resp.json()['error'] and resp.json()['error']['code'] == -28:
+                    # RPC is still in warmup. Sleep some more.
+                    continue
                 # Check that we're running at least the minimum version
                 assert resp.json()['result']['version'] > self.__class__.min_version
                 break  # break out of loop on success

--- a/test/bcnode.py
+++ b/test/bcnode.py
@@ -32,15 +32,15 @@ class BCNode():
 
     def start_node(self):
         try:
-            process = subprocess.Popen([self.__class__.bin_name] + self.args)
+            self.process = subprocess.Popen([self.__class__.bin_name] + self.args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         except FileNotFoundError:
             print("%s not found on path. Please install %s" % (self.__class__.bin_name, self.__class__.bin_name))
             sys.exit(1)
 
         # Wait for process to start
         while True:
-            if process.poll() is not None:
-                raise Exception('%s exited with status %i during initialization' % (self.__class__.bin_name, process.returncode))
+            if self.process.poll() is not None:
+                raise Exception('%s exited with status %i during initialization' % (self.__class__.bin_name, self.process.returncode))
             try:
                 resp = self.getinfo()
                 # Check that we're running at least the minimum version

--- a/test/bcnode.py
+++ b/test/bcnode.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The lit developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+"""Classes representing bitcoind and litecoind nodes
+
+BCNode and LCNode represent a bitcoind and litecoind node respectively.
+They can be used to start/stop a bitcoin/litecoin node and communicate
+with it over RPC."""
+import json
+import os
+import random
+import subprocess
+import sys
+import time
+
+import requests  # `pip install requests`
+
+class BCNode():
+    """A class representing a bitcoind node"""
+    bin_name = "bitcoind"
+    short_name = "bc"
+
+    def __init__(self, i, tmd_dir):
+        self.data_dir = tmd_dir + "/%snode%s" % (self.__class__.short_name, i)
+        os.makedirs(self.data_dir)
+
+        self.args = ["-regtest", "-datadir=%s" % self.data_dir, "-rpcuser=regtestuser", "-rpcpassword=regtestpass", "-rpcport=18332"]
+        self.msg_id = random.randint(0, 9999)
+        self.rpc_url = "http://regtestuser:regtestpass@127.0.0.1:18332"
+
+    def start_node(self):
+        try:
+            process = subprocess.Popen([self.__class__.bin_name] + self.args)
+        except FileNotFoundError:
+            print("%s not found on path. Please install %s" % (self.__class__.bin_name, self.__class__.bin_name))
+            sys.exit(1)
+
+        # Wait for process to start
+        while True:
+            if process.poll() is not None:
+                raise Exception('%s exited with status %i during initialization' % (self.__class__.bin_name, process.returncode))
+            try:
+                self.getblockcount()
+                break  # break out of loop on success
+            except:
+                time.sleep(0.25)
+
+    def send_message(self, method, params):
+        self.msg_id += 1
+        rpcCmd = {
+            "method": method,
+            "params": params,
+            "jsonrpc": "2.0",
+            "id": str(self.msg_id)
+        }
+        payload = json.dumps(rpcCmd)
+
+        return requests.post(self.rpc_url, headers={"Content-type": "application/json"}, data=payload)
+
+    def __getattr__(self, name):
+        """Dispatches any unrecognised messages to the websocket connection"""
+        def dispatcher(**kwargs):
+            return self.send_message(name, kwargs)
+        return dispatcher
+
+class LCNode(BCNode):
+    """A class representing a litecoind node"""
+    bin_name = "litecoind"
+    short_name = "lc"

--- a/test/bcnode.py
+++ b/test/bcnode.py
@@ -20,6 +20,7 @@ class BCNode():
     """A class representing a bitcoind node"""
     bin_name = "bitcoind"
     short_name = "bc"
+    min_version = 140000
 
     def __init__(self, i, tmd_dir):
         self.data_dir = tmd_dir + "/%snode%s" % (self.__class__.short_name, i)
@@ -41,9 +42,11 @@ class BCNode():
             if process.poll() is not None:
                 raise Exception('%s exited with status %i during initialization' % (self.__class__.bin_name, process.returncode))
             try:
-                self.getblockcount()
+                resp = self.getinfo()
+                # Check that we're running at least the minimum version
+                assert resp.json()['result']['version'] > self.__class__.min_version
                 break  # break out of loop on success
-            except:
+            except requests.exceptions.ConnectionError as e:
                 time.sleep(0.25)
 
     def send_message(self, method, params):
@@ -68,3 +71,4 @@ class LCNode(BCNode):
     """A class representing a litecoind node"""
     bin_name = "litecoind"
     short_name = "lc"
+    min_version = 130200

--- a/test/litnode.py
+++ b/test/litnode.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The lit developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+"""Class representing a lit node
+
+LitNode represents a lit node. It can be used to start/stop a lit node
+and communicate with it over RPC."""
+import os
+import subprocess
+
+from litpy import litrpc
+
+LIT_BIN = "%s/../lit" % os.path.abspath(os.path.dirname(__file__))
+
+class LitNode():
+    """A class representing a Lit node"""
+    def __init__(self, i, tmp_dir):
+        self.data_dir = tmp_dir + "/litnode%s" % i
+        os.makedirs(self.data_dir)
+
+        # Write a hexkey to the hexkey file
+        with open(self.data_dir + "/testkey.hex", 'w+') as f:
+            f.write("1" * 63 + str(i) + "\n")
+
+        self.args = ["-dir", self.data_dir]
+
+    def start_node(self):
+        subprocess.Popen([LIT_BIN] + self.args)
+
+    def add_rpc_connection(self, ip, port):
+        self.rpc = litrpc.LitConnection(ip, port)
+        self.rpc.connect()
+
+    def __getattr__(self, name):
+        return self.rpc.__getattr__(name)

--- a/test/litnode.py
+++ b/test/litnode.py
@@ -26,7 +26,7 @@ class LitNode():
         self.args = ["-dir", self.data_dir]
 
     def start_node(self):
-        subprocess.Popen([LIT_BIN] + self.args)
+        self.process = subprocess.Popen([LIT_BIN] + self.args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
     def add_rpc_connection(self, ip, port):
         self.rpc = litrpc.LitConnection(ip, port)

--- a/test/litnode.py
+++ b/test/litnode.py
@@ -19,8 +19,8 @@ class LitNode():
         self.data_dir = tmp_dir + "/litnode%s" % i
         os.makedirs(self.data_dir)
 
-        # Write a hexkey to the hexkey file
-        with open(self.data_dir + "/testkey.hex", 'w+') as f:
+        # Write a hexkey to the privkey file
+        with open(self.data_dir + "/privkey.hex", 'w+') as f:
             f.write("1" * 63 + str(i) + "\n")
 
         self.args = ["-dir", self.data_dir]

--- a/test/test_lit.py
+++ b/test/test_lit.py
@@ -1,38 +1,13 @@
 #!/usr/bin/python3
 """Test lit"""
-import os
-import subprocess
 import tempfile
 import time
 
 from bcnode import BCNode
-from litpy import litrpc
+from litnode import LitNode
 
 TMP_DIR = tempfile.mkdtemp(prefix="test")
 print("Using tmp dir %s" % TMP_DIR)
-LIT_BIN = "%s/../lit" % os.path.abspath(os.path.dirname(__file__))
-
-class LitNode():
-    """A class representing a Lit node"""
-    def __init__(self, i):
-        self.data_dir = TMP_DIR + "/litnode%s" % i
-        os.makedirs(self.data_dir)
-
-        # Write a hexkey to the hexkey file
-        with open(self.data_dir + "/privkey.hex", 'w+') as f:
-            f.write("1" * 63 + str(i) + "\n")
-
-        self.args = ["-dir", self.data_dir]
-
-    def start_node(self):
-        subprocess.Popen([LIT_BIN] + self.args)
-
-    def add_rpc_connection(self, ip, port):
-        self.rpc = litrpc.LitConnection(ip, port)
-        self.rpc.connect()
-
-    def __getattr__(self, name):
-        return self.rpc.__getattr__(name)
 
 def testLit():
     """starts two lit processes and tests basic functionality:
@@ -54,7 +29,7 @@ def testLit():
     print("Received response from bitcoin node: %s" % bcnode.getinfo().text)
 
     # Start lit node 0 and open websocket connection
-    litnode0 = LitNode(0)
+    litnode0 = LitNode(0, TMP_DIR)
     litnode0.args.extend(["-reg", "127.0.0.1"])
     litnode0.start_node()
     time.sleep(1)
@@ -63,7 +38,7 @@ def testLit():
     litnode0.Bal()
 
     # Start lit node 1 and open websocket connection
-    litnode1 = LitNode(1)
+    litnode1 = LitNode(1, TMP_DIR)
     litnode1.args.extend(["-rpcport", "8002", "-reg", "127.0.0.1"])
     litnode1.start_node()
     time.sleep(1)

--- a/test/test_lit.py
+++ b/test/test_lit.py
@@ -10,13 +10,13 @@ import time
 from bcnode import BCNode
 from litnode import LitNode
 
-TMP_DIR = tempfile.mkdtemp(prefix="test")
-print("Using tmp dir %s" % TMP_DIR)
 
 class LitTest():
     def __init__(self):
         self.litnodes = []
         self.bcnodes = []
+        self.tmpdir = tempfile.mkdtemp(prefix="test")
+        print("Using tmp dir %s" % self.tmpdir)
 
     def main(self):
         rc = 0
@@ -43,7 +43,7 @@ class LitTest():
         - stop"""
 
         # Start a bitcoind node
-        self.bcnodes = [BCNode(0, TMP_DIR)]
+        self.bcnodes = [BCNode(0, self.tmdpir)]
         self.bcnodes[0].start_node()
         time.sleep(15)
         print("generate response: %s" % bcnode.generate(nblocks=150).text)
@@ -51,7 +51,7 @@ class LitTest():
         print("Received response from bitcoin node: %s" % self.bcnodes[0].getinfo().text)
 
         # Start lit node 0 and open websocket connection
-        self.litnodes.append(LitNode(0, TMP_DIR))
+        self.litnodes.append(LitNode(0, self.tmpdir))
         self.litnodes[0].args.extend(["-reg", "127.0.0.1"])
         self.litnodes[0].start_node()
         time.sleep()
@@ -60,7 +60,7 @@ class LitTest():
         self.litnodes[0].Bal()
 
         # Start lit node 1 and open websocket connection
-        self.litnodes[1] = LitNode(1, TMP_DIR)
+        self.litnodes[1] = LitNode(1, self.tmpdir)
         self.litnodes[1].args.extend(["-rpcport", "8002", "-reg", "127.0.0.1"])
         self.litnodes[1].start_node()
         time.sleep(1)
@@ -98,7 +98,6 @@ class LitTest():
         else:
             print("Test failed. No transaction received")
             exit(1)
-
 
     def cleanup(self):
         # Stop bitcoind and lit nodes

--- a/test/test_lit.py
+++ b/test/test_lit.py
@@ -1,4 +1,7 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
+# Copyright (c) 2017 The lit developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 """Test lit"""
 import tempfile
 import time

--- a/test/test_lit.py
+++ b/test/test_lit.py
@@ -3,6 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 """Test lit"""
+import subprocess
 import tempfile
 import time
 
@@ -12,81 +13,107 @@ from litnode import LitNode
 TMP_DIR = tempfile.mkdtemp(prefix="test")
 print("Using tmp dir %s" % TMP_DIR)
 
-def testLit():
-    """starts two lit processes and tests basic functionality:
+class LitTest():
+    def __init__(self):
+        self.litnodes = []
+        self.bcnodes = []
 
-    - connect over websocket
-    - create new address
-    - get balance
-    - listen on litnode0
-    - connect from litnode1 to litnode0
-    - stop"""
+    def main(self):
+        rc = 0
+        try:
+            self.run_test()
+            print("Test succeeds!")
+        except:
+            # Test asserted. Return 1
+            rc = 1
+            print("Test fails")
+        finally:
+            self.cleanup()
 
-    # Start a bitcoind node
-    bcnode = BCNode(0, TMP_DIR)
-    bcnode.start_node()
-    # takes a while to start on a pi
-    time.sleep(15)
-    print("generate response: %s" % bcnode.generate(nblocks=150).text)
-    time.sleep(2)
-    print("Received response from bitcoin node: %s" % bcnode.getinfo().text)
+        return rc
 
-    # Start lit node 0 and open websocket connection
-    litnode0 = LitNode(0, TMP_DIR)
-    litnode0.args.extend(["-reg", "127.0.0.1"])
-    litnode0.start_node()
-    time.sleep(1)
-    litnode0.add_rpc_connection("127.0.0.1", "8001")
-    print(litnode0.rpc.new_address())
-    litnode0.Bal()
+    def run_test(self):
+        """starts two lit processes and tests basic functionality:
 
-    # Start lit node 1 and open websocket connection
-    litnode1 = LitNode(1, TMP_DIR)
-    litnode1.args.extend(["-rpcport", "8002", "-reg", "127.0.0.1"])
-    litnode1.start_node()
-    time.sleep(1)
-    litnode1.add_rpc_connection("127.0.0.1", "8002")
-    litnode1.rpc.new_address()
-    litnode1.Bal()
+        - connect over websocket
+        - create new address
+        - get balance
+        - listen on litnode0
+        - connect from litnode1 to litnode0
+        - stop"""
 
-    # Listen on lit litnode0 and connect from lit litnode1
-    res = litnode0.Listen(Port="127.0.0.1:10001")["result"]
-    litnode0.lit_address = res["Adr"] + '@' + res["LisIpPorts"][0]
+        # Start a bitcoind node
+        self.bcnodes = [BCNode(0, TMP_DIR)]
+        self.bcnodes[0].start_node()
+        time.sleep(15)
+        print("generate response: %s" % bcnode.generate(nblocks=150).text)
+        time.sleep(2)
+        print("Received response from bitcoin node: %s" % self.bcnodes[0].getinfo().text)
 
-    res = litnode1.Connect(LNAddr=litnode0.lit_address)
-    assert not res['error']
+        # Start lit node 0 and open websocket connection
+        self.litnodes.append(LitNode(0, TMP_DIR))
+        self.litnodes[0].args.extend(["-reg", "127.0.0.1"])
+        self.litnodes[0].start_node()
+        time.sleep()
+        self.litnodes[0].add_rpc_connection("127.0.0.1", "8001")
+        print(self.litnodes[0].rpc.new_address())
+        self.litnodes[0].Bal()
 
-    time.sleep(1)
-    # Check that litnode0 and litnode1 are connected
-    assert len(litnode0.ListConnections()['result']['Connections']) == 1
-    assert len(litnode1.ListConnections()['result']['Connections']) == 1
+        # Start lit node 1 and open websocket connection
+        self.litnodes[1] = LitNode(1, TMP_DIR)
+        self.litnodes[1].args.extend(["-rpcport", "8002", "-reg", "127.0.0.1"])
+        self.litnodes[1].start_node()
+        time.sleep(1)
+        self.litnodes[1].add_rpc_connection("127.0.0.1", "8002")
+        self.litnodes[1].rpc.new_address()
+        self.litnodes[1].Bal()
 
-    # Send funds from the bitcoin node to lit node 0
-    #print(litnode0.Bal())
-    bal = litnode0.Balance()['result']['Balances'][0]["TxoTotal"]
-    print("previous bal: " + str(bal))
-    addr = litnode0.rpc.new_address()
-    bcnode.sendtoaddress(address=addr["result"]["LegacyAddresses"][0], amount=12.34)
-    print("generate response: %s" % bcnode.generate(nblocks=1).text)
-    print("waiting to receive transaction")
+        # Listen on litnode0 and connect from litnode1
+        res = self.litnodes[0].Listen(Port="127.0.0.1:10001")["result"]
+        self.litnodes[0].lit_address = res["Adr"] + '@' + res["LisIpPorts"][0]
 
-    # wait for transaction to be received (5 seconds timeout)
-    for i in range(50):
-        time.sleep(0.1)
-        balNew = litnode0.Balance()['result']["Balances"][0]["TxoTotal"]
-        if balNew - bal == 1234000000:
-            print("Transaction received. Current balance = %s" % balNew)
-            break
-    else:
-        print("Test failed. No transaction received")
-        exit(1)
+        res = self.litnodes[1].Connect(LNAddr=self.litnodes[0].lit_address)
+        assert not res['error']
 
-    # Stop bitcoind and lit nodes
-    bcnode.stop()
-    litnode0.Stop()
-    litnode1.Stop()
+        time.sleep(1)
+        # Check that litnode0 and litnode1 are connected
+        assert len(self.litnodes[0].ListConnections()['result']['Connections']) == 1
+        assert len(self.litnodes[1].ListConnections()['result']['Connections']) == 1
 
-    print("Test succeeds!")
+        # Send funds from the bitcoin node to litnode0
+        bal = self.litnodes[0].Bal()['result']['balances'][0]['TxoTotal']
+        print("previous bal: " + str(bal))
+        addr = self.litnodes[0].rpc.new_address()
+        self.bcnodes[0].sendtoaddress(address=addr["result"]["LegacyAddresses"][0], amount=12.34)
+        print("generate response: %s" % bcnodes[0].generate(nblocks=1).text)
+        print("waiting to receive transaction")
+
+        # wait for transaction to be received (5 seconds timeout)
+        for i in range(50):
+            time.sleep(0.1)
+            balNew = self.litnodes[0].Bal()['result']["Balances"][0]["TxoTotal"]
+            if balNew - bal == 1234000000:
+                print("Transaction received. Current balance = %s" % balNew)
+                break
+        else:
+            print("Test failed. No transaction received")
+            exit(1)
+
+
+    def cleanup(self):
+        # Stop bitcoind and lit nodes
+        for bcnode in self.bcnodes:
+            bcnode.stop()
+            try:
+                bcnode.process.wait(2)
+            except subprocess.TimeoutExpired:
+                bcnode.process.kill()
+        for litnode in self.litnodes:
+            litnode.Stop()
+            try:
+                litnode.process.wait(2)
+            except subprocess.TimeoutExpired:
+                litnode.process.kill()
 
 if __name__ == "__main__":
-    testLit()
+    exit(LitTest().main())

--- a/test/test_lit.py
+++ b/test/test_lit.py
@@ -4,8 +4,10 @@
 # file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 """Test lit"""
 import subprocess
+import sys
 import tempfile
 import time
+import traceback
 
 from bcnode import BCNode
 from litnode import LitNode
@@ -25,8 +27,9 @@ class LitTest():
             print("Test succeeds!")
         except:
             # Test asserted. Return 1
+            print("Unexpected error:", sys.exc_info()[0])
+            traceback.print_exc(file=sys.stdout)
             rc = 1
-            print("Test fails")
         finally:
             self.cleanup()
 
@@ -43,7 +46,7 @@ class LitTest():
         - stop"""
 
         # Start a bitcoind node
-        self.bcnodes = [BCNode(0, self.tmdpir)]
+        self.bcnodes = [BCNode(0, self.tmpdir)]
         self.bcnodes[0].start_node()
         time.sleep(15)
         print("generate response: %s" % bcnode.generate(nblocks=150).text)


### PR DESCRIPTION
A bunch of improvements:

- refactor BCNode, LCNode and LitNode into their own modules
- Add copyright notice and use `#!/usr/bin/env python3` hashbang instead of `#!/usr/bin/python3` for portability
- check that bitcoind version is >0.14 and litecoind version is >0.13.2
- fix build/test in travis
- cache bitcoind and litecoind in travis to avoid slow downloads
- improve logging on failure
- make sure bitcoind and lit processes are cleaned up at the end of the test

Some of these commits are broken until the `[tests] fixups` commit, but I'm not going to bother rearranging them since I expect you'll merge this as a single commit.