### PR TITLE
[wip] Test litecoin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,5 @@ script:
   - go test ./...
   - go build
   - test/test_basic.py
+  - test/test_lc.py
 

--- a/cmd/litpy/litrpc.py
+++ b/cmd/litpy/litrpc.py
@@ -27,7 +27,7 @@ class LitConnection():
                 self.ws.connect("ws://%s:%s/ws" % (self.ip, self.port))
             except ConnectionRefusedError:
                 # lit is not ready to accept connections yet
-                time.sleep(0.2)
+                time.sleep(0.25)
             else:
                 # No exception - we're connected!
                 break
@@ -44,7 +44,7 @@ class LitConnection():
         self.msg_id = self.msg_id + 1 % 10000
 
         resp = json.loads(self.ws.recv())
-        logger.debug("Recieved rpc response from %s:%s Metohd: %s Response: %s." % (self.ip, self.port, method, str(resp)))
+        logger.debug("Recieved rpc response from %s:%s method: %s Response: %s." % (self.ip, self.port, method, str(resp)))
         return resp
 
     def __getattr__(self, name):
@@ -60,10 +60,3 @@ class LitConnection():
     def balance(self):
         """Get wallit balance"""
         return self.Bal()
-
-if __name__ == '__main__':
-    """Test litrpc.py. lit instance must be running and available on 127.0.0.1:8001"""
-    litConn = LitConnection("127.0.0.1", "8001")
-    litConn.connect()
-    print(litConn.new_address())
-    print(litConn.balance())

--- a/test/combine_logs.py
+++ b/test/combine_logs.py
@@ -50,13 +50,24 @@ def read_logs(tmp_dir):
     Delegates to generator function get_log_events() to provide individual log events
     for each of the input log files."""
 
+    # Test framework logs
     files = [("test", "%s/test_framework.log" % tmp_dir, TIMESTAMP_PATTERN1, None)]
+
+    # bitcoin node logs
+    for i in itertools.count():
+        logfile = "{}/lcnode{}/regtest/debug.log".format(tmp_dir, i)
+        if not os.path.isfile(logfile):
+            break
+        files.append(("lcnode%d" % i, logfile, TIMESTAMP_PATTERN1, None))
+
+    # litecoin node logs
     for i in itertools.count():
         logfile = "{}/bcnode{}/regtest/debug.log".format(tmp_dir, i)
         if not os.path.isfile(logfile):
             break
         files.append(("bcnode%d" % i, logfile, TIMESTAMP_PATTERN1, None))
 
+    # lit node logs
     for i in itertools.count():
         logfile = "{}/litnode{}/lit.log".format(tmp_dir, i)
         if not os.path.isfile(logfile):
@@ -108,6 +119,8 @@ def print_logs(log_events, color=False, html=False):
             colors["bcnode1"]  = "\033[0;32m"  # GREEN
             colors["litnode0"] = "\033[0;31m"  # RED
             colors["litnode1"] = "\033[0;33m"  # YELLOW
+            colors["lcnode0"]  = "\033[0;35m"  # MAGENTA
+            colors["lcnode1"]  = "\033[0;33m"  # YELLOW
             colors["reset"]    = "\033[0m"     # Reset font color
 
         for event in log_events:

--- a/test/lit_test_framework.py
+++ b/test/lit_test_framework.py
@@ -22,6 +22,19 @@ class LitTest():
     # Mainline functions. run_test() should be overridden by subclasses. Other
     # methods should not be overridden.
     def __init__(self):
+        # Warn and exit if lit or coin nodes are already running
+        try:
+            if subprocess.check_output(["pidof", "lit"]) is not None:
+                print("ERROR! There is already a lit process running on this system. Tests may fail unexpectedly due to resource contention!")
+                sys.exit(1)
+            if subprocess.check_output(["pidof", "bitcoind"]) is not None:
+                print("ERROR! There is already a bitcoind process running on this system. Tests may fail unexpectedly due to resource contention!")
+                sys.exit(1)
+            if subprocess.check_output(["pidof", "litecoind"]) is not None:
+                print("ERROR! There is already a litecoind process running on this system. Tests may fail unexpectedly due to resource contention!")
+                sys.exit(1)
+        except (OSError, subprocess.SubprocessError):
+            pass
         self.litnodes = []
         self.bcnodes = []
         self.lcnodes = []

--- a/test/lit_test_framework.py
+++ b/test/lit_test_framework.py
@@ -7,6 +7,10 @@ import argparse
 import collections
 import glob
 import logging
+try:
+    import ipdb as pdb
+except:
+    import pdb
 import shutil
 import subprocess
 import sys
@@ -55,6 +59,9 @@ class LitTest():
             self.log.error("Unexpected error: %s" % str(sys.exc_info()[0]))
             traceback.print_exc(file=sys.stdout)
             self.rc = 1
+            if self.args.debugger:
+                self.log.info("Attaching debugger")
+                pdb.set_trace()
         finally:
             self.cleanup()
 
@@ -137,6 +144,7 @@ class LitTest():
     def _getargs(self):
         """Parse arguments and pass through unrecognised args"""
         parser = argparse.ArgumentParser(description=__doc__)
+        parser.add_argument("--debugger", "-d", action='store_true', help="Automatically attach a debugger on test failure.")
         parser.add_argument("--loglevel", "-l", default="INFO", help="log events at this level and higher to the console. Can be set to DEBUG, INFO, WARNING, ERROR or CRITICAL. Passing --loglevel DEBUG will output all logs to console. Note that logs at all levels are always written to the test_framework.log file in the temporary test directory.")
         parser.add_argument("--nocleanup", "-n", action='store_true', help="Don't clean up the test directory after running (even on success).")
         self.args, self.unknown_args = parser.parse_known_args()

--- a/test/lit_test_framework.py
+++ b/test/lit_test_framework.py
@@ -11,7 +11,7 @@ import tempfile
 import time
 import traceback
 
-from bcnode import BCNode
+from bcnode import BCNode, LCNode
 from litnode import LitNode
 
 class LitTest():
@@ -22,6 +22,7 @@ class LitTest():
     def __init__(self):
         self.litnodes = []
         self.bcnodes = []
+        self.lcnodes = []
         self.tmpdir = tempfile.mkdtemp(prefix="test")
         self._getargs()
         self._start_logging()
@@ -55,6 +56,14 @@ class LitTest():
                 bcnode.process.wait(2)
             except subprocess.TimeoutExpired:
                 bcnode.process.kill()
+
+        for lcnode in self.lcnodes:
+            lcnode.stop()
+            try:
+                lcnode.process.wait(2)
+            except subprocess.TimeoutExpired:
+                lcnode.process.kill()
+
         for litnode in self.litnodes:
             litnode.Stop()
             try:
@@ -68,6 +77,9 @@ class LitTest():
 
     def add_bcnode(self):
         self.bcnodes.append(BCNode(self.tmpdir))
+
+    def add_lcnode(self):
+        self.lcnodes.append(LCNode(self.tmpdir))
 
     def log_balances(self, coin_type):
         log_str = "Balances:"
@@ -131,7 +143,7 @@ def wait_until(predicate, *, attempts=float('inf'), timeout=float('inf')):
         if predicate():
             return True
         attempt += 1
-        elapsed += 0.05
-        time.sleep(0.05)
+        elapsed += 0.25
+        time.sleep(0.25)
 
     raise AssertionError("wait_until() timed out")

--- a/test/litnode.py
+++ b/test/litnode.py
@@ -36,7 +36,7 @@ class LitNode():
         self.args.extend(['-tn3', '', '-lt4', ''])
 
     def start_node(self):
-        logger.debug("Starting litnode %d" % self.index)
+        logger.debug("Starting litnode %d with args %s" % (self.index, str(self.args)))
         self.process = subprocess.Popen([LIT_BIN] + self.args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
     def add_rpc_connection(self, ip, port):

--- a/test/test_lc.py
+++ b/test/test_lc.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The lit developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+"""Test basic lit functionality
+
+- start bitcoind process
+- start two lit processes
+- connect over websocket
+- create new address
+- get balance
+- listen on litnode0
+- connect from litnode1 to litnode0
+- send funds from bitcoind process to litnode0 address
+- open channel between litnode0 and litnode1
+- push funds from litnode0 to litnode1
+- push funds back
+- close channel co-operatively
+- stop"""
+import time
+
+from lit_test_framework import LitTest, wait_until
+
+LC_REGTEST = 258
+
+class TestLC(LitTest):
+    def run_test(self):
+
+        # Start a bitcoind node
+        self.add_lcnode()
+        self.lcnodes[0].start_node()
+
+        self.log.info("Generate 500 blocks to activate segwit")
+        self.lcnodes[0].generate(500)
+        network_info = self.lcnodes[0].getblockchaininfo().json()['result']
+        assert network_info['bip9_softforks']['segwit']['status'] == 'active'
+
+        # Start lit node 0 and open websocket connection
+        self.add_litnode()
+        self.litnodes[0].args.extend(["-ltr", "127.0.0.1"])
+        self.litnodes[0].start_node()
+        self.litnodes[0].add_rpc_connection("127.0.0.1", "8001")
+
+        # Start lit node 1 and open websocket connection
+        self.add_litnode()
+        self.litnodes[1].args.extend(["-rpcport", "8002", "-ltr", "127.0.0.1"])
+        self.litnodes[1].start_node()
+        self.litnodes[1].add_rpc_connection("127.0.0.1", "8002")
+
+        self.log.info("Connect lit nodes")
+        res = self.litnodes[0].Listen(Port="127.0.0.1:10001")["result"]
+        self.litnodes[0].lit_address = res["Adr"] + '@' + res["LisIpPorts"][0]
+
+        res = self.litnodes[1].Connect(LNAddr=self.litnodes[0].lit_address)
+        assert not res['error']
+        time.sleep(1)
+
+        # Check that litnode0 and litnode1 are connected
+        assert len(self.litnodes[0].ListConnections()['result']['Connections']) == 1
+        assert len(self.litnodes[1].ListConnections()['result']['Connections']) == 1
+        self.log.info("lit nodes connected")
+
+        self.log.info("Send funds from bitcoind node to litnode0")
+        balance = self.litnodes[0].get_balance(LC_REGTEST)
+        self.log_balances(LC_REGTEST)
+        addr = self.litnodes[0].rpc.Address(NumToMake=1, CoinType=LC_REGTEST)
+        self.lcnodes[0].sendtoaddress(addr["result"]["LegacyAddresses"][0], 12.34)
+        self.lcnodes[0].generate(1).text
+
+        self.log.info("Waiting to receive transaction")
+
+        # Wait for transaction to be received (15 seconds timeout)
+        wait_until(lambda: self.litnodes[0].get_balance(LC_REGTEST) - balance == 1234000000)
+        balance = self.litnodes[0].get_balance(LC_REGTEST)
+        self.log.info("Funds received")
+        self.log_balances(LC_REGTEST)
+
+        self.log.info("Send money from litnode0 to its own segwit address and confirm")
+        self.log.info("sending 1000000000 satoshis to litnode1 address")
+        self.litnodes[0].Send(DestAddrs=[self.litnodes[0].Address()['result']['WitAddresses'][0]], Amts=[1000000000])
+        wait_until(lambda: self.lcnodes[0].getmempoolinfo().json()['result']['size'] == 1)
+        self.lcnodes[0].generate(1)
+        wait_until(lambda: self.litnodes[0].Balance()['result']["Balances"][0]["SyncHeight"] == 502)
+
+        # We'll lose some money to fees. Hopefully not too much!
+        assert balance - self.litnodes[0].get_balance(LC_REGTEST) < 200000
+        balance = self.litnodes[0].get_balance(LC_REGTEST)
+        self.log.info("Funds transferred to segwit address")
+        self.log_balances(LC_REGTEST)
+
+        self.litnodes[0].TxoList()
+
+        self.log.info("Open channel from litnode0 to litnode1")
+        assert self.litnodes[0].ChannelList()['result']['Channels'] == []
+        assert self.litnodes[1].ChannelList()['result']['Channels'] == []
+
+        self.litnodes[0].FundChannel(Peer=1, CoinType=LC_REGTEST, Capacity=1000000000)
+        self.log.info("litnode0 has funded channel")
+
+        wait_until(lambda: self.lcnodes[0].getmempoolinfo().json()['result']['size'] == 1)
+        self.lcnodes[0].generate(1)
+        wait_until(lambda: self.litnodes[0].Balance()['result']["Balances"][0]["SyncHeight"] == 503)
+
+        # Wait for channel to open
+        wait_until(lambda: len(self.litnodes[0].ChannelList()['result']['Channels']) > 0)
+        assert len(self.litnodes[1].ChannelList()['result']['Channels']) > 0
+        self.log.info("Channel open")
+
+        assert abs(balance - self.litnodes[0].get_balance(LC_REGTEST) - 1000000000) < 200000
+        balance = self.litnodes[0].get_balance(LC_REGTEST)
+        self.log_balances(LC_REGTEST)
+
+        litnode0_channel = self.litnodes[0].ChannelList()['result']['Channels'][0]
+        litnode1_channel = self.litnodes[1].ChannelList()['result']['Channels'][0]
+
+        assert litnode0_channel['Capacity'] == 1000000000
+        assert litnode0_channel['StateNum'] == 0
+        assert not litnode0_channel['Closed']
+        assert litnode0_channel['MyBalance'] == 1000000000
+
+        assert litnode1_channel['Capacity'] == 1000000000
+        assert litnode1_channel['StateNum'] == 0
+        assert not litnode1_channel['Closed']
+        assert litnode1_channel['MyBalance'] == 0
+
+        self.log_channel_balance(self.litnodes[0], 0, self.litnodes[1], 0)
+        self.log.info("Now push some funds from litnode0 to litnode1")
+
+        self.litnodes[0].Push(ChanIdx=1, Amt=100000000)
+
+        litnode0_channel = self.litnodes[0].ChannelList()['result']['Channels'][0]
+        litnode1_channel = self.litnodes[1].ChannelList()['result']['Channels'][0]
+        assert litnode0_channel['MyBalance'] == 900000000
+        assert litnode1_channel['MyBalance'] == 100000000
+
+        self.log_channel_balance(self.litnodes[0], 0, self.litnodes[1], 0)
+
+        self.log.info("Push some funds back")
+        self.litnodes[1].Push(ChanIdx=1, Amt=50000000)
+
+        litnode0_channel = self.litnodes[0].ChannelList()['result']['Channels'][0]
+        litnode1_channel = self.litnodes[1].ChannelList()['result']['Channels'][0]
+        assert litnode0_channel['MyBalance'] == 950000000
+        assert litnode1_channel['MyBalance'] == 50000000
+
+        self.log_channel_balance(self.litnodes[0], 0, self.litnodes[1], 0)
+        self.log.info("Close channel")
+        self.litnodes[0].CloseChannel(ChanIdx=1)
+        wait_until(lambda: self.lcnodes[0].getmempoolinfo().json()['result']['size'] == 1)
+        self.lcnodes[0].generate(1)
+        wait_until(lambda: self.litnodes[0].Balance()['result']["Balances"][0]["SyncHeight"] == 504)
+
+        assert abs(self.litnodes[1].get_balance(LC_REGTEST) - 50000000) < 200000
+        assert abs(balance + 950000000 - self.litnodes[0].get_balance(LC_REGTEST)) < 200000
+
+        self.log_balances(LC_REGTEST)
+
+if __name__ == "__main__":
+    exit(TestLC().main())

--- a/wallit/init.go
+++ b/wallit/init.go
@@ -23,7 +23,7 @@ func NewWallit(
 	w.FreezeSet = make(map[wire.OutPoint]*FrozenTx)
 
 	w.FeeRate = 80
-	if w.Param.HDCoinType == 65537 { // litecoin testnet4 has high fee
+	if w.Param.HDCoinType == 65537 || w.Param.HDCoinType == 258 { // litecoin testnet4 has high fee
 		w.FeeRate = 800
 	}
 


### PR DESCRIPTION
Adds a test for litecoin. At the moment, this is almost a duplicate of the test_basic test. In the future it'd be nice to refactor into a single test. An argument would be passed into the test to specify which chain should be used (or a list of chains in the case where we're testing multiple chains).

There are a few odds and ends in here as well - attaching a debugger, testing whether any of the required binaries are already running when the test starts, and cleaning up the temp directory after a test run.

Still a work in progress. Travis is failing to build this correctly. I can't tell why.