### PR TITLE
Test framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,5 @@ script:
   - go get -v ./...
   - go test ./...
   - go build
-  - test/test_lit.py
+  - test/test_basic.py
 

--- a/test/README.md
+++ b/test/README.md
@@ -1,9 +1,24 @@
 # Lit integration tests
 
-run tests with ./test_lit.py
+This directory contains lit integration tests, which start lit and bitcoind/litecoind nodes and test functionality.
 
-Requires:
+### Directory Structure
+
+- `lit_test_framework.py` is the test framework. Individual test cases should import this and subclass the LitTest class
+- `litnode.py` contains a class representing a lit node. This can be used to start/stop the node and communicate with it over the websocket RPC.
+- `bcnode.py` contains a class representing a bitcoind node or litecoin node. These can be used to start/stop the bitcoin/litecoin nodes and communicate with them over RPC.
+- `test_*.py` individual tests cases.
+
+### Dependencies
 
 - websocket-client (`pip install websocket-client`)
 - requests (`pip install requests`)
 - bitcoind and litecoind on the path
+
+### Running tests
+
+Run tests with `./test_[testname].py`
+
+### Adding tests
+
+New tests should be named `tests_[description].py`. They should import the `LitTest` class from `lit_test_framework.py`. The test should subclass the `LitTest` class and override the `run_test()` method to include its own test logic. See `test_basic.py` for an example.

--- a/test/lit_test_framework.py
+++ b/test/lit_test_framework.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The lit developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+"""Test lit"""
+import subprocess
+import sys
+import tempfile
+import traceback
+
+class LitTest():
+    def __init__(self):
+        self.litnodes = []
+        self.bcnodes = []
+        self.tmpdir = tempfile.mkdtemp(prefix="test")
+        print("Using tmp dir %s" % self.tmpdir)
+
+    def main(self):
+        rc = 0
+        try:
+            self.run_test()
+            print("Test succeeds!")
+        except:
+            # Test asserted. Return 1
+            print("Unexpected error:", sys.exc_info()[0])
+            traceback.print_exc(file=sys.stdout)
+            rc = 1
+        finally:
+            self.cleanup()
+
+        return rc
+
+    def run_test(self):
+        """Test Logic. This method should be overridden by subclasses"""
+        raise NotImplementedError
+
+    def cleanup(self):
+        # Stop bitcoind and lit nodes
+        for bcnode in self.bcnodes:
+            bcnode.stop()
+            try:
+                bcnode.process.wait(2)
+            except subprocess.TimeoutExpired:
+                bcnode.process.kill()
+        for litnode in self.litnodes:
+            litnode.Stop()
+            try:
+                litnode.process.wait(2)
+            except subprocess.TimeoutExpired:
+                litnode.process.kill()
+
+if __name__ == "__main__":
+    exit(LitTest().main())

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -2,48 +2,25 @@
 # Copyright (c) 2017 The lit developers
 # Distributed under the MIT software license, see the accompanying
 # file LICENSE or http://www.opensource.org/licenses/mit-license.php.
-"""Test lit"""
-import subprocess
-import sys
-import tempfile
+"""Test basic lit functionality
+
+- start bitcoind process
+- start two lit processes
+- connect over websocket
+- create new address
+- get balance
+- listen on litnode0
+- connect from litnode1 to litnode0
+- send funds from bitcoind process to litnode0 address
+- stop"""
 import time
-import traceback
 
 from bcnode import BCNode
 from litnode import LitNode
+from lit_test_framework import LitTest
 
-
-class LitTest():
-    def __init__(self):
-        self.litnodes = []
-        self.bcnodes = []
-        self.tmpdir = tempfile.mkdtemp(prefix="test")
-        print("Using tmp dir %s" % self.tmpdir)
-
-    def main(self):
-        rc = 0
-        try:
-            self.run_test()
-            print("Test succeeds!")
-        except:
-            # Test asserted. Return 1
-            print("Unexpected error:", sys.exc_info()[0])
-            traceback.print_exc(file=sys.stdout)
-            rc = 1
-        finally:
-            self.cleanup()
-
-        return rc
-
+class TestBasic(LitTest):
     def run_test(self):
-        """starts two lit processes and tests basic functionality:
-
-        - connect over websocket
-        - create new address
-        - get balance
-        - listen on litnode0
-        - connect from litnode1 to litnode0
-        - stop"""
 
         # Start a bitcoind node
         self.bcnodes = [BCNode(0, self.tmpdir)]
@@ -100,20 +77,5 @@ class LitTest():
             print("Test failed. No transaction received")
             raise AssertionError
 
-    def cleanup(self):
-        # Stop bitcoind and lit nodes
-        for bcnode in self.bcnodes:
-            bcnode.stop()
-            try:
-                bcnode.process.wait(2)
-            except subprocess.TimeoutExpired:
-                bcnode.process.kill()
-        for litnode in self.litnodes:
-            litnode.Stop()
-            try:
-                litnode.process.wait(2)
-            except subprocess.TimeoutExpired:
-                litnode.process.kill()
-
 if __name__ == "__main__":
-    exit(LitTest().main())
+    exit(TestBasic().main())


### PR DESCRIPTION
This moves the test framework into its own lit_test_framework module, to be imported and subclassed by indvidual test scripts.

There is currently only one test script: test_basic.py. Additional tests named `test_[description].py` can be added.

This splits the test logic from the test framework so additional tests can be added and worked on in parallel.

README updated to describe the new structure.