### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ go build
 (Note : Windows users can take off ./ but may need to change lit to lit.exe in the second line.) 
 ```
 cd GOPATH/src/github.com/mit-dci/lit 
-./lit -spv my.testnet.node.tld
+./lit -tn3 my.testnet.node.tld
 ```
 
 ## Using Lightning


### PR DESCRIPTION
-spv flag looks not anymore available, I suppose tn3 is the appropriate
`flag provided but not defined: -spv`