### PR TITLE
Add the packaging metadata to build the lit snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,26 @@
+name: lit
+version: master
+summary: Lightning Network node software
+description: |
+  Under development, not for use with real money.
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: strict
+
+apps:
+  lit:
+    command: lit
+    plugs: [network, network-bind]
+  af:
+    command: lit-af
+    plugs: [network, network-bind]
+    aliases: [lit-af]
+
+parts:
+  lit:
+    source: .
+    plugin: go
+    go-importpath: github.com/mit-dci/lit
+    after: [go]
+  go:
+    source-tag: go1.8.3


### PR DESCRIPTION
This package will let you publish the latest lit in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and more Linux distributions in progress. You just have to go to https://build.snapcraft.io and enable the automated continuous delivery.