### PR TITLE
Add SetFee RPC command

### DIFF
--- a/cmd/lit-af/shell.go
+++ b/cmd/lit-af/shell.go
@@ -158,6 +158,13 @@ func (lc *litAfClient) Shellparse(cmdslice []string) error {
 		}
 		return nil
 	}
+	if cmd == "fee" { // set fee rate for a wallet
+		err = lc.SetFee(args)
+		if err != nil {
+			fmt.Fprintf(color.Output, "fee error: %s\n", err)
+		}
+		return nil
+	}
 
 	fmt.Fprintf(color.Output, "Command not recognized. type help for command list.\n")
 	return nil

--- a/cmd/lit-af/walletcmds.go
+++ b/cmd/lit-af/walletcmds.go
@@ -168,6 +168,48 @@ func (lc *litAfClient) Fan(textArgs []string) error {
 	return nil
 }
 
+// ------------------ set fee
+
+func (lc *litAfClient) SetFee(textArgs []string) error {
+	//	if len(textArgs) > 0 && textArgs[0] == "-h" {
+	//		fmt.Fprintf(color.Output, fanCommand.Format)
+	//		fmt.Fprintf(color.Output, fanCommand.Description)
+	//		return nil
+	//	}
+
+	args := new(litrpc.SetFeeArgs)
+	reply := new(litrpc.SetFeeReply)
+
+	// if no arguments are given, the "fee rate" is -1, which means
+	// we'll find out what the current fee rate is
+	args.Fee = -1
+
+	// there is at least 1 argument; that should be the new fee rate
+	if len(textArgs) > 0 {
+		feeint, err := strconv.Atoi(textArgs[0])
+		if err != nil {
+			return err
+		}
+		args.Fee = int64(feeint)
+	}
+	// there is another argument. That's the coin type. (coin type 0 means default)
+	if len(textArgs) > 1 {
+		coinint, err := strconv.Atoi(textArgs[1])
+		if err != nil {
+			return err
+		}
+		args.CoinType = uint32(coinint)
+	}
+	err := lc.rpccon.Call("LitRPC.SetFee", args, reply)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Current fee rate %d sat / byte\n", reply.CurrentFee)
+
+	return nil
+}
+
 // Address makes new addresses
 func (lc *litAfClient) Address(textArgs []string) error {
 	if len(textArgs) > 0 && textArgs[0] == "-h" {

--- a/litrpc/walletcmds.go
+++ b/litrpc/walletcmds.go
@@ -276,6 +276,31 @@ func (r *LitRPC) Fanout(args FanArgs, reply *TxidsReply) error {
 	return nil
 }
 
+// set fee
+type SetFeeArgs struct {
+	Fee      int64
+	CoinType uint32
+}
+type SetFeeReply struct {
+	CurrentFee int64
+}
+
+// SetFee allows you to set a fee rate for a wallet.  If you try to set a negative
+// fee rate, it will return the current rate.
+func (r *LitRPC) SetFee(args *SetFeeArgs, reply *SetFeeReply) error {
+	// if cointype is 0, use the node's default coin
+	if args.CoinType == 0 {
+		args.CoinType = r.Node.DefaultCoin
+	}
+	// make sure we support that coin type
+	wal, ok := r.Node.SubWallet[args.CoinType]
+	if !ok {
+		return fmt.Errorf("no connnected wallet for coin type %d", args.CoinType)
+	}
+	reply.CurrentFee = wal.Fee(args.Fee)
+	return nil
+}
+
 // ------------------------- address
 type AddressArgs struct {
 	NumToMake uint32

--- a/qln/basewallet.go
+++ b/qln/basewallet.go
@@ -82,6 +82,9 @@ type UWallet interface {
 	// Ask for network parameters
 	Params() *chaincfg.Params
 
+	// Set / Ask for current fee rate.  A negative value means check, dont' set.
+	Fee(int64) int64
+
 	// ===== TESTING / SPAMMING ONLY, these funcs will not be in the real interface
 	// Sweep sends lots of txs (uint32 of them) to the specified address.
 	Sweep([]byte, uint32) ([]*chainhash.Hash, error)

--- a/qln/fund.go
+++ b/qln/fund.go
@@ -178,18 +178,16 @@ func (nd *LitNode) PointReqHandler(msg lnutil.PointReqMsg) {
 		return
 	}
 
-	cointype := msg.Cointype
-
-	_, ok := nd.SubWallet[cointype]
+	_, ok := nd.SubWallet[msg.Cointype]
 	if !ok {
-		fmt.Printf("PointReqHandler err no wallet for type %d", cointype)
+		fmt.Printf("PointReqHandler err no wallet for type %d", msg.Cointype)
 		return
 	}
 
 	var kg portxo.KeyGen
 	kg.Depth = 5
 	kg.Step[0] = 44 | 1<<31
-	kg.Step[1] = cointype | 1<<31
+	kg.Step[1] = msg.Cointype | 1<<31
 	kg.Step[2] = UseChannelFund
 	kg.Step[3] = msg.Peer() | 1<<31
 	kg.Step[4] = cIdx | 1<<31
@@ -300,7 +298,9 @@ func (nd LitNode) PointRespHandler(msg lnutil.PointRespMsg) error {
 	q.State = new(StatCom)
 	q.State.StateIdx = 0
 	q.State.MyAmt = nd.InProg.Amt - nd.InProg.InitSend
-	q.State.Fee = 10000 // fixed fee for now here.
+	// get fee from sub wallet.  Later should make fee per channel and update state
+	// based on size
+	q.State.Fee = nd.SubWallet[q.Coin()].Fee(-1) * 1000
 
 	// save channel to db
 	err = nd.SaveQChan(q)
@@ -341,6 +341,12 @@ func (nd LitNode) PointRespHandler(msg lnutil.PointRespMsg) error {
 // QChanDescHandler takes in a description of a channel output.  It then
 // saves it to the local db, and returns a channel acknowledgement
 func (nd *LitNode) QChanDescHandler(msg lnutil.ChanDescMsg) {
+
+	wal, ok := nd.SubWallet[msg.CoinType]
+	if !ok {
+		fmt.Printf("QChanDescHandler err no wallet for type %d", msg.CoinType)
+		return
+	}
 
 	// deserialize desc
 	op := msg.Outpoint
@@ -387,7 +393,8 @@ func (nd *LitNode) QChanDescHandler(msg lnutil.ChanDescMsg) {
 	qc.State = new(StatCom)
 	// similar to SIGREV in pushpull
 
-	qc.State.Fee = 10000
+	// TODO assumes both parties use same fee
+	qc.State.Fee = wal.Fee(-1) * 1000
 	qc.State.MyAmt = msg.InitPayment
 
 	qc.State.StateIdx = 0
@@ -395,14 +402,6 @@ func (nd *LitNode) QChanDescHandler(msg lnutil.ChanDescMsg) {
 	qc.State.ElkPoint = msg.ElkZero
 	qc.State.NextElkPoint = msg.ElkOne
 	qc.State.N2ElkPoint = msg.ElkTwo
-
-	// create empty elkrem receiver to save
-	//	qc.ElkRcv = new(elkrem.ElkremReceiver)
-	//	err = qc.IngestElkrem(revElk)
-	//	if err != nil { // this can't happen because it's the first elk... remove?
-	//		fmt.Printf("QChanDescHandler err %s", err.Error())
-	//		return
-	//	}
 
 	// save new channel to db
 	err = nd.SaveQChan(qc)

--- a/wallit/basewalletif.go
+++ b/wallit/basewalletif.go
@@ -115,6 +115,14 @@ func (w *Wallit) WatchThis(op wire.OutPoint) error {
 	return nil
 }
 
+func (w *Wallit) Fee(set int64) int64 {
+	if set < 0 {
+		return w.FeeRate
+	}
+	w.FeeRate = set
+	return set
+}
+
 // ********* sweep is for testing / spamming, remove for real use
 func (w *Wallit) Sweep(outScript []byte, n uint32) ([]*chainhash.Hash, error) {
 	var err error


### PR DESCRIPTION
This isn't a good long term solution, but for now it helps to be able to manually set fee rates.

There's a new RPC command SetFee which lets you set a fee rate (satoshis per byte) for any wallet.  If you give it a negative number, it won't change the fee rate.  It always returns the current fee rate.

(So if you want to just check what the fee rate is, send -1)

The corresponding command has been added to lit-af.