### PR TITLE
Move parameters from btcsuite/chaincfg to lit/coinparam

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 go:
   - 1.8
 sudo: required
+go_import_path: github.com/mit-dci/lit
 cache:
   directories:
   - bitcoin-0.14.1

--- a/coinparam/bc2.go
+++ b/coinparam/bc2.go
@@ -1,0 +1,84 @@
+package coinparam
+
+import (
+	"time"
+
+	"github.com/adiabat/btcd/chaincfg/chainhash"
+	"github.com/adiabat/btcd/wire"
+)
+
+// BC2NetParams are the parameters for the BC2 test network.
+var BC2NetParams = Params{
+	Name:          "bc2",
+	NetMagicBytes: 0xcaa5afea,
+	DefaultPort:   "8444",
+	DNSSeeds:      []string{},
+
+	// Chain parameters
+	GenesisBlock:             &bc2GenesisBlock,
+	GenesisHash:              &bc2GenesisHash,
+	PowLimit:                 bc2NetPowLimit,
+	PowLimitBits:             0x1d7fffff,
+	CoinbaseMaturity:         10,
+	SubsidyReductionInterval: 210000,
+	TargetTimespan:           time.Hour * 1,   // 1 hour
+	TargetTimePerBlock:       time.Minute * 1, // 1 minute
+	RetargetAdjustmentFactor: 4,               // 25% less, 400% more
+	ReduceMinDifficulty:      false,
+	MinDiffReductionTime:     time.Minute * 20, // TargetTimePerBlock * 2
+	GenerateSupported:        false,
+
+	// Checkpoints ordered from oldest to newest.
+	Checkpoints: []Checkpoint{},
+
+	// Enforce current block version once majority of the network has
+	// upgraded.
+	// 51% (51 / 100)
+	// Reject previous block versions once a majority of the network has
+	// upgraded.
+	// 75% (75 / 100)
+	BlockEnforceNumRequired: 51,
+	BlockRejectNumRequired:  75,
+	BlockUpgradeNumToCheck:  100,
+
+	// Mempool parameters
+	RelayNonStdTxs: true,
+
+	// Address encoding magics
+	PubKeyHashAddrID: 0x19, // starts with B
+	ScriptHashAddrID: 0x1c, // starts with ?
+	Bech32Prefix:     "bc2",
+	PrivateKeyID:     0xef, // starts with 9 7(uncompressed) or c (compressed)
+
+	// BIP32 hierarchical deterministic extended key magics
+	HDPrivateKeyID: [4]byte{0x04, 0x35, 0x83, 0x94}, // starts with tprv
+	HDPublicKeyID:  [4]byte{0x04, 0x35, 0x87, 0xcf}, // starts with tpub
+
+	// BIP44 coin type used in the hierarchical deterministic path for
+	// address generation.
+	HDCoinType: 2,
+}
+
+// bc2GenesisHash is the hash of the first block in the block chain for the
+// test network (version 3).
+var bc2GenesisHash = chainhash.Hash([chainhash.HashSize]byte{ // Make go vet happy.
+	0x71, 0xed, 0xa3, 0xc2, 0xe3, 0x36, 0x73, 0x3d, 0x45, 0x03, 0x88, 0x90,
+	0xd8, 0xae, 0x54, 0x11, 0x87, 0x92, 0x1c, 0x49, 0xb8, 0x7f, 0x41, 0xd6,
+	0x99, 0xf6, 0xf3, 0xae, 0x0a, 0x00, 0x00, 0x00,
+})
+
+// bc2GenesisMerkleRoot is the same on bc2
+var bc2GenesisMerkleRoot = genesisMerkleRoot
+
+// bc2GenesisBlock has a different time stamp and difficulty
+var bc2GenesisBlock = wire.MsgBlock{
+	Header: wire.BlockHeader{
+		Version:    1,
+		PrevBlock:  chainhash.Hash{},         // 0000000000000000000000000000000000000000000000000000000000000000
+		MerkleRoot: bc2GenesisMerkleRoot,     // 4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b
+		Timestamp:  time.Unix(1483467305, 0), // later
+		Bits:       0x1d7fffff,               // 486604799 [00000000ffff0000000000000000000000000000000000000000000000000000]
+		Nonce:      0x334188d,                // 53745805
+	},
+	Transactions: []*wire.MsgTx{&genesisCoinbaseTx},
+}

--- a/coinparam/bitcoin.go
+++ b/coinparam/bitcoin.go
@@ -1,0 +1,332 @@
+package coinparam
+
+import (
+	"time"
+
+	"github.com/adiabat/btcd/chaincfg/chainhash"
+	"github.com/adiabat/btcd/wire"
+)
+
+// MainNetParams defines the network parameters for the main Bitcoin network.
+var BitcoinParams = Params{
+	Name:          "bitcoin",
+	NetMagicBytes: 0xd9b4bef9,
+	DefaultPort:   "8333",
+	DNSSeeds: []string{
+		"seed.bitcoin.sipa.be",
+		"dnsseed.bluematt.me",
+		"dnsseed.bitcoin.dashjr.org",
+		"seed.bitcoinstats.com",
+		"seed.bitnodes.io",
+		"bitseed.xf2.org",
+		"seed.bitcoin.jonasschnelli.ch",
+	},
+
+	// Chain parameters
+	GenesisBlock:             &genesisBlock,
+	GenesisHash:              &genesisHash,
+	PowLimit:                 mainPowLimit,
+	PowLimitBits:             0x1d00ffff,
+	CoinbaseMaturity:         100,
+	SubsidyReductionInterval: 210000,
+	TargetTimespan:           time.Hour * 24 * 14, // 14 days
+	TargetTimePerBlock:       time.Minute * 10,    // 10 minutes
+	RetargetAdjustmentFactor: 4,                   // 25% less, 400% more
+	ReduceMinDifficulty:      false,
+	MinDiffReductionTime:     0,
+	GenerateSupported:        false,
+
+	// Checkpoints ordered from oldest to newest.
+	Checkpoints: []Checkpoint{
+		{11111, newHashFromStr("0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d")},
+		{33333, newHashFromStr("000000002dd5588a74784eaa7ab0507a18ad16a236e7b1ce69f00d7ddfb5d0a6")},
+		{74000, newHashFromStr("0000000000573993a3c9e41ce34471c079dcf5f52a0e824a81e7f953b8661a20")},
+		{105000, newHashFromStr("00000000000291ce28027faea320c8d2b054b2e0fe44a773f3eefb151d6bdc97")},
+		{134444, newHashFromStr("00000000000005b12ffd4cd315cd34ffd4a594f430ac814c91184a0d42d2b0fe")},
+		{168000, newHashFromStr("000000000000099e61ea72015e79632f216fe6cb33d7899acb35b75c8303b763")},
+		{193000, newHashFromStr("000000000000059f452a5f7340de6682a977387c17010ff6e6c3bd83ca8b1317")},
+		{210000, newHashFromStr("000000000000048b95347e83192f69cf0366076336c639f9b7228e9ba171342e")},
+		{216116, newHashFromStr("00000000000001b4f4b433e81ee46494af945cf96014816a4e2370f11b23df4e")},
+		{225430, newHashFromStr("00000000000001c108384350f74090433e7fcf79a606b8e797f065b130575932")},
+		{250000, newHashFromStr("000000000000003887df1f29024b06fc2200b55f8af8f35453d7be294df2d214")},
+		{267300, newHashFromStr("000000000000000a83fbd660e918f218bf37edd92b748ad940483c7c116179ac")},
+		{279000, newHashFromStr("0000000000000001ae8c72a0b0c301f67e3afca10e819efa9041e458e9bd7e40")},
+		{300255, newHashFromStr("0000000000000000162804527c6e9b9f0563a280525f9d08c12041def0a0f3b2")},
+		{319400, newHashFromStr("000000000000000021c6052e9becade189495d1c539aa37c58917305fd15f13b")},
+		{343185, newHashFromStr("0000000000000000072b8bf361d01a6ba7d445dd024203fafc78768ed4368554")},
+		{352940, newHashFromStr("000000000000000010755df42dba556bb72be6a32f3ce0b6941ce4430152c9ff")},
+		{382320, newHashFromStr("00000000000000000a8dc6ed5b133d0eb2fd6af56203e4159789b092defd8ab2")},
+	},
+
+	// Enforce current block version once majority of the network has
+	// upgraded.
+	// 75% (750 / 1000)
+	// Reject previous block versions once a majority of the network has
+	// upgraded.
+	// 95% (950 / 1000)
+	BlockEnforceNumRequired: 750,
+	BlockRejectNumRequired:  950,
+	BlockUpgradeNumToCheck:  1000,
+
+	// Mempool parameters
+	RelayNonStdTxs: false,
+
+	// Address encoding magics
+	PubKeyHashAddrID: 0x00, // starts with 1
+	ScriptHashAddrID: 0x05, // starts with 3
+	PrivateKeyID:     0x80, // starts with 5 (uncompressed) or K (compressed)
+	Bech32Prefix:     "bc", // starts with bc1
+
+	// BIP32 hierarchical deterministic extended key magics
+	HDPrivateKeyID: [4]byte{0x04, 0x88, 0xad, 0xe4}, // starts with xprv
+	HDPublicKeyID:  [4]byte{0x04, 0x88, 0xb2, 0x1e}, // starts with xpub
+
+	// BIP44 coin type used in the hierarchical deterministic path for
+	// address generation.
+	HDCoinType: 0,
+}
+
+// TestNet3Params defines the network parameters for the test Bitcoin network
+// (version 3).  Not to be confused with the regression test network, this
+// network is sometimes simply called "testnet".
+var TestNet3Params = Params{
+	Name:          "testnet3",
+	NetMagicBytes: 0x0709110b,
+	DefaultPort:   "18333",
+	DNSSeeds: []string{
+		"testnet-seed.bitcoin.petertodd.org",
+		"testnet-seed.bluematt.me",
+	},
+
+	// Chain parameters
+	GenesisBlock:             &testNet3GenesisBlock,
+	GenesisHash:              &testNet3GenesisHash,
+	PowLimit:                 testNet3PowLimit,
+	PowLimitBits:             0x1d00ffff,
+	CoinbaseMaturity:         100,
+	SubsidyReductionInterval: 210000,
+	TargetTimespan:           time.Hour * 24 * 14, // 14 days
+	TargetTimePerBlock:       time.Minute * 10,    // 10 minutes
+	RetargetAdjustmentFactor: 4,                   // 25% less, 400% more
+	ReduceMinDifficulty:      true,
+	MinDiffReductionTime:     time.Minute * 20, // TargetTimePerBlock * 2
+	GenerateSupported:        false,
+
+	// Checkpoints ordered from oldest to newest.
+	Checkpoints: []Checkpoint{
+		{546, newHashFromStr("000000002a936ca763904c3c35fce2f3556c559c0214345d31b1bcebf76acb70")},
+	},
+
+	// Enforce current block version once majority of the network has
+	// upgraded.
+	// 51% (51 / 100)
+	// Reject previous block versions once a majority of the network has
+	// upgraded.
+	// 75% (75 / 100)
+	BlockEnforceNumRequired: 51,
+	BlockRejectNumRequired:  75,
+	BlockUpgradeNumToCheck:  100,
+
+	// Mempool parameters
+	RelayNonStdTxs: true,
+
+	// Address encoding magics
+	PubKeyHashAddrID: 0x6f, // starts with m or n
+	ScriptHashAddrID: 0xc4, // starts with 2
+	Bech32Prefix:     "tb",
+	PrivateKeyID:     0xef, // starts with 9 (uncompressed) or c (compressed)
+
+	// BIP32 hierarchical deterministic extended key magics
+	HDPrivateKeyID: [4]byte{0x04, 0x35, 0x83, 0x94}, // starts with tprv
+	HDPublicKeyID:  [4]byte{0x04, 0x35, 0x87, 0xcf}, // starts with tpub
+
+	// BIP44 coin type used in the hierarchical deterministic path for
+	// address generation.
+	HDCoinType: 1,
+}
+
+// RegressionNetParams defines the network parameters for the regression test
+// Bitcoin network.  Not to be confused with the test Bitcoin network (version
+// 3), this network is sometimes simply called "testnet".
+var RegressionNetParams = Params{
+	Name:          "regtest",
+	NetMagicBytes: 0xdab5bffa,
+	DefaultPort:   "18444",
+	DNSSeeds:      []string{},
+
+	// Chain parameters
+	GenesisBlock:             &regTestGenesisBlock,
+	GenesisHash:              &regTestGenesisHash,
+	PowLimit:                 regressionPowLimit,
+	PowLimitBits:             0x207fffff,
+	CoinbaseMaturity:         100,
+	SubsidyReductionInterval: 150,
+	TargetTimespan:           time.Hour * 24 * 14, // 14 days
+	TargetTimePerBlock:       time.Minute * 10,    // 10 minutes
+	RetargetAdjustmentFactor: 4,                   // 25% less, 400% more
+	ReduceMinDifficulty:      true,
+	MinDiffReductionTime:     time.Minute * 20, // TargetTimePerBlock * 2
+	GenerateSupported:        true,
+
+	// Checkpoints ordered from oldest to newest.
+	Checkpoints: nil,
+
+	// Enforce current block version once majority of the network has
+	// upgraded.
+	// 75% (750 / 1000)
+	// Reject previous block versions once a majority of the network has
+	// upgraded.
+	// 95% (950 / 1000)
+	BlockEnforceNumRequired: 750,
+	BlockRejectNumRequired:  950,
+	BlockUpgradeNumToCheck:  1000,
+
+	// Mempool parameters
+	RelayNonStdTxs: true,
+
+	// Address encoding magics
+	PubKeyHashAddrID: 0x6f, // starts with m or n
+	ScriptHashAddrID: 0xc4, // starts with 2
+	PrivateKeyID:     0xef, // starts with 9 (uncompressed) or c (compressed)
+	Bech32Prefix:     "rt",
+
+	// BIP32 hierarchical deterministic extended key magics
+	HDPrivateKeyID: [4]byte{0x04, 0x35, 0x83, 0x94}, // starts with tprv
+	HDPublicKeyID:  [4]byte{0x04, 0x35, 0x87, 0xcf}, // starts with tpub
+
+	// BIP44 coin type used in the hierarchical deterministic path for
+	// address generation.
+	HDCoinType: 257,
+}
+
+// genesisCoinbaseTx is the coinbase transaction for the genesis blocks for
+// the main network, regression test network, and test network (version 3).
+var genesisCoinbaseTx = wire.MsgTx{
+	Version: 1,
+	TxIn: []*wire.TxIn{
+		{
+			PreviousOutPoint: wire.OutPoint{
+				Hash:  chainhash.Hash{},
+				Index: 0xffffffff,
+			},
+			SignatureScript: []byte{
+				0x04, 0xff, 0xff, 0x00, 0x1d, 0x01, 0x04, 0x45, /* |.......E| */
+				0x54, 0x68, 0x65, 0x20, 0x54, 0x69, 0x6d, 0x65, /* |The Time| */
+				0x73, 0x20, 0x30, 0x33, 0x2f, 0x4a, 0x61, 0x6e, /* |s 03/Jan| */
+				0x2f, 0x32, 0x30, 0x30, 0x39, 0x20, 0x43, 0x68, /* |/2009 Ch| */
+				0x61, 0x6e, 0x63, 0x65, 0x6c, 0x6c, 0x6f, 0x72, /* |ancellor| */
+				0x20, 0x6f, 0x6e, 0x20, 0x62, 0x72, 0x69, 0x6e, /* | on brin| */
+				0x6b, 0x20, 0x6f, 0x66, 0x20, 0x73, 0x65, 0x63, /* |k of sec|*/
+				0x6f, 0x6e, 0x64, 0x20, 0x62, 0x61, 0x69, 0x6c, /* |ond bail| */
+				0x6f, 0x75, 0x74, 0x20, 0x66, 0x6f, 0x72, 0x20, /* |out for |*/
+				0x62, 0x61, 0x6e, 0x6b, 0x73, /* |banks| */
+			},
+			Sequence: 0xffffffff,
+		},
+	},
+	TxOut: []*wire.TxOut{
+		{
+			Value: 0x12a05f200,
+			PkScript: []byte{
+				0x41, 0x04, 0x67, 0x8a, 0xfd, 0xb0, 0xfe, 0x55, /* |A.g....U| */
+				0x48, 0x27, 0x19, 0x67, 0xf1, 0xa6, 0x71, 0x30, /* |H'.g..q0| */
+				0xb7, 0x10, 0x5c, 0xd6, 0xa8, 0x28, 0xe0, 0x39, /* |..\..(.9| */
+				0x09, 0xa6, 0x79, 0x62, 0xe0, 0xea, 0x1f, 0x61, /* |..yb...a| */
+				0xde, 0xb6, 0x49, 0xf6, 0xbc, 0x3f, 0x4c, 0xef, /* |..I..?L.| */
+				0x38, 0xc4, 0xf3, 0x55, 0x04, 0xe5, 0x1e, 0xc1, /* |8..U....| */
+				0x12, 0xde, 0x5c, 0x38, 0x4d, 0xf7, 0xba, 0x0b, /* |..\8M...| */
+				0x8d, 0x57, 0x8a, 0x4c, 0x70, 0x2b, 0x6b, 0xf1, /* |.W.Lp+k.| */
+				0x1d, 0x5f, 0xac, /* |._.| */
+			},
+		},
+	},
+	LockTime: 0,
+}
+
+// genesisHash is the hash of the first block in the block chain for the main
+// network (genesis block).
+var genesisHash = chainhash.Hash([chainhash.HashSize]byte{ // Make go vet happy.
+	0x6f, 0xe2, 0x8c, 0x0a, 0xb6, 0xf1, 0xb3, 0x72,
+	0xc1, 0xa6, 0xa2, 0x46, 0xae, 0x63, 0xf7, 0x4f,
+	0x93, 0x1e, 0x83, 0x65, 0xe1, 0x5a, 0x08, 0x9c,
+	0x68, 0xd6, 0x19, 0x00, 0x00, 0x00, 0x00, 0x00,
+})
+
+// genesisMerkleRoot is the hash of the first transaction in the genesis block
+// for the main network.
+var genesisMerkleRoot = chainhash.Hash([chainhash.HashSize]byte{ // Make go vet happy.
+	0x3b, 0xa3, 0xed, 0xfd, 0x7a, 0x7b, 0x12, 0xb2,
+	0x7a, 0xc7, 0x2c, 0x3e, 0x67, 0x76, 0x8f, 0x61,
+	0x7f, 0xc8, 0x1b, 0xc3, 0x88, 0x8a, 0x51, 0x32,
+	0x3a, 0x9f, 0xb8, 0xaa, 0x4b, 0x1e, 0x5e, 0x4a,
+})
+
+// genesisBlock defines the genesis block of the block chain which serves as the
+// public transaction ledger for the main network.
+var genesisBlock = wire.MsgBlock{
+	Header: wire.BlockHeader{
+		Version:    1,
+		PrevBlock:  chainhash.Hash{},         // 0000000000000000000000000000000000000000000000000000000000000000
+		MerkleRoot: genesisMerkleRoot,        // 4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b
+		Timestamp:  time.Unix(0x495fab29, 0), // 2009-01-03 18:15:05 +0000 UTC
+		Bits:       0x1d00ffff,               // 486604799 [00000000ffff0000000000000000000000000000000000000000000000000000]
+		Nonce:      0x7c2bac1d,               // 2083236893
+	},
+	Transactions: []*wire.MsgTx{&genesisCoinbaseTx},
+}
+
+// regTestGenesisHash is the hash of the first block in the block chain for the
+// regression test network (genesis block).
+var regTestGenesisHash = chainhash.Hash([chainhash.HashSize]byte{ // Make go vet happy.
+	0x06, 0x22, 0x6e, 0x46, 0x11, 0x1a, 0x0b, 0x59,
+	0xca, 0xaf, 0x12, 0x60, 0x43, 0xeb, 0x5b, 0xbf,
+	0x28, 0xc3, 0x4f, 0x3a, 0x5e, 0x33, 0x2a, 0x1f,
+	0xc7, 0xb2, 0xb7, 0x3c, 0xf1, 0x88, 0x91, 0x0f,
+})
+
+// regTestGenesisMerkleRoot is the hash of the first transaction in the genesis
+// block for the regression test network.  It is the same as the merkle root for
+// the main network.
+var regTestGenesisMerkleRoot = genesisMerkleRoot
+
+// regTestGenesisBlock defines the genesis block of the block chain which serves
+// as the public transaction ledger for the regression test network.
+var regTestGenesisBlock = wire.MsgBlock{
+	Header: wire.BlockHeader{
+		Version:    1,
+		PrevBlock:  chainhash.Hash{},         // 0000000000000000000000000000000000000000000000000000000000000000
+		MerkleRoot: regTestGenesisMerkleRoot, // 4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b
+		Timestamp:  time.Unix(1296688602, 0), // 2011-02-02 23:16:42 +0000 UTC
+		Bits:       0x207fffff,               // 545259519 [7fffff0000000000000000000000000000000000000000000000000000000000]
+		Nonce:      2,
+	},
+	Transactions: []*wire.MsgTx{&genesisCoinbaseTx},
+}
+
+// testNet3GenesisHash is the hash of the first block in the block chain for the
+// test network (version 3).
+var testNet3GenesisHash = chainhash.Hash([chainhash.HashSize]byte{ // Make go vet happy.
+	0x43, 0x49, 0x7f, 0xd7, 0xf8, 0x26, 0x95, 0x71,
+	0x08, 0xf4, 0xa3, 0x0f, 0xd9, 0xce, 0xc3, 0xae,
+	0xba, 0x79, 0x97, 0x20, 0x84, 0xe9, 0x0e, 0xad,
+	0x01, 0xea, 0x33, 0x09, 0x00, 0x00, 0x00, 0x00,
+})
+
+// testNet3GenesisMerkleRoot is the hash of the first transaction in the genesis
+// block for the test network (version 3).  It is the same as the merkle root
+// for the main network.
+var testNet3GenesisMerkleRoot = genesisMerkleRoot
+
+// testNet3GenesisBlock defines the genesis block of the block chain which
+// serves as the public transaction ledger for the test network (version 3).
+var testNet3GenesisBlock = wire.MsgBlock{
+	Header: wire.BlockHeader{
+		Version:    1,
+		PrevBlock:  chainhash.Hash{},          // 0000000000000000000000000000000000000000000000000000000000000000
+		MerkleRoot: testNet3GenesisMerkleRoot, // 4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b
+		Timestamp:  time.Unix(1296688602, 0),  // 2011-02-02 23:16:42 +0000 UTC
+		Bits:       0x1d00ffff,                // 486604799 [00000000ffff0000000000000000000000000000000000000000000000000000]
+		Nonce:      0x18aea41a,                // 414098458
+	},
+	Transactions: []*wire.MsgTx{&genesisCoinbaseTx},
+}

--- a/coinparam/litecoin.go
+++ b/coinparam/litecoin.go
@@ -1,0 +1,172 @@
+package coinparam
+
+import (
+	"time"
+
+	"github.com/adiabat/btcd/chaincfg/chainhash"
+	"github.com/adiabat/btcd/wire"
+)
+
+// LiteCoinTestNet4Params are the parameters for the litecoin test network 4.
+var LiteCoinTestNet4Params = Params{
+	Name:          "litetest4",
+	NetMagicBytes: 0xf1c8d2fd,
+	DefaultPort:   "19335",
+	DNSSeeds: []string{
+		"testnet-seed.litecointools.com",
+		"seed-b.litecoin.loshan.co.uk",
+		"dnsseed-testnet.thrasher.io",
+	},
+
+	// Chain parameters
+	GenesisBlock:             &bc2GenesisBlock, // no it's not
+	GenesisHash:              &liteCoinTestNet4GenesisHash,
+	PowLimit:                 liteCoinTestNet4PowLimit,
+	PowLimitBits:             0x1e0fffff,
+	CoinbaseMaturity:         100,
+	SubsidyReductionInterval: 840000,
+	TargetTimespan:           time.Hour * 84,    // 84 hours
+	TargetTimePerBlock:       time.Second * 150, // 150 seconds
+	RetargetAdjustmentFactor: 4,                 // 25% less, 400% more
+	ReduceMinDifficulty:      true,
+	MinDiffReductionTime:     time.Minute * 10, // ?? unknown
+	GenerateSupported:        false,
+
+	// Checkpoints ordered from oldest to newest.
+	Checkpoints: []Checkpoint{},
+
+	// Enforce current block version once majority of the network has
+	// upgraded.
+	// 51% (51 / 100)
+	// Reject previous block versions once a majority of the network has
+	// upgraded.
+	// 75% (75 / 100)
+	BlockEnforceNumRequired: 51,
+	BlockRejectNumRequired:  75,
+	BlockUpgradeNumToCheck:  100,
+
+	// Mempool parameters
+	RelayNonStdTxs: true,
+
+	// Address encoding magics
+	PubKeyHashAddrID: 0x6f, // starts with m or n
+	ScriptHashAddrID: 0xc4, // starts with 2
+	Bech32Prefix:     "tltc",
+	PrivateKeyID:     0xef, // starts with 9 7(uncompressed) or c (compressed)
+
+	// BIP32 hierarchical deterministic extended key magics
+	HDPrivateKeyID: [4]byte{0x04, 0x35, 0x83, 0x94}, // starts with tprv
+	HDPublicKeyID:  [4]byte{0x04, 0x35, 0x87, 0xcf}, // starts with tpub
+
+	// BIP44 coin type used in the hierarchical deterministic path for
+	// address generation.
+	HDCoinType: 65537, // i dunno, 0x010001 ?
+}
+
+// LiteCoinTestNet4Params are the parameters for the litecoin test network 4.
+var LiteRegNetParams = Params{
+	Name:          "litereg",
+	NetMagicBytes: 0xdab5bffa,
+	DefaultPort:   "19444",
+	DNSSeeds:      []string{},
+
+	// Chain parameters
+	GenesisBlock:             &liteCoinRegTestGenesisBlock, // no it's not
+	GenesisHash:              &liteCoinRegTestGenesisHash,
+	PowLimit:                 regressionPowLimit,
+	PowLimitBits:             0x207fffff,
+	CoinbaseMaturity:         100,
+	SubsidyReductionInterval: 150,
+	TargetTimespan:           time.Hour * 84,    // 84 hours (3.5 days)
+	TargetTimePerBlock:       time.Second * 150, // 150 seconds (2.5 min)
+	RetargetAdjustmentFactor: 4,                 // 25% less, 400% more
+	ReduceMinDifficulty:      true,
+	MinDiffReductionTime:     time.Minute * 10, // ?? unknown
+	GenerateSupported:        true,
+
+	// Checkpoints ordered from oldest to newest.
+	Checkpoints: []Checkpoint{},
+
+	// Enforce current block version once majority of the network has
+	// upgraded.
+	// 51% (51 / 100)
+	// Reject previous block versions once a majority of the network has
+	// upgraded.
+	// 75% (75 / 100)
+	BlockEnforceNumRequired: 51,
+	BlockRejectNumRequired:  75,
+	BlockUpgradeNumToCheck:  100,
+
+	// Mempool parameters
+	RelayNonStdTxs: true,
+
+	// Address encoding magics
+	PubKeyHashAddrID: 0x6f, // starts with m or n
+	ScriptHashAddrID: 0xc4, // starts with 2
+	Bech32Prefix:     "rltc",
+	PrivateKeyID:     0xef, // starts with 9 7(uncompressed) or c (compressed)
+
+	// BIP32 hierarchical deterministic extended key magics
+	HDPrivateKeyID: [4]byte{0x04, 0x35, 0x83, 0x94}, // starts with tprv
+	HDPublicKeyID:  [4]byte{0x04, 0x35, 0x87, 0xcf}, // starts with tpub
+
+	// BIP44 coin type used in the hierarchical deterministic path for
+	// address generation.
+	HDCoinType: 258, // i dunno
+}
+
+// liteCoinTestNet4GenesisHash is the first hash in litecoin testnet4
+var liteCoinTestNet4GenesisHash = chainhash.Hash([chainhash.HashSize]byte{ // Make go vet happy.
+	0xa0, 0x29, 0x3e, 0x4e, 0xeb, 0x3d, 0xa6, 0xe6, 0xf5, 0x6f, 0x81, 0xed,
+	0x59, 0x5f, 0x57, 0x88, 0x0d, 0x1a, 0x21, 0x56, 0x9e, 0x13, 0xee, 0xfd,
+	0xd9, 0x51, 0x28, 0x4b, 0x5a, 0x62, 0x66, 0x49,
+})
+
+var liteCoinTestNet4MerkleRoot = chainhash.Hash([chainhash.HashSize]byte{ // Make go vet happy.
+	0xd9, 0xce, 0xd4, 0xed, 0x11, 0x30, 0xf7, 0xb7, 0xfa, 0xad, 0x9b, 0xe2,
+	0x53, 0x23, 0xff, 0xaf, 0xa3, 0x32, 0x32, 0xa1, 0x7c, 0x3e, 0xdf, 0x6c,
+	0xfd, 0x97, 0xbe, 0xe6, 0xba, 0xfb, 0xdd, 0x97,
+})
+
+// liteCoinTestNet4GenesisBlock has is like completely its own thing
+var liteCoinTestNet4GenesisBlock = wire.MsgBlock{
+	Header: wire.BlockHeader{
+		Version:    1,
+		PrevBlock:  chainhash.Hash{}, // empty
+		MerkleRoot: liteCoinTestNet4MerkleRoot,
+		Timestamp:  time.Unix(1486949366, 0), // later
+		Bits:       0x1e0ffff0,
+		Nonce:      293345,
+	},
+	//	Transactions: []*wire.MsgTx{&genesisCoinbaseTx}, // this is wrong... will it break?
+}
+
+// ==================== LiteRegNet
+
+// liteCoinRegTestGenesisHash is the first hash in litecoin regtest
+var liteCoinRegTestGenesisHash = chainhash.Hash([chainhash.HashSize]byte{ // Make go vet happy.
+	0x06, 0x22, 0x6e, 0x46, 0x11, 0x1a, 0x0b, 0x59,
+	0xca, 0xaf, 0x12, 0x60, 0x43, 0xeb, 0x5b, 0xbf,
+	0x28, 0xc3, 0x4f, 0x3a, 0x5e, 0x33, 0x2a, 0x1f,
+	0xc7, 0xb2, 0xb7, 0x3c, 0xf1, 0x88, 0x91, 0x0f,
+})
+
+// is this the same...?
+var liteCoinRegTestMerkleRoot = chainhash.Hash([chainhash.HashSize]byte{ // Make go vet happy.
+	0xd9, 0xce, 0xd4, 0xed, 0x11, 0x30, 0xf7, 0xb7, 0xfa, 0xad, 0x9b, 0xe2,
+	0x53, 0x23, 0xff, 0xaf, 0xa3, 0x32, 0x32, 0xa1, 0x7c, 0x3e, 0xdf, 0x6c,
+	0xfd, 0x97, 0xbe, 0xe6, 0xba, 0xfb, 0xdd, 0x97,
+})
+
+// liteCoinTestNet4GenesisBlock has is like completely its own thing
+var liteCoinRegTestGenesisBlock = wire.MsgBlock{
+	Header: wire.BlockHeader{
+		Version:    1,
+		PrevBlock:  chainhash.Hash{}, // empty
+		MerkleRoot: liteCoinRegTestMerkleRoot,
+		Timestamp:  time.Unix(1296688602, 0), // later
+		Bits:       0x207fffff,
+		Nonce:      2,
+	},
+	//	Transactions: []*wire.MsgTx{&genesisCoinbaseTx}, // this is wrong... will it break?
+}

--- a/coinparam/register.go
+++ b/coinparam/register.go
@@ -1,0 +1,284 @@
+package coinparam
+
+import (
+	"errors"
+	"math/big"
+	"time"
+
+	"github.com/adiabat/btcd/chaincfg/chainhash"
+	"github.com/adiabat/btcd/wire"
+)
+
+// Params defines a Bitcoin network by its parameters.  These parameters may be
+// used by Bitcoin applications to differentiate networks as well as addresses
+// and keys for one network from those intended for use on another network.
+type Params struct {
+	// Name defines a human-readable identifier for the network.
+	Name string
+
+	// Net defines the magic bytes used to identify the network.
+	NetMagicBytes uint32
+
+	// DefaultPort defines the default peer-to-peer port for the network.
+	DefaultPort string
+
+	// DNSSeeds defines a list of DNS seeds for the network that are used
+	// as one method to discover peers.
+	DNSSeeds []string
+
+	// GenesisBlock defines the first block of the chain.
+	GenesisBlock *wire.MsgBlock
+
+	// GenesisHash is the starting block hash.
+	GenesisHash *chainhash.Hash
+
+	// PowLimit defines the highest allowed proof of work value for a block
+	// as a uint256.
+	PowLimit *big.Int
+
+	// PowLimitBits defines the highest allowed proof of work value for a
+	// block in compact form.
+	PowLimitBits uint32
+
+	// CoinbaseMaturity is the number of blocks required before newly mined
+	// coins (coinbase transactions) can be spent.
+	CoinbaseMaturity uint16
+
+	// SubsidyReductionInterval is the interval of blocks before the subsidy
+	// is reduced.
+	SubsidyReductionInterval int32
+
+	// TargetTimespan is the desired amount of time that should elapse
+	// before the block difficulty requirement is examined to determine how
+	// it should be changed in order to maintain the desired block
+	// generation rate.
+	TargetTimespan time.Duration
+
+	// TargetTimePerBlock is the desired amount of time to generate each
+	// block.
+	TargetTimePerBlock time.Duration
+
+	// RetargetAdjustmentFactor is the adjustment factor used to limit
+	// the minimum and maximum amount of adjustment that can occur between
+	// difficulty retargets.
+	RetargetAdjustmentFactor int64
+
+	// ReduceMinDifficulty defines whether the network should reduce the
+	// minimum required difficulty after a long enough period of time has
+	// passed without finding a block.  This is really only useful for test
+	// networks and should not be set on a main network.
+	ReduceMinDifficulty bool
+
+	// MinDiffReductionTime is the amount of time after which the minimum
+	// required difficulty should be reduced when a block hasn't been found.
+	//
+	// NOTE: This only applies if ReduceMinDifficulty is true.
+	MinDiffReductionTime time.Duration
+
+	// GenerateSupported specifies whether or not CPU mining is allowed.
+	GenerateSupported bool
+
+	// Checkpoints ordered from oldest to newest.
+	Checkpoints []Checkpoint
+
+	// Enforce current block version once network has
+	// upgraded.  This is part of BIP0034.
+	BlockEnforceNumRequired uint64
+
+	// Reject previous block versions once network has
+	// upgraded.  This is part of BIP0034.
+	BlockRejectNumRequired uint64
+
+	// The number of nodes to check.  This is part of BIP0034.
+	BlockUpgradeNumToCheck uint64
+
+	// Mempool parameters
+	RelayNonStdTxs bool
+
+	// Address encoding magics
+	PubKeyHashAddrID byte   // First byte of a P2PKH address
+	ScriptHashAddrID byte   // First byte of a P2SH address
+	PrivateKeyID     byte   // First byte of a WIF private key
+	Bech32Prefix     string // HRP for bech32 address
+
+	// BIP32 hierarchical deterministic extended key magics
+	HDPrivateKeyID [4]byte
+	HDPublicKeyID  [4]byte
+
+	// BIP44 coin type used in the hierarchical deterministic path for
+	// address generation.
+	HDCoinType uint32
+}
+
+// These variables are the chain proof-of-work limit parameters for each default
+// network.
+var (
+	// bigOne is 1 represented as a big.Int.  It is defined here to avoid
+	// the overhead of creating it multiple times.
+	bigOne = big.NewInt(1)
+
+	// mainPowLimit is the highest proof of work value a Bitcoin block can
+	// have for the main network.  It is the value 2^224 - 1.
+	mainPowLimit = new(big.Int).Sub(new(big.Int).Lsh(bigOne, 224), bigOne)
+
+	// regressionPowLimit is the highest proof of work value a Bitcoin block
+	// can have for the regression test network.  It is the value 2^255 - 1.
+	regressionPowLimit = new(big.Int).Sub(new(big.Int).Lsh(bigOne, 255), bigOne)
+
+	// testNet3PowLimit is the highest proof of work value a Bitcoin block
+	// can have for the test network (version 3).  It is the value
+	// 2^224 - 1.
+	testNet3PowLimit = new(big.Int).Sub(new(big.Int).Lsh(bigOne, 224), bigOne)
+
+	bc2NetPowLimit = new(big.Int).Sub(new(big.Int).Lsh(bigOne, 231), bigOne)
+
+	liteCoinTestNet4PowLimit = new(big.Int).Sub(new(big.Int).Lsh(bigOne, 236), bigOne)
+
+	// simNetPowLimit is the highest proof of work value a Bitcoin block
+	// can have for the simulation test network.  It is the value 2^255 - 1.
+	simNetPowLimit = new(big.Int).Sub(new(big.Int).Lsh(bigOne, 255), bigOne)
+)
+
+// Checkpoint identifies a known good point in the block chain.  Using
+// checkpoints allows a few optimizations for old blocks during initial download
+// and also prevents forks from old blocks.
+//
+// Each checkpoint is selected based upon several factors.  See the
+// documentation for blockchain.IsCheckpointCandidate for details on the
+// selection criteria.
+type Checkpoint struct {
+	Height int32
+	Hash   *chainhash.Hash
+}
+
+func init() {
+	// Register all default networks when the package is initialized.
+	mustRegister(&BitcoinParams)
+	mustRegister(&TestNet3Params)
+	mustRegister(&RegressionNetParams)
+	mustRegister(&BC2NetParams)
+	mustRegister(&LiteCoinTestNet4Params)
+	mustRegister(&LiteRegNetParams)
+}
+
+// mustRegister performs the same function as Register except it panics if there
+// is an error.  This should only be called from package init functions.
+func mustRegister(params *Params) {
+	if err := Register(params); err != nil {
+		panic("failed to register network: " + err.Error())
+	}
+}
+
+// Register registers the network parameters for a Bitcoin network.  This may
+// error with ErrDuplicateNet if the network is already registered (either
+// due to a previous Register call, or the network being one of the default
+// networks).
+//
+// Network parameters should be registered into this package by a main package
+// as early as possible.  Then, library packages may lookup networks or network
+// parameters based on inputs and work regardless of the network being standard
+// or not.
+func Register(params *Params) error {
+	if _, ok := registeredNets[params.HDCoinType]; ok {
+		return ErrDuplicateNet
+	}
+	registeredNets[params.HDCoinType] = struct{}{}
+	bech32Prefixes[params.Bech32Prefix] = params.HDCoinType
+	pubKeyHashAddrIDs[params.PubKeyHashAddrID] = struct{}{}
+	scriptHashAddrIDs[params.ScriptHashAddrID] = struct{}{}
+	hdPrivToPubKeyIDs[params.HDPrivateKeyID] = params.HDPublicKeyID[:]
+	return nil
+}
+
+var (
+	// ErrDuplicateNet describes an error where the parameters for a Bitcoin
+	// network could not be set due to the network already being a standard
+	// network or previously-registered into this package.
+	ErrDuplicateNet = errors.New("duplicate Bitcoin network")
+
+	// ErrUnknownHDKeyID describes an error where the provided id which
+	// is intended to identify the network for a hierarchical deterministic
+	// private extended key is not registered.
+	ErrUnknownHDKeyID = errors.New("unknown hd private extended key bytes")
+
+	// ErrUnknownPrefix describes and error where the provided prefix string
+	// isn't found associated with a parameter set / HDCoinType
+	ErrUnknownPrefix = errors.New("unknown bech32 prefix")
+)
+
+var (
+	registeredNets    = make(map[uint32]struct{})
+	bech32Prefixes    = make(map[string]uint32)
+	pubKeyHashAddrIDs = make(map[byte]struct{})
+	scriptHashAddrIDs = make(map[byte]struct{})
+	hdPrivToPubKeyIDs = make(map[[4]byte][]byte)
+)
+
+// PrefixToCoinType returns the HDCoinType for a params set given the bech32 prefix.
+// If that prefix isn't registered, it returns an error.
+func PrefixToCoinType(prefix string) (uint32, error) {
+	coinType, ok := bech32Prefixes[prefix]
+	if !ok {
+		return 0, ErrUnknownPrefix
+	}
+	return coinType, nil
+}
+
+// IsPubKeyHashAddrID returns whether the id is an identifier known to prefix a
+// pay-to-pubkey-hash address on any default or registered network.  This is
+// used when decoding an address string into a specific address type.  It is up
+// to the caller to check both this and IsScriptHashAddrID and decide whether an
+// address is a pubkey hash address, script hash address, neither, or
+// undeterminable (if both return true).
+func IsPubKeyHashAddrID(id byte) bool {
+	_, ok := pubKeyHashAddrIDs[id]
+	return ok
+}
+
+// IsScriptHashAddrID returns whether the id is an identifier known to prefix a
+// pay-to-script-hash address on any default or registered network.  This is
+// used when decoding an address string into a specific address type.  It is up
+// to the caller to check both this and IsPubKeyHashAddrID and decide whether an
+// address is a pubkey hash address, script hash address, neither, or
+// undeterminable (if both return true).
+func IsScriptHashAddrID(id byte) bool {
+	_, ok := scriptHashAddrIDs[id]
+	return ok
+}
+
+// HDPrivateKeyToPublicKeyID accepts a private hierarchical deterministic
+// extended key id and returns the associated public key id.  When the provided
+// id is not registered, the ErrUnknownHDKeyID error will be returned.
+func HDPrivateKeyToPublicKeyID(id []byte) ([]byte, error) {
+	if len(id) != 4 {
+		return nil, ErrUnknownHDKeyID
+	}
+
+	var key [4]byte
+	copy(key[:], id)
+	pubBytes, ok := hdPrivToPubKeyIDs[key]
+	if !ok {
+		return nil, ErrUnknownHDKeyID
+	}
+
+	return pubBytes, nil
+}
+
+// newHashFromStr converts the passed big-endian hex string into a
+// chainhash.Hash.  It only differs from the one available in chainhash in that
+// it panics on an error since it will only (and must only) be called with
+// hard-coded, and therefore known good, hashes.
+func newHashFromStr(hexStr string) *chainhash.Hash {
+	hash, err := chainhash.NewHashFromStr(hexStr)
+	if err != nil {
+		// Ordinarily I don't like panics in library code since it
+		// can take applications down without them having a chance to
+		// recover which is extremely annoying, however an exception is
+		// being made in this case because the only way this can panic
+		// is if there is an error in the hard-coded hashes.  Thus it
+		// will only ever potentially panic on init and therefore is
+		// 100% predictable.
+		panic(err)
+	}
+	return hash
+}

--- a/lit.go
+++ b/lit.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/adiabat/btcd/chaincfg"
+	"github.com/mit-dci/lit/coinparam"
 	"github.com/mit-dci/lit/litbamf"
 	"github.com/mit-dci/lit/litrpc"
 	"github.com/mit-dci/lit/lnutil"
@@ -40,7 +40,7 @@ type LitConfig struct {
 	rpcport    uint16
 	litHomeDir string
 
-	Params *chaincfg.Params
+	Params *coinparam.Params
 }
 
 func setConfig(lc *LitConfig) {
@@ -92,7 +92,7 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *LitConfig) error {
 	var err error
 	// try regtest
 	if conf.reghost != "" {
-		p := &chaincfg.RegressionNetParams
+		p := &coinparam.RegressionNetParams
 		if !strings.Contains(conf.reghost, ":") {
 			conf.reghost = conf.reghost + ":" + p.DefaultPort
 		}
@@ -104,7 +104,7 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *LitConfig) error {
 	}
 	// try testnet3
 	if conf.tn3host != "" {
-		p := &chaincfg.TestNet3Params
+		p := &coinparam.TestNet3Params
 		if !strings.Contains(conf.tn3host, ":") {
 			conf.tn3host = conf.tn3host + ":" + p.DefaultPort
 		}
@@ -116,7 +116,7 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *LitConfig) error {
 	}
 	// try litecoin regtest
 	if conf.litereghost != "" {
-		p := &chaincfg.LiteRegNetParams
+		p := &coinparam.LiteRegNetParams
 		if !strings.Contains(conf.litereghost, ":") {
 			conf.litereghost = conf.litereghost + ":" + p.DefaultPort
 		}
@@ -128,7 +128,7 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *LitConfig) error {
 
 	// try litecoin testnet4
 	if conf.lt4host != "" {
-		p := &chaincfg.LiteCoinTestNet4Params
+		p := &coinparam.LiteCoinTestNet4Params
 		if !strings.Contains(conf.lt4host, ":") {
 			conf.lt4host = conf.lt4host + ":" + p.DefaultPort
 		}

--- a/qln/basewallet.go
+++ b/qln/basewallet.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 
 	"github.com/adiabat/btcd/btcec"
-	"github.com/adiabat/btcd/chaincfg"
 	"github.com/adiabat/btcd/chaincfg/chainhash"
 	"github.com/adiabat/btcd/wire"
+	"github.com/mit-dci/lit/coinparam"
 	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/portxo"
 )
@@ -80,7 +80,7 @@ type UWallet interface {
 	BlockMonitor() chan *wire.MsgBlock
 
 	// Ask for network parameters
-	Params() *chaincfg.Params
+	Params() *coinparam.Params
 
 	// Get current fee rate.
 	Fee() int64

--- a/qln/init.go
+++ b/qln/init.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/adiabat/btcd/chaincfg"
 	"github.com/adiabat/btcd/wire"
 	"github.com/adiabat/btcutil/hdkeychain"
 	"github.com/boltdb/bolt"
+	"github.com/mit-dci/lit/coinparam"
 	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/portxo"
 	"github.com/mit-dci/lit/wallit"
@@ -27,7 +27,8 @@ func NewLitNode(privKey *[32]byte, path string, tower bool) (*LitNode, error) {
 	}
 
 	// Maybe make a new parameter set for "LN".. meh
-	rootPrivKey, err := hdkeychain.NewMaster(privKey[:], &chaincfg.TestNet3Params)
+	// TODO change this to a non-coin
+	rootPrivKey, err := hdkeychain.NewMaster(privKey[:], &coinparam.TestNet3Params)
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +90,7 @@ func NewLitNode(privKey *[32]byte, path string, tower bool) (*LitNode, error) {
 // LinkBaseWallet activates a wallet and hooks it into the litnode.
 func (nd *LitNode) LinkBaseWallet(
 	privKey *[32]byte, birthHeight int32, resync bool,
-	host string, param *chaincfg.Params) error {
+	host string, param *coinparam.Params) error {
 
 	rootpriv, err := hdkeychain.NewMaster(privKey[:], param)
 	if err != nil {

--- a/uspv/chainhook.go
+++ b/uspv/chainhook.go
@@ -3,9 +3,9 @@ package uspv
 import (
 	"path/filepath"
 
-	"github.com/adiabat/btcd/chaincfg"
 	"github.com/adiabat/btcd/chaincfg/chainhash"
 	"github.com/adiabat/btcd/wire"
+	"github.com/mit-dci/lit/coinparam"
 	"github.com/mit-dci/lit/lnutil"
 )
 
@@ -24,7 +24,7 @@ type ChainHook interface {
 // --- implementation of ChainHook interface ----
 
 func (s *SPVCon) Start(
-	startHeight int32, host, path string, params *chaincfg.Params) (
+	startHeight int32, host, path string, params *coinparam.Params) (
 	chan lnutil.TxAndHeight, chan int32, error) {
 
 	// These can be set before calling Start()

--- a/uspv/header.go
+++ b/uspv/header.go
@@ -13,13 +13,13 @@ import (
 	"time"
 
 	"github.com/adiabat/btcd/blockchain"
-	"github.com/adiabat/btcd/chaincfg"
 	"github.com/adiabat/btcd/chaincfg/chainhash"
 	"github.com/adiabat/btcd/wire"
+	"github.com/mit-dci/lit/coinparam"
 )
 
 // blockchain settings.  These are kindof bitcoin specific, but not contained in
-// chaincfg.Params so they'll go here.  If you're into the [ANN]altcoin scene,
+// coinparam.Params so they'll go here.  If you're into the [ANN]altcoin scene,
 // you may want to paramaterize these constants.
 const (
 	targetTimespanx = time.Hour * 24 * 14
@@ -33,7 +33,7 @@ const (
 
 /* checkProofOfWork verifies the header hashes into something
 lower than specified by the 4-byte bits field. */
-func checkProofOfWork(header wire.BlockHeader, p *chaincfg.Params) bool {
+func checkProofOfWork(header wire.BlockHeader, p *coinparam.Params) bool {
 
 	target := blockchain.CompactToBig(header.Bits)
 
@@ -75,7 +75,7 @@ true if the correct dificulty adjustment is seen in the "next" header.
 Only feed it headers n-2016 and n-1, otherwise it will calculate a difficulty
 when no adjustment should take place, and return false.
 Note that the epoch is actually 2015 blocks long, which is confusing. */
-func calcDiffAdjust(start, end wire.BlockHeader, p *chaincfg.Params) uint32 {
+func calcDiffAdjust(start, end wire.BlockHeader, p *coinparam.Params) uint32 {
 
 	minRetargetTimespan := int64(p.TargetTimespan.Seconds()) / p.RetargetAdjustmentFactor
 	maxRetargetTimespan := int64(p.TargetTimespan.Seconds()) * p.RetargetAdjustmentFactor
@@ -107,7 +107,7 @@ func calcDiffAdjust(start, end wire.BlockHeader, p *chaincfg.Params) uint32 {
 	return blockchain.BigToCompact(newTarget)
 }
 
-func CheckHeader(r io.ReadSeeker, height, startheight int32, p *chaincfg.Params) bool {
+func CheckHeader(r io.ReadSeeker, height, startheight int32, p *coinparam.Params) bool {
 	// startHeight is the height the file starts at
 	// header start must be 0 mod 2106
 	epochLength := int32(p.TargetTimespan / p.TargetTimePerBlock)
@@ -206,7 +206,7 @@ difficulty adjustments, and that they all link in to each other properly.
 This is the only blockchain technology in the whole code base.
 Returns false if anything bad happens.  Returns true if the range checks
 out with no errors. */
-func CheckRange(r io.ReadSeeker, first, last, startHeight int32, p *chaincfg.Params) bool {
+func CheckRange(r io.ReadSeeker, first, last, startHeight int32, p *coinparam.Params) bool {
 	for i := first; i <= last; i++ {
 		if !CheckHeader(r, i, startHeight, p) {
 			return false

--- a/uspv/init.go
+++ b/uspv/init.go
@@ -35,7 +35,7 @@ func (s *SPVCon) Connect(remoteNode string) error {
 	myMsgVer.AddService(wire.SFNodeWitness)
 	// this actually sends
 	n, err := wire.WriteMessageWithEncodingN(
-		s.con, myMsgVer, s.localVersion, s.Param.Net, wire.LatestEncoding)
+		s.con, myMsgVer, s.localVersion, wire.BitcoinNet(s.Param.NetMagicBytes), wire.LatestEncoding)
 	if err != nil {
 		return err
 	}
@@ -43,7 +43,7 @@ func (s *SPVCon) Connect(remoteNode string) error {
 	log.Printf("wrote %d byte version message to %s\n",
 		n, s.con.RemoteAddr().String())
 	n, m, b, err := wire.ReadMessageWithEncodingN(
-		s.con, s.localVersion, s.Param.Net, wire.LatestEncoding)
+		s.con, s.localVersion, wire.BitcoinNet(s.Param.NetMagicBytes), wire.LatestEncoding)
 	if err != nil {
 		return err
 	}
@@ -61,7 +61,7 @@ func (s *SPVCon) Connect(remoteNode string) error {
 	s.remoteHeight = mv.LastBlock
 	mva := wire.NewMsgVerAck()
 	n, err = wire.WriteMessageWithEncodingN(
-		s.con, mva, s.localVersion, s.Param.Net, wire.LatestEncoding)
+		s.con, mva, s.localVersion, wire.BitcoinNet(s.Param.NetMagicBytes), wire.LatestEncoding)
 	if err != nil {
 		return err
 	}

--- a/uspv/msghandler.go
+++ b/uspv/msghandler.go
@@ -10,8 +10,8 @@ import (
 
 func (s *SPVCon) incomingMessageHandler() {
 	for {
-		n, xm, _, err := wire.ReadMessageWithEncodingN(
-			s.con, s.localVersion, s.Param.Net, wire.LatestEncoding)
+		n, xm, _, err := wire.ReadMessageWithEncodingN(s.con, s.localVersion,
+			wire.BitcoinNet(s.Param.NetMagicBytes), wire.LatestEncoding)
 		if err != nil {
 			log.Printf("ReadMessageWithEncodingN error.  Disconnecting: %s\n", err.Error())
 			return
@@ -65,7 +65,9 @@ func (s *SPVCon) incomingMessageHandler() {
 func (s *SPVCon) outgoingMessageHandler() {
 	for {
 		msg := <-s.outMsgQueue
-		n, err := wire.WriteMessageWithEncodingN(s.con, msg, s.localVersion, s.Param.Net, wire.LatestEncoding)
+		n, err := wire.WriteMessageWithEncodingN(s.con, msg, s.localVersion,
+			wire.BitcoinNet(s.Param.NetMagicBytes), wire.LatestEncoding)
+
 		if err != nil {
 			log.Printf("Write message error: %s", err.Error())
 		}

--- a/uspv/spvcon.go
+++ b/uspv/spvcon.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"sync"
 
-	"github.com/adiabat/btcd/chaincfg"
 	"github.com/adiabat/btcd/chaincfg/chainhash"
 	"github.com/adiabat/btcd/wire"
+	"github.com/mit-dci/lit/coinparam"
 	"github.com/mit-dci/lit/lnutil"
 )
 
@@ -52,7 +52,7 @@ type SPVCon struct {
 	WBytes uint64 // total bytes written
 	RBytes uint64 // total bytes read
 
-	Param *chaincfg.Params // network parameters (testnet3, segnet, etc)
+	Param *coinparam.Params // network parameters (testnet3, segnet, etc)
 
 	// TxUpToWallit is the channel for sending txs up a level to the wallit.
 	TxUpToWallit chan lnutil.TxAndHeight

--- a/wallit/basewalletif.go
+++ b/wallit/basewalletif.go
@@ -5,9 +5,9 @@ import (
 	"sort"
 
 	"github.com/adiabat/btcd/btcec"
-	"github.com/adiabat/btcd/chaincfg"
 	"github.com/adiabat/btcd/chaincfg/chainhash"
 	"github.com/adiabat/btcd/wire"
+	"github.com/mit-dci/lit/coinparam"
 	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/portxo"
 )
@@ -45,7 +45,7 @@ func (w *Wallit) PushTx(tx *wire.MsgTx) error {
 	return w.Hook.PushTx(tx)
 }
 
-func (w *Wallit) Params() *chaincfg.Params {
+func (w *Wallit) Params() *coinparam.Params {
 	return w.Param
 }
 

--- a/wallit/chainhook.go
+++ b/wallit/chainhook.go
@@ -1,8 +1,8 @@
 package wallit
 
 import (
-	"github.com/adiabat/btcd/chaincfg"
 	"github.com/adiabat/btcd/wire"
+	"github.com/mit-dci/lit/coinparam"
 	"github.com/mit-dci/lit/lnutil"
 )
 
@@ -27,7 +27,7 @@ type ChainHook interface {
 	// ChainHook layer; wallit should not have to handle ingesting irrelevant txs.
 	// You get back an error and 2 channels: one for txs with height attached, and
 	// one with block heights.  Subject to change; maybe this is redundant.
-	Start(height int32, host, path string, params *chaincfg.Params) (
+	Start(height int32, host, path string, params *coinparam.Params) (
 		chan lnutil.TxAndHeight, chan int32, error)
 
 	// The Register functions send information to the ChainHook about what txs to

--- a/wallit/init.go
+++ b/wallit/init.go
@@ -5,17 +5,17 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/adiabat/btcd/chaincfg"
 	"github.com/adiabat/btcd/wire"
 	"github.com/adiabat/btcutil/hdkeychain"
 	"github.com/boltdb/bolt"
+	"github.com/mit-dci/lit/coinparam"
 	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/uspv"
 )
 
 func NewWallit(
 	rootkey *hdkeychain.ExtendedKey, birthHeight int32, resync bool,
-	spvhost, path string, p *chaincfg.Params) *Wallit {
+	spvhost, path string, p *coinparam.Params) *Wallit {
 
 	var w Wallit
 	w.rootPrivKey = rootkey

--- a/wallit/wallit.go
+++ b/wallit/wallit.go
@@ -8,12 +8,12 @@ import (
 	"sync"
 
 	"github.com/adiabat/btcd/blockchain"
-	"github.com/adiabat/btcd/chaincfg"
 	"github.com/adiabat/btcd/chaincfg/chainhash"
 	"github.com/adiabat/btcd/wire"
 	"github.com/adiabat/btcutil"
 	"github.com/adiabat/btcutil/hdkeychain"
 	"github.com/boltdb/bolt"
+	"github.com/mit-dci/lit/coinparam"
 	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/portxo"
 )
@@ -33,7 +33,7 @@ type Wallit struct {
 	OPEventChan chan lnutil.OutPointEvent
 
 	// Params live here...
-	Param *chaincfg.Params // network parameters (testnet3, segnet, etc)
+	Param *coinparam.Params // network parameters (testnet3, segnet, etc)
 
 	// Hook is the connection to a blockchain.
 	Hook ChainHook


### PR DESCRIPTION
We've extended a fork of the btcsuite package, but it's getting hard to manage.
This brings the coin parameter libraries into lit.  It's organized so that adding a new coin will just be one .go file for everything (network bytes, params, genesis info)

Also can't use btcutil address structs, but had nearly stopped using those anyway.