### PR TITLE
[ci] Update travis for forked repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 go:
   - 1.8
 sudo: required
+go_import_path: github.com/mit-dci/lit
 cache:
   directories:
   - bitcoin-0.14.1


### PR DESCRIPTION
golang imports are all absolute rather than relative, so if you fork a repo then all of your imports are pointing to the forked-from repo rather than your own repo.

This isn't a problem locally - you clone the forked-from repo and then add your forked repo as a new remote. However, when you push a branch to github, travis will clone from *your* forked repo, and will then download import from the forked-from repo.

I think this is fixed by setting the `go_import_path` in travis. That causes travis to clone from your forked repository into `$GOPATH/src/<go_import_path>`, so when go comes to import the packages, it already has them in the right place.

This is what was causing https://github.com/mit-dci/lit/pull/72#issuecomment-301909049 to fail for my travis, but not the travis PR build.