### PR TITLE
Update uspv and wallit to recognize chain reorgs

### DIFF
--- a/coinparam/bc2.go
+++ b/coinparam/bc2.go
@@ -18,7 +18,7 @@ var BC2NetParams = Params{
 	GenesisBlock:             &bc2GenesisBlock,
 	GenesisHash:              &bc2GenesisHash,
 	PoWFunction:              chainhash.DoubleHashH,
-	DiffCalcFunction:         diffBTC,
+	DiffCalcFunction:         diffBitcoin,
 	FeePerByte:               80,
 	PowLimit:                 bc2NetPowLimit,
 	PowLimitBits:             0x1d7fffff,

--- a/coinparam/bc2.go
+++ b/coinparam/bc2.go
@@ -1,7 +1,6 @@
 package coinparam
 
 import (
-	"io"
 	"time"
 
 	"github.com/adiabat/btcd/chaincfg/chainhash"
@@ -16,12 +15,10 @@ var BC2NetParams = Params{
 	DNSSeeds:      []string{},
 
 	// Chain parameters
-	GenesisBlock: &bc2GenesisBlock,
-	GenesisHash:  &bc2GenesisHash,
-	PoWFunction:  chainhash.DoubleHashH,
-	DiffCalcFunction: func(r io.ReadSeeker, height, startheight int32, p *Params) (uint32, error) {
-		return diffBTC(r, height, startheight, p, false)
-	},
+	GenesisBlock:             &bc2GenesisBlock,
+	GenesisHash:              &bc2GenesisHash,
+	PoWFunction:              chainhash.DoubleHashH,
+	DiffCalcFunction:         diffBTC,
 	FeePerByte:               80,
 	PowLimit:                 bc2NetPowLimit,
 	PowLimitBits:             0x1d7fffff,

--- a/coinparam/bitcoin.go
+++ b/coinparam/bitcoin.go
@@ -26,7 +26,7 @@ var BitcoinParams = Params{
 	GenesisBlock:             &genesisBlock,
 	GenesisHash:              &genesisHash,
 	PoWFunction:              chainhash.DoubleHashH,
-	DiffCalcFunction:         diffBTC,
+	DiffCalcFunction:         diffBitcoin,
 	FeePerByte:               80,
 	PowLimit:                 mainPowLimit,
 	PowLimitBits:             0x1d00ffff,
@@ -105,7 +105,7 @@ var TestNet3Params = Params{
 	GenesisBlock:     &testNet3GenesisBlock,
 	GenesisHash:      &testNet3GenesisHash,
 	PoWFunction:      chainhash.DoubleHashH,
-	DiffCalcFunction: diffBTC,
+	DiffCalcFunction: diffBitcoin,
 	StartHeader: [80]byte{
 		0x00, 0x00, 0x00, 0x20, 0xda, 0x33, 0x92, 0x5b, 0x1f, 0x7a, 0x55,
 		0xe9, 0xfa, 0x8e, 0x6c, 0x95, 0x5a, 0x20, 0xea, 0x09, 0x41, 0x48,
@@ -176,7 +176,7 @@ var RegressionNetParams = Params{
 	GenesisBlock:     &regTestGenesisBlock,
 	GenesisHash:      &regTestGenesisHash,
 	PoWFunction:      chainhash.DoubleHashH,
-	DiffCalcFunction: diffBTC,
+	DiffCalcFunction: diffBitcoin,
 	//	func(r io.ReadSeeker, height, startheight int32, p *Params) (uint32, error) {
 	//		return diffBTC(r, height, startheight, p, false)
 	//	},

--- a/coinparam/bitcoin.go
+++ b/coinparam/bitcoin.go
@@ -1,7 +1,6 @@
 package coinparam
 
 import (
-	"io"
 	"time"
 
 	"github.com/adiabat/btcd/chaincfg/chainhash"
@@ -24,12 +23,10 @@ var BitcoinParams = Params{
 	},
 
 	// Chain parameters
-	GenesisBlock: &genesisBlock,
-	GenesisHash:  &genesisHash,
-	PoWFunction:  chainhash.DoubleHashH,
-	DiffCalcFunction: func(r io.ReadSeeker, height, startheight int32, p *Params) (uint32, error) {
-		return diffBTC(r, height, startheight, p, false)
-	},
+	GenesisBlock:             &genesisBlock,
+	GenesisHash:              &genesisHash,
+	PoWFunction:              chainhash.DoubleHashH,
+	DiffCalcFunction:         diffBTC,
 	FeePerByte:               80,
 	PowLimit:                 mainPowLimit,
 	PowLimitBits:             0x1d00ffff,
@@ -105,12 +102,10 @@ var TestNet3Params = Params{
 	},
 
 	// Chain parameters
-	GenesisBlock: &testNet3GenesisBlock,
-	GenesisHash:  &testNet3GenesisHash,
-	PoWFunction:  chainhash.DoubleHashH,
-	DiffCalcFunction: func(r io.ReadSeeker, height, startheight int32, p *Params) (uint32, error) {
-		return diffBTC(r, height, startheight, p, false)
-	},
+	GenesisBlock:     &testNet3GenesisBlock,
+	GenesisHash:      &testNet3GenesisHash,
+	PoWFunction:      chainhash.DoubleHashH,
+	DiffCalcFunction: diffBTC,
 	StartHeader: [80]byte{
 		0x00, 0x00, 0x00, 0x20, 0xda, 0x33, 0x92, 0x5b, 0x1f, 0x7a, 0x55,
 		0xe9, 0xfa, 0x8e, 0x6c, 0x95, 0x5a, 0x20, 0xea, 0x09, 0x41, 0x48,
@@ -178,12 +173,13 @@ var RegressionNetParams = Params{
 	DNSSeeds:      []string{},
 
 	// Chain parameters
-	GenesisBlock: &regTestGenesisBlock,
-	GenesisHash:  &regTestGenesisHash,
-	PoWFunction:  chainhash.DoubleHashH,
-	DiffCalcFunction: func(r io.ReadSeeker, height, startheight int32, p *Params) (uint32, error) {
-		return diffBTC(r, height, startheight, p, false)
-	},
+	GenesisBlock:     &regTestGenesisBlock,
+	GenesisHash:      &regTestGenesisHash,
+	PoWFunction:      chainhash.DoubleHashH,
+	DiffCalcFunction: diffBTC,
+	//	func(r io.ReadSeeker, height, startheight int32, p *Params) (uint32, error) {
+	//		return diffBTC(r, height, startheight, p, false)
+	//	},
 	FeePerByte:               80,
 	PowLimit:                 regressionPowLimit,
 	PowLimitBits:             0x207fffff,

--- a/coinparam/difficulty.go
+++ b/coinparam/difficulty.go
@@ -1,13 +1,14 @@
 package coinparam
 
 import (
-    "io"
-    "math/big"
-    "math"
-    "os"
-    "log"
+	"fmt"
+	"io"
+	"log"
+	"math"
+	"math/big"
+	"os"
 
-    "github.com/adiabat/btcd/wire"
+	"github.com/adiabat/btcd/wire"
 )
 
 /* calcDiff returns a bool given two block headers.  This bool is
@@ -15,7 +16,7 @@ true if the correct dificulty adjustment is seen in the "next" header.
 Only feed it headers n-2016 and n-1, otherwise it will calculate a difficulty
 when no adjustment should take place, and return false.
 Note that the epoch is actually 2015 blocks long, which is confusing. */
-func calcDiffAdjustBitcoin(start, end wire.BlockHeader, p *Params) uint32 {
+func calcDiffAdjustBitcoin(start, end *wire.BlockHeader, p *Params) uint32 {
 	minRetargetTimespan := int64(p.TargetTimespan.Seconds()) / p.RetargetAdjustmentFactor
 	maxRetargetTimespan := int64(p.TargetTimespan.Seconds()) * p.RetargetAdjustmentFactor
 	duration := end.Timestamp.Unix() - start.Timestamp.Unix()
@@ -42,18 +43,61 @@ func calcDiffAdjustBitcoin(start, end wire.BlockHeader, p *Params) uint32 {
 	return BigToCompact(newTarget)
 }
 
-func diffBTC(r io.ReadSeeker, height, startheight int32, p *Params, ltc bool) (uint32, error) {
-    epochLength := int32(p.TargetTimespan / p.TargetTimePerBlock)
+// diffBitcoin finds the difficulty of the next header after the slice presented
+// needs at least 1 epochlength of headers
+func diffBitcoin(
+	headers []*wire.BlockHeader, height int32, p *Params) (uint32, error) {
+
+	ltcmode := p.Name == "litetest4" || p.Name == "litereg" ||
+		p.Name == "litecoin" || p.Name == "vtctest" || p.Name == "vtc"
+
+	epochLength := int32(p.TargetTimespan / p.TargetTimePerBlock)
+
+	if len(headers) < int(epochLength) {
+		return 0, fmt.Errorf(
+			"diffBitcoin not enough headers, got %d, need %d",
+			len(headers), epochLength)
+	}
+
+	prev := headers[len(headers)-1]
+
+	// normal, no adjustment; Dn = Dn-1
+	rightBits := prev.Bits
+
+	// see if we're on a difficulty adjustment block
+	if (height)%epochLength == 0 {
+		epochStart := new(wire.BlockHeader)
+		if ltcmode {
+			if height == epochLength {
+				epochStart = headers[height-epochLength]
+			} else {
+				epochStart = headers[height-epochLength-1]
+			}
+		} else {
+			epochStart = headers[height-epochLength]
+		}
+		// if so, check if difficulty adjustment is valid.
+		// That whole "controlled supply" thing.
+		// calculate diff n based on n-2016 ... n-1
+		rightBits = calcDiffAdjustBitcoin(epochStart, prev, p)
+	}
+
+	return rightBits, nil
+}
+
+func diffBTC(r io.ReadSeeker, height, startheight int32, p *Params) (uint32, error) {
+	epochLength := int32(p.TargetTimespan / p.TargetTimePerBlock)
 	var err error
 	var cur, prev wire.BlockHeader
-  
-    offsetHeight := height - startheight
+	ltcmode := p.Name == "litetest4" || p.Name == "litereg" ||
+		p.Name == "litecoin" || p.Name == "vtctest" || p.Name == "vtc"
+	offsetHeight := height - startheight
 	// seek to n-1 header
 	_, err = r.Seek(int64(80*(offsetHeight-1)), os.SEEK_SET)
 	if err != nil {
 		log.Printf(err.Error())
 		return 0, err
-	}  
+	}
 	// read in n-1
 	err = prev.Deserialize(r)
 	if err != nil {
@@ -71,192 +115,199 @@ func diffBTC(r io.ReadSeeker, height, startheight int32, p *Params, ltc bool) (u
 		log.Printf(err.Error())
 		return 0, err
 	}
-  
-    rightBits := prev.Bits // normal, no adjustment; Dn = Dn-1
+
+	rightBits := prev.Bits // normal, no adjustment; Dn = Dn-1
 	// see if we're on a difficulty adjustment block
 	if (height)%epochLength == 0 {
-        var epochStart wire.BlockHeader
-        if ltc {
-          if height == epochLength {
-            _, err = r.Seek(int64(80*(offsetHeight-epochLength)), os.SEEK_SET)
-          } else {
-            _, err = r.Seek(int64(80*(offsetHeight-epochLength-1)), os.SEEK_SET)
-          }
-        } else {
-          _, err = r.Seek(int64(80*(offsetHeight-epochLength)), os.SEEK_SET)
-        }
-        if err != nil {
-          log.Printf(err.Error())
-          return 0, err
-        }
-        err = epochStart.Deserialize(r)
-        if err != nil {
-          log.Printf(err.Error())
-          return 0, err
-        }
+		var epochStart wire.BlockHeader
+		if ltcmode {
+			if height == epochLength {
+				_, err = r.Seek(int64(80*(offsetHeight-epochLength)), os.SEEK_SET)
+			} else {
+				_, err = r.Seek(int64(80*(offsetHeight-epochLength-1)), os.SEEK_SET)
+			}
+		} else {
+			_, err = r.Seek(int64(80*(offsetHeight-epochLength)), os.SEEK_SET)
+		}
+		if err != nil {
+			log.Printf(err.Error())
+			return 0, err
+		}
+		err = epochStart.Deserialize(r)
+		if err != nil {
+			log.Printf(err.Error())
+			return 0, err
+		}
 		// if so, check if difficulty adjustment is valid.
 		// That whole "controlled supply" thing.
 		// calculate diff n based on n-2016 ... n-1
-		rightBits = calcDiffAdjustBitcoin(epochStart, prev, p)
+		rightBits = calcDiffAdjustBitcoin(&epochStart, &prev, p)
 	} else if p.ReduceMinDifficulty { // not a new epoch
 		// if on testnet, check for difficulty nerfing
 		if cur.Timestamp.After(
-			prev.Timestamp.Add(p.TargetTimePerBlock*2)) {
+			prev.Timestamp.Add(p.TargetTimePerBlock * 2)) {
 			rightBits = p.PowLimitBits // difficulty 1
 		} else {
-		    var epochStart wire.BlockHeader
-            _, err = r.Seek(int64(80*(offsetHeight-(offsetHeight%epochLength))), os.SEEK_SET)
-            if err != nil {
-              log.Printf(err.Error())
-              return 0, err
-            }
-            err = epochStart.Deserialize(r)
-            if err != nil {
-              log.Printf(err.Error())
-              return 0, err
-            }
-          
-            rightBits = epochStart.Bits
-        }
-    }
-  
-    return rightBits, nil
+			var epochStart wire.BlockHeader
+			_, err = r.Seek(int64(80*(offsetHeight-(offsetHeight%epochLength))), os.SEEK_SET)
+			if err != nil {
+				log.Printf(err.Error())
+				return 0, err
+			}
+			err = epochStart.Deserialize(r)
+			if err != nil {
+				log.Printf(err.Error())
+				return 0, err
+			}
+
+			rightBits = epochStart.Bits
+		}
+	}
+
+	return rightBits, nil
 }
 
 // Uses Kimoto Gravity Well for difficulty adjustment. Used in VTC, MONA etc
 func calcDiffAdjustKGW(r io.ReadSeeker, height, startheight int32, p *Params) (uint32, error) {
-    var minBlocks, maxBlocks int32
-    minBlocks = 144
-    maxBlocks = 4032
+	var minBlocks, maxBlocks int32
+	minBlocks = 144
+	maxBlocks = 4032
 
-    if height - 1 < minBlocks {
-    return p.PowLimitBits, nil
-    }
+	if height-1 < minBlocks {
+		return p.PowLimitBits, nil
+	}
 
-    offsetHeight := height - startheight - 1
+	offsetHeight := height - startheight - 1
 
-    var currentBlock wire.BlockHeader
-    var err error
+	var currentBlock wire.BlockHeader
+	var err error
 
-    // seek to n-1 header
-    _, err = r.Seek(int64(80*offsetHeight), os.SEEK_SET)
-    if err != nil {
-    return 0, err
-    }
-    // read in n-1
-    err = currentBlock.Deserialize(r)
-    if err != nil {
-    return 0, err
-    }
+	// seek to n-1 header
+	_, err = r.Seek(int64(80*offsetHeight), os.SEEK_SET)
+	if err != nil {
+		return 0, err
+	}
+	// read in n-1
+	err = currentBlock.Deserialize(r)
+	if err != nil {
+		return 0, err
+	}
 
-    lastSolved := currentBlock
+	lastSolved := currentBlock
 
-    var blocksScanned, actualRate, targetRate int64
-    var difficultyAverage, previousDifficultyAverage big.Int
-    var rateAdjustmentRatio, eventHorizonDeviation, eventHorizonDeviationFast, eventHorizonDevationSlow float64
-    rateAdjustmentRatio = 1
+	var blocksScanned, actualRate, targetRate int64
+	var difficultyAverage, previousDifficultyAverage big.Int
+	var rateAdjustmentRatio, eventHorizonDeviation, eventHorizonDeviationFast, eventHorizonDevationSlow float64
+	rateAdjustmentRatio = 1
 
-    currentHeight := height - 1
+	currentHeight := height - 1
 
-    var i int32
+	var i int32
 
-    for i = 1; currentHeight > 0; i++ {
-        if i > maxBlocks {
-            break
-        }
+	for i = 1; currentHeight > 0; i++ {
+		if i > maxBlocks {
+			break
+		}
 
-        blocksScanned++
+		blocksScanned++
 
-        if i == 1 {
-            difficultyAverage = *CompactToBig(currentBlock.Bits)
-        } else {
-            compact := CompactToBig(currentBlock.Bits)
-          
-            difference  := new(big.Int).Sub(compact, &previousDifficultyAverage)
-            difference.Div(difference, big.NewInt(int64(i)))
-            difference.Add(difference, &previousDifficultyAverage)
-            difficultyAverage = *difference
-        }
+		if i == 1 {
+			difficultyAverage = *CompactToBig(currentBlock.Bits)
+		} else {
+			compact := CompactToBig(currentBlock.Bits)
 
-        previousDifficultyAverage = difficultyAverage
+			difference := new(big.Int).Sub(compact, &previousDifficultyAverage)
+			difference.Div(difference, big.NewInt(int64(i)))
+			difference.Add(difference, &previousDifficultyAverage)
+			difficultyAverage = *difference
+		}
 
-        actualRate = lastSolved.Timestamp.Unix() - currentBlock.Timestamp.Unix()
-        targetRate = int64(p.TargetTimePerBlock.Seconds()) * blocksScanned
-        rateAdjustmentRatio = 1
+		previousDifficultyAverage = difficultyAverage
 
-        if actualRate < 0 {
-            actualRate = 0
-        }
+		actualRate = lastSolved.Timestamp.Unix() - currentBlock.Timestamp.Unix()
+		targetRate = int64(p.TargetTimePerBlock.Seconds()) * blocksScanned
+		rateAdjustmentRatio = 1
 
-        if actualRate != 0 && targetRate != 0 {
-            rateAdjustmentRatio = float64(targetRate) / float64(actualRate)
-        }
+		if actualRate < 0 {
+			actualRate = 0
+		}
 
-        eventHorizonDeviation = 1 + (0.7084 * math.Pow(float64(blocksScanned)/float64(minBlocks), -1.228))
-        eventHorizonDeviationFast = eventHorizonDeviation
-        eventHorizonDevationSlow = 1 / eventHorizonDeviation
+		if actualRate != 0 && targetRate != 0 {
+			rateAdjustmentRatio = float64(targetRate) / float64(actualRate)
+		}
 
-        if blocksScanned >= int64(minBlocks) && (rateAdjustmentRatio <= eventHorizonDevationSlow || rateAdjustmentRatio >= eventHorizonDeviationFast) {
-            break
-        }
+		eventHorizonDeviation = 1 + (0.7084 * math.Pow(float64(blocksScanned)/float64(minBlocks), -1.228))
+		eventHorizonDeviationFast = eventHorizonDeviation
+		eventHorizonDevationSlow = 1 / eventHorizonDeviation
 
-        if currentHeight <= 1 {
-            break
-        }
+		if blocksScanned >= int64(minBlocks) && (rateAdjustmentRatio <= eventHorizonDevationSlow || rateAdjustmentRatio >= eventHorizonDeviationFast) {
+			break
+		}
 
-        currentHeight--
+		if currentHeight <= 1 {
+			break
+		}
 
-        _, err = r.Seek(int64(80*(currentHeight - startheight)), os.SEEK_SET)
-        if err != nil {
-            return 0, err
-        }
-        // read in n-1
-        err = currentBlock.Deserialize(r)
-        if err != nil {
-            return 0, err
-        }
-    }
+		currentHeight--
 
-    newTarget := difficultyAverage
-    if actualRate != 0 && targetRate != 0 {
-        newTarget.Mul(&newTarget, big.NewInt(actualRate))
+		_, err = r.Seek(int64(80*(currentHeight-startheight)), os.SEEK_SET)
+		if err != nil {
+			return 0, err
+		}
+		// read in n-1
+		err = currentBlock.Deserialize(r)
+		if err != nil {
+			return 0, err
+		}
+	}
 
-        newTarget.Div(&newTarget, big.NewInt(targetRate))
-    }
+	newTarget := difficultyAverage
+	if actualRate != 0 && targetRate != 0 {
+		newTarget.Mul(&newTarget, big.NewInt(actualRate))
 
-    if newTarget.Cmp(p.PowLimit) == 1 {
-        newTarget = *p.PowLimit
-    }
+		newTarget.Div(&newTarget, big.NewInt(targetRate))
+	}
 
-    return BigToCompact(&newTarget), nil
+	if newTarget.Cmp(p.PowLimit) == 1 {
+		newTarget = *p.PowLimit
+	}
+
+	return BigToCompact(&newTarget), nil
+}
+
+// dummy function for VTC diff calc
+// TODO
+func diffVTCdummy(
+	headers []*wire.BlockHeader, height int32, p *Params) (uint32, error) {
+	return 0, nil
 }
 
 func diffVTCtest(r io.ReadSeeker, height, startheight int32, p *Params) (uint32, error) {
-  if height < 2116 {
-      return diffBTC(r, height, startheight, p, true)
-  }
-  
-  offsetHeight := height - startheight
-  
-  // Testnet retargets only every 12 blocks
-  if height % 12 != 0 {
-      var prev wire.BlockHeader
-      var err error
-  
-      // seek to n-1 header
-      _, err = r.Seek(int64(80*(offsetHeight-1)), os.SEEK_SET)
-      if err != nil {
-        return 0, err
-      }
-      // read in n-1
-      err = prev.Deserialize(r)
-      if err != nil {
-        return 0, err
-      }
-      
-      return prev.Bits, nil
-  }
-  
-  // Run KGW
-  return calcDiffAdjustKGW(r, height, startheight, p)
+	if height < 2116 {
+		return diffBTC(r, height, startheight, p)
+	}
+
+	offsetHeight := height - startheight
+
+	// Testnet retargets only every 12 blocks
+	if height%12 != 0 {
+		var prev wire.BlockHeader
+		var err error
+
+		// seek to n-1 header
+		_, err = r.Seek(int64(80*(offsetHeight-1)), os.SEEK_SET)
+		if err != nil {
+			return 0, err
+		}
+		// read in n-1
+		err = prev.Deserialize(r)
+		if err != nil {
+			return 0, err
+		}
+
+		return prev.Bits, nil
+	}
+
+	// Run KGW
+	return calcDiffAdjustKGW(r, height, startheight, p)
 }

--- a/coinparam/litecoin.go
+++ b/coinparam/litecoin.go
@@ -28,7 +28,7 @@ var LiteCoinTestNet4Params = Params{
 		asChainHash, _ := chainhash.NewHash(scryptBytes)
 		return *asChainHash
 	},
-	DiffCalcFunction: diffBTC,
+	DiffCalcFunction: diffBitcoin,
 	StartHeader: [80]byte{
 		0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -98,7 +98,7 @@ var LiteRegNetParams = Params{
 		asChainHash, _ := chainhash.NewHash(scryptBytes)
 		return *asChainHash
 	},
-	DiffCalcFunction:         diffBTC,
+	DiffCalcFunction:         diffBitcoin,
 	FeePerByte:               800,
 	PowLimit:                 regressionPowLimit,
 	PowLimitBits:             0x207fffff,

--- a/coinparam/litecoin.go
+++ b/coinparam/litecoin.go
@@ -2,11 +2,10 @@ package coinparam
 
 import (
 	"time"
-	"io"
 
 	"github.com/adiabat/btcd/chaincfg/chainhash"
 	"github.com/adiabat/btcd/wire"
-	
+
 	"golang.org/x/crypto/scrypt"
 )
 
@@ -22,28 +21,26 @@ var LiteCoinTestNet4Params = Params{
 	},
 
 	// Chain parameters
-	GenesisBlock:             &bc2GenesisBlock, // no it's not
-	GenesisHash:              &liteCoinTestNet4GenesisHash,
-	PoWFunction:              func(b []byte) chainhash.Hash {
-                                  scryptBytes, _ := scrypt.Key(b, b, 1024, 1, 1, 32)
-                                  asChainHash, _ := chainhash.NewHash(scryptBytes)
-                                  return *asChainHash
-                              },
-    DiffCalcFunction:         func(r io.ReadSeeker, height, startheight int32, p *Params) (uint32, error) {
-                                  return diffBTC(r, height, startheight, p, true)
-                              },
-    StartHeader:              [80]byte{
-                                    0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
-                                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
-                                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
-                                    0xd9, 0xce, 0xd4, 0xed, 0x11, 0x30, 0xf7, 0xb7, 0xfa, 0xad, 0x9b, 0xe2, 
-                                    0x53, 0x23, 0xff, 0xaf, 0xa3, 0x32, 0x32, 0xa1, 0x7c, 0x3e, 0xdf, 0x6c, 
-                                    0xfd, 0x97, 0xbe, 0xe6, 0xba, 0xfb, 0xdd, 0x97, 0xf6, 0x0b, 0xa1, 0x58, 
-                                    0xf0, 0xff, 0x0f, 0x1e, 0xe1, 0x79, 0x04, 0x00,
-                              },
-    StartHeight:              48384,
-    AssumeDiffBefore:         50401,
-    FeePerByte:               800,
+	GenesisBlock: &bc2GenesisBlock, // no it's not
+	GenesisHash:  &liteCoinTestNet4GenesisHash,
+	PoWFunction: func(b []byte) chainhash.Hash {
+		scryptBytes, _ := scrypt.Key(b, b, 1024, 1, 1, 32)
+		asChainHash, _ := chainhash.NewHash(scryptBytes)
+		return *asChainHash
+	},
+	DiffCalcFunction: diffBTC,
+	StartHeader: [80]byte{
+		0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0xd9, 0xce, 0xd4, 0xed, 0x11, 0x30, 0xf7, 0xb7, 0xfa, 0xad, 0x9b, 0xe2,
+		0x53, 0x23, 0xff, 0xaf, 0xa3, 0x32, 0x32, 0xa1, 0x7c, 0x3e, 0xdf, 0x6c,
+		0xfd, 0x97, 0xbe, 0xe6, 0xba, 0xfb, 0xdd, 0x97, 0xf6, 0x0b, 0xa1, 0x58,
+		0xf0, 0xff, 0x0f, 0x1e, 0xe1, 0x79, 0x04, 0x00,
+	},
+	StartHeight:              48384,
+	AssumeDiffBefore:         50401,
+	FeePerByte:               800,
 	PowLimit:                 liteCoinTestNet4PowLimit,
 	PowLimitBits:             0x1e0fffff,
 	CoinbaseMaturity:         100,
@@ -94,17 +91,15 @@ var LiteRegNetParams = Params{
 	DNSSeeds:      []string{},
 
 	// Chain parameters
-	GenesisBlock:             &liteCoinRegTestGenesisBlock, // no it's not
-	GenesisHash:              &liteCoinRegTestGenesisHash,
-	PoWFunction:              func(b []byte) chainhash.Hash {
-                                  scryptBytes, _ := scrypt.Key(b, b, 1024, 1, 1, 32)
-                                  asChainHash, _ := chainhash.NewHash(scryptBytes)
-                                  return *asChainHash
-                              },
-    DiffCalcFunction:         func(r io.ReadSeeker, height, startheight int32, p *Params) (uint32, error) {
-                                  return diffBTC(r, height, startheight, p, true)
-                              },
-    FeePerByte:               800,
+	GenesisBlock: &liteCoinRegTestGenesisBlock, // no it's not
+	GenesisHash:  &liteCoinRegTestGenesisHash,
+	PoWFunction: func(b []byte) chainhash.Hash {
+		scryptBytes, _ := scrypt.Key(b, b, 1024, 1, 1, 32)
+		asChainHash, _ := chainhash.NewHash(scryptBytes)
+		return *asChainHash
+	},
+	DiffCalcFunction:         diffBTC,
+	FeePerByte:               800,
 	PowLimit:                 regressionPowLimit,
 	PowLimitBits:             0x207fffff,
 	CoinbaseMaturity:         100,

--- a/coinparam/register.go
+++ b/coinparam/register.go
@@ -2,7 +2,6 @@ package coinparam
 
 import (
 	"errors"
-	"io"
 	"log"
 	"math/big"
 	"time"
@@ -38,7 +37,10 @@ type Params struct {
 	PoWFunction func(b []byte) chainhash.Hash
 
 	// The function used to calculate the difficulty of a given block
-	DiffCalcFunction func(r io.ReadSeeker, height, startheight int32, p *Params) (uint32, error)
+	DiffCalcFunction func(
+		headers []*wire.BlockHeader, height int32, p *Params) (uint32, error)
+
+	//DiffCalcFunction func(r io.ReadSeeker, height, startheight int32, p *Params) (uint32, error)
 
 	// The block header to start downloading blocks from
 	StartHeader [80]byte

--- a/coinparam/vertcoin.go
+++ b/coinparam/vertcoin.go
@@ -5,35 +5,35 @@ import (
 
 	"github.com/adiabat/btcd/chaincfg/chainhash"
 	"github.com/adiabat/btcd/wire"
-	
+
 	"github.com/bitgoin/lyra2rev2"
 )
 
 var VertcoinTestNetParams = Params{
-	Name:        "vtctest",
+	Name:          "vtctest",
 	NetMagicBytes: 0x74726576,
-	DefaultPort: "15889",
+	DefaultPort:   "15889",
 	DNSSeeds: []string{
 		"fr1.vtconline.org",
 	},
 
 	// Chain parameters
-    DiffCalcFunction:         diffVTCtest,
-    FeePerByte:               800,
-	GenesisBlock:             &VertcoinTestnetGenesisBlock,
-	GenesisHash:              &VertcoinTestnetGenesisHash,
-	PowLimit:                 liteCoinTestNet4PowLimit,
-	PoWFunction:              func(b []byte) chainhash.Hash {
-                                  lyraBytes, _ := lyra2rev2.Sum(b)
-                                  asChainHash, _ := chainhash.NewHash(lyraBytes)
-                                  return *asChainHash
-                              },
+	DiffCalcFunction: diffVTCdummy,
+	FeePerByte:       800,
+	GenesisBlock:     &VertcoinTestnetGenesisBlock,
+	GenesisHash:      &VertcoinTestnetGenesisHash,
+	PowLimit:         liteCoinTestNet4PowLimit,
+	PoWFunction: func(b []byte) chainhash.Hash {
+		lyraBytes, _ := lyra2rev2.Sum(b)
+		asChainHash, _ := chainhash.NewHash(lyraBytes)
+		return *asChainHash
+	},
 	PowLimitBits:             0x1e0fffff,
 	CoinbaseMaturity:         120,
 	SubsidyReductionInterval: 840000,
-	TargetTimespan:           time.Second * 302400,    // 3.5 weeks
-	TargetTimePerBlock:       time.Second * 150, // 150 seconds
-	RetargetAdjustmentFactor: 4,                 // 25% less, 400% more
+	TargetTimespan:           time.Second * 302400, // 3.5 weeks
+	TargetTimePerBlock:       time.Second * 150,    // 150 seconds
+	RetargetAdjustmentFactor: 4,                    // 25% less, 400% more
 	ReduceMinDifficulty:      true,
 	MinDiffReductionTime:     time.Second * 150 * 2, // ?? unknown
 	GenerateSupported:        false,
@@ -49,10 +49,10 @@ var VertcoinTestNetParams = Params{
 	RelayNonStdTxs: true,
 
 	// Address encoding magics
-	PubKeyHashAddrID:        0x4a, // starts with X or W
-	ScriptHashAddrID:        0xc4,
-	Bech32Prefix:           "tvtc",
-	PrivateKeyID:            0xef, 
+	PubKeyHashAddrID: 0x4a, // starts with X or W
+	ScriptHashAddrID: 0xc4,
+	Bech32Prefix:     "tvtc",
+	PrivateKeyID:     0xef,
 
 	// BIP32 hierarchical deterministic extended key magics
 	HDPrivateKeyID: [4]byte{0x04, 0x35, 0x83, 0x94}, // starts with tprv
@@ -60,68 +60,68 @@ var VertcoinTestNetParams = Params{
 
 	// BIP44 coin type used in the hierarchical deterministic path for
 	// address generation.
-	HDCoinType: 65536, 
+	HDCoinType: 65536,
 }
 
 var VertcoinParams = Params{
-	Name:        "vtc",
-	NetMagicBytes:         0xdab5bffa,
-	DefaultPort: "5889",
+	Name:          "vtc",
+	NetMagicBytes: 0xdab5bffa,
+	DefaultPort:   "5889",
 	DNSSeeds: []string{
 		"fr1.vtconline.org",
-        "uk1.vtconline.org",
-        "useast1.vtconline.org",
-        "vtc.alwayshashing.com",
-        "crypto.office-on-the.net",
-        "p2pool.kosmoplovci.org",
+		"uk1.vtconline.org",
+		"useast1.vtconline.org",
+		"vtc.alwayshashing.com",
+		"crypto.office-on-the.net",
+		"p2pool.kosmoplovci.org",
 	},
 
 	// Chain parameters
-    StartHeader:              [80]byte {
-                                    0x02, 0x00, 0x00, 0x00, 0x36, 0xdc, 0x16, 0xc7, 0x71, 0x63, 
-                                    0x1c, 0x52, 0xa4, 0x3d, 0xb7, 0xb0, 0xa9, 0x86, 0x95, 0x95, 
-                                    0xed, 0x7d, 0xc1, 0x68, 0xe7, 0x2e, 0xaf, 0x0f, 0x55, 0x08, 
-                                    0x02, 0x98, 0x9f, 0x5c, 0x7b, 0xe4, 0x37, 0xa6, 0x90, 0x76, 
-                                    0x66, 0xa7, 0xba, 0x55, 0x75, 0xd8, 0x8a, 0xc5, 0x14, 0x01, 
-                                    0x86, 0x11, 0x8e, 0x34, 0xe2, 0x4a, 0x04, 0x7b, 0x9d, 0x6e, 
-                                    0x96, 0x41, 0xbb, 0x29, 0xe2, 0x04, 0xcb, 0x49, 0x3c, 0x53, 
-                                    0x08, 0x58, 0x3f, 0xf4, 0x4d, 0x1b, 0x42, 0x22, 0x6e, 0x8a,
-                              },
-    StartHeight:              598752,
-    AssumeDiffBefore:         602784,
-    DiffCalcFunction:         calcDiffAdjustKGW,
-    FeePerByte:               800,
-	GenesisBlock:             &VertcoinGenesisBlock,
-	GenesisHash:              &VertcoinGenesisHash,
-	PowLimit:                 liteCoinTestNet4PowLimit,
-	PoWFunction:              func(b []byte) chainhash.Hash {
-                                  lyraBytes, _ := lyra2rev2.Sum(b)
-                                  asChainHash, _ := chainhash.NewHash(lyraBytes)
-                                  return *asChainHash
-                              },
+	StartHeader: [80]byte{
+		0x02, 0x00, 0x00, 0x00, 0x36, 0xdc, 0x16, 0xc7, 0x71, 0x63,
+		0x1c, 0x52, 0xa4, 0x3d, 0xb7, 0xb0, 0xa9, 0x86, 0x95, 0x95,
+		0xed, 0x7d, 0xc1, 0x68, 0xe7, 0x2e, 0xaf, 0x0f, 0x55, 0x08,
+		0x02, 0x98, 0x9f, 0x5c, 0x7b, 0xe4, 0x37, 0xa6, 0x90, 0x76,
+		0x66, 0xa7, 0xba, 0x55, 0x75, 0xd8, 0x8a, 0xc5, 0x14, 0x01,
+		0x86, 0x11, 0x8e, 0x34, 0xe2, 0x4a, 0x04, 0x7b, 0x9d, 0x6e,
+		0x96, 0x41, 0xbb, 0x29, 0xe2, 0x04, 0xcb, 0x49, 0x3c, 0x53,
+		0x08, 0x58, 0x3f, 0xf4, 0x4d, 0x1b, 0x42, 0x22, 0x6e, 0x8a,
+	},
+	StartHeight:      598752,
+	AssumeDiffBefore: 602784,
+	DiffCalcFunction: diffVTCdummy,
+	FeePerByte:       800,
+	GenesisBlock:     &VertcoinGenesisBlock,
+	GenesisHash:      &VertcoinGenesisHash,
+	PowLimit:         liteCoinTestNet4PowLimit,
+	PoWFunction: func(b []byte) chainhash.Hash {
+		lyraBytes, _ := lyra2rev2.Sum(b)
+		asChainHash, _ := chainhash.NewHash(lyraBytes)
+		return *asChainHash
+	},
 	PowLimitBits:             0x1e0fffff,
 	CoinbaseMaturity:         120,
 	SubsidyReductionInterval: 840000,
-	TargetTimespan:           time.Second * 302400,    // 3.5 weeks
-	TargetTimePerBlock:       time.Second * 150, // 150 seconds
-	RetargetAdjustmentFactor: 4,                 // 25% less, 400% more
+	TargetTimespan:           time.Second * 302400, // 3.5 weeks
+	TargetTimePerBlock:       time.Second * 150,    // 150 seconds
+	RetargetAdjustmentFactor: 4,                    // 25% less, 400% more
 	ReduceMinDifficulty:      false,
 	MinDiffReductionTime:     time.Second * 150 * 2, // ?? unknown
 	GenerateSupported:        false,
 
 	// Checkpoints ordered from oldest to newest.
 	Checkpoints: []Checkpoint{
-    {  0,      newHashFromStr("4d96a915f49d40b1e5c2844d1ee2dccb90013a990ccea12c492d22110489f0c4")},
-    {  24200,  newHashFromStr("d7ed819858011474c8b0cae4ad0b9bdbb745becc4c386bc22d1220cc5a4d1787")},
-    {  65000,  newHashFromStr("9e673a69c35a423f736ab66f9a195d7c42f979847a729c0f3cef2c0b8b9d0289")},
-    {  84065,  newHashFromStr("a904170a5a98109b2909379d9bc03ef97a6b44d5dafbc9084b8699b0cba5aa98")},
-    {  228023, newHashFromStr("15c94667a9e941359d2ee6527e2876db1b5e7510a5ded3885ca02e7e0f516b51")},
-    {  346992, newHashFromStr("f1714fa4c7990f4b3d472eb22132891ccd3c7ad7208e2d1ab15bde68854fb0ee")},
-    {  347269, newHashFromStr("fa1e592b7ea2aa97c5f20ccd7c40f3aaaeb31d1232c978847a79f28f83b6c22a")},
-    {  430000, newHashFromStr("2f5703cf7b6f956b84fd49948cbf49dc164cfcb5a7b55903b1c4f53bc7851611")},
-    {  516999, newHashFromStr("572ed47da461743bcae526542053e7bc532de299345e4f51d77786f2870b7b28")},
-	{  627610, newHashFromStr("6000a787f2d8bb77d4f491a423241a4cc8439d862ca6cec6851aba4c79ccfedc")},
-    },
+		{0, newHashFromStr("4d96a915f49d40b1e5c2844d1ee2dccb90013a990ccea12c492d22110489f0c4")},
+		{24200, newHashFromStr("d7ed819858011474c8b0cae4ad0b9bdbb745becc4c386bc22d1220cc5a4d1787")},
+		{65000, newHashFromStr("9e673a69c35a423f736ab66f9a195d7c42f979847a729c0f3cef2c0b8b9d0289")},
+		{84065, newHashFromStr("a904170a5a98109b2909379d9bc03ef97a6b44d5dafbc9084b8699b0cba5aa98")},
+		{228023, newHashFromStr("15c94667a9e941359d2ee6527e2876db1b5e7510a5ded3885ca02e7e0f516b51")},
+		{346992, newHashFromStr("f1714fa4c7990f4b3d472eb22132891ccd3c7ad7208e2d1ab15bde68854fb0ee")},
+		{347269, newHashFromStr("fa1e592b7ea2aa97c5f20ccd7c40f3aaaeb31d1232c978847a79f28f83b6c22a")},
+		{430000, newHashFromStr("2f5703cf7b6f956b84fd49948cbf49dc164cfcb5a7b55903b1c4f53bc7851611")},
+		{516999, newHashFromStr("572ed47da461743bcae526542053e7bc532de299345e4f51d77786f2870b7b28")},
+		{627610, newHashFromStr("6000a787f2d8bb77d4f491a423241a4cc8439d862ca6cec6851aba4c79ccfedc")},
+	},
 
 	BlockEnforceNumRequired: 1512,
 	BlockRejectNumRequired:  1915,
@@ -131,10 +131,10 @@ var VertcoinParams = Params{
 	RelayNonStdTxs: true,
 
 	// Address encoding magics
-	PubKeyHashAddrID:        0x47, // starts with V
-	ScriptHashAddrID:        0x05, // starts with 3
-	Bech32Prefix:           "vtc",
-	PrivateKeyID:            0x80, 
+	PubKeyHashAddrID: 0x47, // starts with V
+	ScriptHashAddrID: 0x05, // starts with 3
+	Bech32Prefix:     "vtc",
+	PrivateKeyID:     0x80,
 
 	// BIP32 hierarchical deterministic extended key magics
 	HDPrivateKeyID: [4]byte{0x04, 0x35, 0x83, 0x94}, // starts with tprv
@@ -148,14 +148,14 @@ var VertcoinParams = Params{
 // ==================== VertcoinTestnet
 
 // VertcoinTestNetGenesisHash
-var VertcoinTestnetGenesisHash = chainhash.Hash([chainhash.HashSize]byte{ 
+var VertcoinTestnetGenesisHash = chainhash.Hash([chainhash.HashSize]byte{
 	0xc9, 0xd2, 0x7a, 0x49, 0x47, 0x27, 0x2e, 0xe3, 0xc2,
 	0xe8, 0x1a, 0x74, 0xb6, 0x79, 0xac, 0xec, 0x5d, 0x85,
 	0xa4, 0x6a, 0x97, 0x16, 0x79, 0xf0, 0xc8, 0x64, 0x7a,
 	0xeb, 0x4f, 0xf2, 0xe8, 0xce,
 })
 
-var VertcoinTestnetMerkleRoot = chainhash.Hash([chainhash.HashSize]byte{ 
+var VertcoinTestnetMerkleRoot = chainhash.Hash([chainhash.HashSize]byte{
 	0xe7, 0x23, 0x01, 0xfc, 0x49, 0x32, 0x3e, 0xe1, 0x51,
 	0xcf, 0x10, 0x48, 0x23, 0x0f, 0x03, 0x2c, 0xa5, 0x89,
 	0x75, 0x3b, 0xa7, 0x08, 0x62, 0x22, 0xa5, 0xc0, 0x23,
@@ -176,17 +176,17 @@ var VertcoinTestnetGenesisBlock = wire.MsgBlock{
 // ==================== Vertcoin
 
 // VertcoinNetGenesisHash
-var VertcoinGenesisHash = chainhash.Hash([chainhash.HashSize]byte{ 
-	0xc4,0xf0,0x89,0x04,0x11,0x22,0x2d,0x49,0x2c,0xa1,
-  0xce,0x0c,0x99,0x3a,0x01,0x90,0xcb,0xdc,0xe2,0x1e,
-  0x4d,0x84,0xc2,0xe5,0xb1,0x40,0x9d,0xf4,0x15,0xa9,
-  0x96,0x4d,
+var VertcoinGenesisHash = chainhash.Hash([chainhash.HashSize]byte{
+	0xc4, 0xf0, 0x89, 0x04, 0x11, 0x22, 0x2d, 0x49, 0x2c, 0xa1,
+	0xce, 0x0c, 0x99, 0x3a, 0x01, 0x90, 0xcb, 0xdc, 0xe2, 0x1e,
+	0x4d, 0x84, 0xc2, 0xe5, 0xb1, 0x40, 0x9d, 0xf4, 0x15, 0xa9,
+	0x96, 0x4d,
 })
 
-var VertcoinMerkleRoot = chainhash.Hash([chainhash.HashSize]byte{ 
-	0xe7,0x23,0x01,0xfc,0x49,0x32,0x3e,0xe1,0x51,0xcf,0x10,0x48,0x23,0x0f,
-  0x03,0x2c,0xa5,0x89,0x75,0x3b,0xa7,0x08,0x62,0x22,0xa5,0xc0,0x23,0xe3,
-  0xa0,0x8c,0xf3,0x4a,
+var VertcoinMerkleRoot = chainhash.Hash([chainhash.HashSize]byte{
+	0xe7, 0x23, 0x01, 0xfc, 0x49, 0x32, 0x3e, 0xe1, 0x51, 0xcf, 0x10, 0x48, 0x23, 0x0f,
+	0x03, 0x2c, 0xa5, 0x89, 0x75, 0x3b, 0xa7, 0x08, 0x62, 0x22, 0xa5, 0xc0, 0x23, 0xe3,
+	0xa0, 0x8c, 0xf3, 0x4a,
 })
 
 var VertcoinGenesisBlock = wire.MsgBlock{
@@ -199,4 +199,3 @@ var VertcoinGenesisBlock = wire.MsgBlock{
 		Nonce:      5749262,
 	},
 }
-

--- a/lit.go
+++ b/lit.go
@@ -30,9 +30,9 @@ type LitConfig struct {
 	// hostnames to connect to for different networks
 	tn3host, bc2host, lt4host, reghost, litereghost, tvtchost, vtchost string
 
-	verbose    bool
-	rpcport    uint16
-	litHomeDir string
+	verbose, tower bool
+	rpcport        uint16
+	litHomeDir     string
 
 	Params *coinparam.Params
 }
@@ -41,6 +41,8 @@ func setConfig(lc *LitConfig) {
 	easyptr := flag.Bool("ez", false, "use easy mode (bloom filters)")
 
 	verbptr := flag.Bool("v", false, "verbose; print all logs to stdout")
+
+	towerptr := flag.Bool("tower", false, "watchtower: run a watching node")
 
 	tn3ptr := flag.String("tn3", "", "testnet3 full node")
 	regptr := flag.String("reg", "", "regtest full node")
@@ -67,6 +69,7 @@ func setConfig(lc *LitConfig) {
 	lc.reSync = *resyncprt
 	lc.hard = !*easyptr
 	lc.verbose = *verbptr
+	lc.tower = *towerptr
 
 	lc.rpcport = uint16(*rpcportptr)
 
@@ -89,7 +92,8 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *LitConfig) error {
 			conf.reghost = conf.reghost + ":" + p.DefaultPort
 		}
 		fmt.Printf("reg: %s\n", conf.reghost)
-		err = node.LinkBaseWallet(key, 120, conf.reSync, conf.reghost, p)
+		err = node.LinkBaseWallet(
+			key, 120, conf.reSync, conf.tower, conf.reghost, p)
 		if err != nil {
 			return err
 		}
@@ -101,8 +105,7 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *LitConfig) error {
 			conf.tn3host = conf.tn3host + ":" + p.DefaultPort
 		}
 		err = node.LinkBaseWallet(
-			key, 1150000, conf.reSync,
-			conf.tn3host, p)
+			key, 1150000, conf.reSync, conf.tower, conf.tn3host, p)
 		if err != nil {
 			return err
 		}
@@ -113,7 +116,8 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *LitConfig) error {
 		if !strings.Contains(conf.litereghost, ":") {
 			conf.litereghost = conf.litereghost + ":" + p.DefaultPort
 		}
-		err = node.LinkBaseWallet(key, 120, conf.reSync, conf.litereghost, p)
+		err = node.LinkBaseWallet(
+			key, 120, conf.reSync, conf.tower, conf.litereghost, p)
 		if err != nil {
 			return err
 		}
@@ -126,8 +130,7 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *LitConfig) error {
 			conf.lt4host = conf.lt4host + ":" + p.DefaultPort
 		}
 		err = node.LinkBaseWallet(
-			key, p.StartHeight, conf.reSync,
-			conf.lt4host, p)
+			key, p.StartHeight, conf.reSync, conf.tower, conf.lt4host, p)
 		if err != nil {
 			return err
 		}
@@ -139,8 +142,7 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *LitConfig) error {
 			conf.tvtchost = conf.tvtchost + ":" + p.DefaultPort
 		}
 		err = node.LinkBaseWallet(
-			key, 0, conf.reSync,
-			conf.tvtchost, p)
+			key, 0, conf.reSync, conf.tower, conf.tvtchost, p)
 		if err != nil {
 			return err
 		}
@@ -152,8 +154,7 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *LitConfig) error {
 			conf.vtchost = conf.vtchost + ":" + p.DefaultPort
 		}
 		err = node.LinkBaseWallet(
-			key, p.StartHeight, conf.reSync,
-			conf.vtchost, p)
+			key, p.StartHeight, conf.reSync, conf.tower, conf.vtchost, p)
 		if err != nil {
 			return err
 		}

--- a/qln/init.go
+++ b/qln/init.go
@@ -69,7 +69,7 @@ func NewLitNode(privKey *[32]byte, path string) (*LitNode, error) {
 
 // LinkBaseWallet activates a wallet and hooks it into the litnode.
 func (nd *LitNode) LinkBaseWallet(
-	privKey *[32]byte, birthHeight int32, resync bool,
+	privKey *[32]byte, birthHeight int32, resync bool, tower bool,
 	host string, param *coinparam.Params) error {
 
 	rootpriv, err := hdkeychain.NewMaster(privKey[:], param)
@@ -104,10 +104,12 @@ func (nd *LitNode) LinkBaseWallet(
 	// if this node is running a watchtower, link the watchtower to the
 	// new wallet block events
 
-	err = nd.Tower.HookLink(
-		nd.LitFolder, param, nd.SubWallet[WallitIdx].ExportHook())
-	if err != nil {
-		return err
+	if tower {
+		err = nd.Tower.HookLink(
+			nd.LitFolder, param, nd.SubWallet[WallitIdx].ExportHook())
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/uspv/chainhook.go
+++ b/uspv/chainhook.go
@@ -1,6 +1,7 @@
 package uspv
 
 import (
+	"log"
 	"path/filepath"
 
 	"github.com/adiabat/btcd/chaincfg/chainhash"
@@ -114,11 +115,13 @@ func (s *SPVCon) Start(
 
 	err = s.Connect(host)
 	if err != nil {
+		log.Printf("Can't connect to host %s\n", host)
 		return nil, nil, err
 	}
 
 	err = s.AskForHeaders()
 	if err != nil {
+		log.Printf("AskForHeaders error\n")
 		return nil, nil, err
 	}
 

--- a/uspv/eight333.go
+++ b/uspv/eight333.go
@@ -226,6 +226,13 @@ func (s *SPVCon) IngestMerkleBlock(m *wire.MsgMerkleBlock) {
 // If there are no headers, it assumes we're done and returns false.
 // Otherwise it assumes there's more to request and returns true.
 func (s *SPVCon) IngestHeaders(m *wire.MsgHeaders) (bool, error) {
+
+	// headerChainLength is how many headers we give to the
+	// verification function.  In bitcoin you never need more than 2016 previous
+	// headers to figure out the validity of the next; some alcoins need more
+	// though, like 4K or so.
+	headerChainLength := 4096
+
 	gotNum := int64(len(m.Headers))
 	if gotNum > 0 {
 		log.Printf("got %d headers. Range:\n%s - %s\n",

--- a/uspv/eight333.go
+++ b/uspv/eight333.go
@@ -253,74 +253,9 @@ func (s *SPVCon) IngestHeaders(m *wire.MsgHeaders) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	fmt.Printf("checked out\n")
-	// write all incoming headers to disk
 
-	//	tipheight := s.GetHeaderTipHeight()
-
-	//	tipheader, err := s.GetHeaderAtHeight(tipheight)
-	//	if err != nil {
-	//		return false, err
-	//	}
-	//	tiphash := tipheader.BlockHash()
-
-	//	// first, read our tip and see if the first thing we've gotten links up
-	//	if !m.Headers[0].PrevBlock.IsEqual(&tiphash) {
-	//		// reorg
-	//	}
-
-	//	// check all the headers
-	//	//	for n, curheader := range m.Headers {
-	//	//		worked := CheckHeader()
-	//	//	}
-
-	//	// seek to last header
-	//	_, err = s.headerFile.Seek(-80, os.SEEK_END)
-	//	if err != nil {
-	//		return false, err
-	//	}
-	//	var last wire.BlockHeader
-	//	err = last.Deserialize(s.headerFile)
-	//	if err != nil {
-	//		return false, err
-	//	}
-	//	prevHash := last.BlockHash()
-
-	//	endPos, err := s.headerFile.Seek(0, os.SEEK_END)
-	//	if err != nil {
-	//		return false, err
-	//	}
-	//	tip := int32(endPos/80) + (s.headerStartHeight - 1) // move back 1 header length to read
-
-	//	// check first header returned to make sure it fits on the end
-	//	// of our header file
-	//	if !m.Headers[0].PrevBlock.IsEqual(&prevHash) {
-
-	//		// node is telling us about a header that doesn't fit.
-	//		// Try to find where it hooks in to; if it's in the last 100 blocks,
-	//		// then we'll re-org.  If the re-org is more than 100 blocks deep
-	//		// we should disconnect and crash.
-
-	//		log.Printf("header msg doesn't fit. points to %s, expect %s",
-	//			m.Headers[0].PrevBlock.String(), prevHash.String())
-
-	//		if endPos < 8160 {
-	//			// jeez I give up, back to genesis
-	//			s.headerFile.Truncate(160)
-	//		} else {
-	//			height, err := FindHeader(s.headerFile, *m.Headers[0])
-	//			log.Printf("header %s is back at height %d",
-	//				m.Headers[0].PrevBlock.String(), height)
-	//			if err != nil {
-	//				return false, err
-	//			}
-	//			err = s.headerFile.Truncate(endPos - 8000)
-	//			if err != nil {
-	//				return false, fmt.Errorf("couldn't truncate header file")
-	//			}
-	//		}
-	//		return true, fmt.Errorf("Truncated header file to try again")
-	//	}
+	// a header message is all or nothing; if we think there's something
+	// wrong with it, we don't take any of their headers
 
 	for _, resphdr := range m.Headers {
 		// write to end of file

--- a/uspv/eight333.go
+++ b/uspv/eight333.go
@@ -231,7 +231,7 @@ func (s *SPVCon) IngestHeaders(m *wire.MsgHeaders) (bool, error) {
 	// verification function.  In bitcoin you never need more than 2016 previous
 	// headers to figure out the validity of the next; some alcoins need more
 	// though, like 4K or so.
-	headerChainLength := 4096
+	//	headerChainLength := 4096
 
 	gotNum := int64(len(m.Headers))
 	if gotNum > 0 {

--- a/uspv/eight333.go
+++ b/uspv/eight333.go
@@ -261,9 +261,15 @@ func (s *SPVCon) IngestHeaders(m *wire.MsgHeaders) (bool, error) {
 	// check first header returned to make sure it fits on the end
 	// of our header file
 	if !m.Headers[0].PrevBlock.IsEqual(&prevHash) {
-		// delete 100 headers if this happens!  Dumb reorg.
-		log.Printf("reorg? header msg doesn't fit. points to %s, expect %s",
+
+		// node is telling us about a header that doesn't fit.
+		// Try to find where it hooks in to; if it's in the last 100 blocks,
+		// then we'll re-org.  If the re-org is more than 100 blocks deep
+		// we should disconnect and crash.
+
+		log.Printf("header msg doesn't fit. points to %s, expect %s",
 			m.Headers[0].PrevBlock.String(), prevHash.String())
+
 		if endPos < 8160 {
 			// jeez I give up, back to genesis
 			s.headerFile.Truncate(160)

--- a/uspv/eight333.go
+++ b/uspv/eight333.go
@@ -221,10 +221,10 @@ func (s *SPVCon) IngestMerkleBlock(m *wire.MsgMerkleBlock) {
 	return
 }
 
-// IngestHeaders takes in a bunch of headers and appends them to the
-// local header file, checking that they fit.  If there's no headers,
-// it assumes we're done and returns false.  If it worked it assumes there's
-// more to request and returns true.
+// IngestHeaders takes in a bunch of headers, checks them,
+// and if they're OK, appends them to the loccal header file.
+// If there are no headers, it assumes we're done and returns false.
+// Otherwise it assumes there's more to request and returns true.
 func (s *SPVCon) IngestHeaders(m *wire.MsgHeaders) (bool, error) {
 	gotNum := int64(len(m.Headers))
 	if gotNum > 0 {
@@ -237,9 +237,29 @@ func (s *SPVCon) IngestHeaders(m *wire.MsgHeaders) (bool, error) {
 	}
 
 	s.headerMutex.Lock()
+	// even though we will be doing a bunch without writing, should be
+	// OK performance-wise to keep it locked for this function duration,
+	// because verification is pretty quick.
 	defer s.headerMutex.Unlock()
 
-	var err error
+	tipheight := s.GetHeaderTipHeight()
+
+	tipheader, err := s.GetHeaderAtHeight(tipheight)
+	if err != nil {
+		return false, err
+	}
+	tiphash := tipheader.BlockHash()
+
+	// first, read our tip and see if the first thing we've gotten links up
+	if !m.Headers[0].PrevBlock.IsEqual(&tiphash) {
+		// reorg
+	}
+
+	// check all the headers
+	//	for n, curheader := range m.Headers {
+	//		worked := CheckHeader()
+	//	}
+
 	// seek to last header
 	_, err = s.headerFile.Seek(-80, os.SEEK_END)
 	if err != nil {
@@ -274,6 +294,12 @@ func (s *SPVCon) IngestHeaders(m *wire.MsgHeaders) (bool, error) {
 			// jeez I give up, back to genesis
 			s.headerFile.Truncate(160)
 		} else {
+			height, err := FindHeader(s.headerFile, *m.Headers[0])
+			log.Printf("header %s is back at height %d",
+				m.Headers[0].PrevBlock.String(), height)
+			if err != nil {
+				return false, err
+			}
 			err = s.headerFile.Truncate(endPos - 8000)
 			if err != nil {
 				return false, fmt.Errorf("couldn't truncate header file")
@@ -314,43 +340,45 @@ func (s *SPVCon) IngestHeaders(m *wire.MsgHeaders) (bool, error) {
 }
 
 func (s *SPVCon) AskForHeaders() error {
-	var hdr wire.BlockHeader
 	ghdr := wire.NewMsgGetHeaders()
 	ghdr.ProtocolVersion = s.localVersion
 
-	s.headerMutex.Lock() // start header file ops
-	info, err := s.headerFile.Stat()
+	tipheight := s.GetHeaderTipHeight()
+	fmt.Printf("got header tip height %d\n", tipheight)
+	// get tip header, as well as a few older ones (inefficient...?)
+	// yes, inefficient; really we should use "getheaders" and skip some of this
+
+	tipheader, err := s.GetHeaderAtHeight(tipheight)
 	if err != nil {
 		return err
 	}
-	headerFileSize := info.Size()
-	if headerFileSize == 0 || headerFileSize%80 != 0 { // header file broken
-		// try to fix it!
-		s.headerFile.Truncate(headerFileSize - (headerFileSize % 80))
-		log.Printf("ERROR: Header file not a multiple of 80 bytes. Truncating")
-	}
 
-	// seek to 80 bytes from end of file
-	ns, err := s.headerFile.Seek(-80, os.SEEK_END)
+	tHash := tipheader.BlockHash()
+	err = ghdr.AddBlockLocatorHash(&tHash)
 	if err != nil {
-		log.Printf("can't seek\n")
 		return err
 	}
 
-	log.Printf("sought to offset %d (should be near the end\n", ns)
+	backnum := int32(1)
 
-	// get header from last 80 bytes of file
-	err = hdr.Deserialize(s.headerFile)
-	if err != nil {
-		log.Printf("can't Deserialize")
-		return err
-	}
-	s.headerMutex.Unlock() // done with header file
+	// add more blockhashes in there if we're high enough
+	for tipheight > s.Param.StartHeight+backnum {
+		backhdr, err := s.GetHeaderAtHeight(tipheight - backnum)
+		if err != nil {
+			return err
+		}
+		backhash := backhdr.BlockHash()
 
-	cHash := hdr.BlockHash()
-	err = ghdr.AddBlockLocatorHash(&cHash)
-	if err != nil {
-		return err
+		err = ghdr.AddBlockLocatorHash(&backhash)
+		if err != nil {
+			return err
+		}
+		backnum++
+
+		// send the most recent 10 blockhashes, then get sparse
+		if backnum > 10 {
+			backnum <<= 2
+		}
 	}
 
 	log.Printf("get headers message has %d header hashes, first one is %s\n",

--- a/uspv/hardmode.go
+++ b/uspv/hardmode.go
@@ -38,6 +38,11 @@ func BlockOK(blk wire.MsgBlock) bool {
 		}
 	}
 
+	// block minus witnesses should be < 1M
+	if blk.SerializeSizeStripped() > 1000000 {
+		return false
+	}
+
 	var commitBytes []byte
 	// try to extract coinbase witness commitment (even if !witMode)
 	cb := blk.Transactions[0]                 // get coinbase tx

--- a/uspv/header.go
+++ b/uspv/header.go
@@ -133,7 +133,7 @@ func FindHeader(r io.ReadSeeker, hdr wire.BlockHeader) (int32, error) {
 // Note we don't know what the height is, just the relative height.
 // returnin nil means it worked
 func CheckHeaderChain(
-	r io.ReadSeeker, inHeaders []*wire.BlockHeader, p *coinparam.Params) error {
+	r io.ReadWriteSeeker, inHeaders []*wire.BlockHeader, p *coinparam.Params) error {
 
 	// make sure we actually got new headers
 	if len(inHeaders) < 1 {
@@ -218,8 +218,16 @@ func CheckHeaderChain(
 
 	// make sure the first header in the message points to our on-disk tip
 	if !inHeaders[0].PrevBlock.IsEqual(&tiphash) {
-		return fmt.Errorf(
-			"CheckHeaderChain: header message doesn't attach to tip.")
+
+		// find where it points to
+
+		attchHeight, err := FindHeader(r, *inHeaders[0])
+		if err != nil {
+			return fmt.Errorf(
+				"CheckHeaderChain: header message doesn't attach to tip or anywhere.")
+		}
+		return fmt.Errorf("Header message attaches at height %d", attchHeight)
+
 	}
 	// TODO reorg detection here
 

--- a/uspv/header.go
+++ b/uspv/header.go
@@ -244,7 +244,7 @@ func CheckHeaderChain(
 		}
 
 		log.Printf("reorg from height %d to %d",
-			height, attachHeight+int32(len(inHeaders)))
+			height-1, attachHeight+int32(len(inHeaders)))
 
 		// reorg is go, snip to attach height
 		reorgDepth := height - attachHeight

--- a/uspv/header.go
+++ b/uspv/header.go
@@ -189,8 +189,8 @@ func CheckHeaderChain(
 	var numheaders int32 // number of headers to read
 
 	// load only last epoch if there are a lot on disk
-	if pos > int64(80*epochLength) {
-		_, err = r.Seek(int64(-80*epochLength), os.SEEK_END)
+	if pos > int64(80*(epochLength+1)) {
+		_, err = r.Seek(int64(-80*(epochLength+1)), os.SEEK_END)
 		numheaders = epochLength
 	} else { // otherwise load everything, start at byte 0
 		_, err = r.Seek(0, os.SEEK_SET)

--- a/uspv/header.go
+++ b/uspv/header.go
@@ -142,7 +142,7 @@ func CheckHeaderChain(
 			"CheckHeaderChain: Header file not a multiple of 80 bytes.")
 	}
 	// get the height of this tip from the file length
-	height := int32(pos/80) + p.StartHeight
+	//	height := int32(pos/80) + p.StartHeight
 	// read in last header
 	err = prevTip.Deserialize(r)
 	if err != nil {
@@ -175,7 +175,8 @@ func CheckHeaderChain(
 			}
 		}
 	}
-
+	// more here
+	return true, nil
 }
 
 func CheckHeader(r io.ReadSeeker, height, startheight int32, p *coinparam.Params) bool {

--- a/uspv/header.go
+++ b/uspv/header.go
@@ -128,7 +128,6 @@ func FindHeader(r io.ReadSeeker, hdr wire.BlockHeader) (int32, error) {
 // CheckHeaderChain takes in the headers message and sees if they all validate.
 // This function also needs read access to the previous headers.
 // Does not deal with re-orgs; assumes new headers link to tip
-// TODO do reorgs and append here! why not
 // returns true if *all* headers are cool, false if there is any problem
 // Note we don't know what the height is, just the relative height.
 // returnin nil means it worked
@@ -234,7 +233,7 @@ func CheckHeaderChain(
 		log.Printf("Header %s attaches at height %d\n",
 			inHeaders[0].BlockHash().String(), attachHeight)
 
-		// TODO check for more work here instead of length
+		// TODO check for more work here instead of length.  This is wrong...
 		// if we've been given insufficient headers, don't reorg, but
 		// ask for more headers.
 		if attachHeight+int32(len(inHeaders)) < height {

--- a/uspv/header.go
+++ b/uspv/header.go
@@ -191,7 +191,7 @@ func CheckHeaderChain(
 	// load only last epoch if there are a lot on disk
 	if pos > int64(80*(epochLength+1)) {
 		_, err = r.Seek(int64(-80*(epochLength+1)), os.SEEK_END)
-		numheaders = epochLength
+		numheaders = epochLength + 1
 	} else { // otherwise load everything, start at byte 0
 		_, err = r.Seek(0, os.SEEK_SET)
 		numheaders = height - p.StartHeight

--- a/uspv/msghandler.go
+++ b/uspv/msghandler.go
@@ -65,6 +65,7 @@ func (s *SPVCon) incomingMessageHandler() {
 func (s *SPVCon) outgoingMessageHandler() {
 	for {
 		msg := <-s.outMsgQueue
+
 		n, err := wire.WriteMessageWithEncodingN(s.con, msg, s.localVersion,
 			wire.BitcoinNet(s.Param.NetMagicBytes), wire.LatestEncoding)
 
@@ -199,7 +200,7 @@ func (s *SPVCon) GetDataHandler(m *wire.MsgGetData) {
 		// I don't think they'll request non-witness anyway.
 		if thing.Type == wire.InvTypeWitnessTx || thing.Type == wire.InvTypeTx {
 			tx, ok := s.TxMap[thing.Hash]
-			if !ok {
+			if !ok || tx == nil {
 				log.Printf("tx %s requested by we don't have it\n",
 					thing.Hash.String())
 			}

--- a/wallit/dbio.go
+++ b/wallit/dbio.go
@@ -341,7 +341,6 @@ func NewPorTxoBytesFromKGBytes(
 }
 
 // Rollback rewinds the wallet state to a previous height.  It removes new UTXOs
-// and restores utxos spent before this time.
 func (w *Wallit) RollBack(rollHeight int32) error {
 	// Assume this is an actual reord / rewind.  If you supply a height *greater*
 	// than the current height, all bets are off.  ( probably nothing will
@@ -407,47 +406,6 @@ func (w *Wallit) RollBack(rollHeight int32) error {
 		// where if the stored txs above the reorg height aren't re-confirmed,
 		// then it will attempt to rebroadcast them.
 
-		/*
-			var reTxos [][]byte
-
-			// reanimate old stxos
-			err = old.ForEach(func(k, v []byte) error {
-				// these are all k:op v:everything else
-				x := make([]byte, len(k)+len(v))
-				copy(x, k)
-				copy(x[len(k):], v)
-
-				thisStxo, err := StxoFromBytes(x)
-				if err != nil {
-					return err
-				}
-				// if this spent txo was spent after the rollback height,
-				// need to reanimate
-				if thisStxo.SpendHeight > rollHeight {
-					// get portxo bytes to store
-					ptxoBytes, err := thisStxo.PorTxo.Bytes()
-					if err != nil {
-						return err
-					}
-					// stash portxo bytes
-					reTxos = append(reTxos, ptxoBytes)
-				}
-
-				return nil
-			})
-
-			// now reanimate by adding the utxo, and deleting the stxo
-			for _, txob := range reTxos {
-				err = dufb.Put(txob[:36], txob[36:])
-				if err != nil {
-					return err
-				}
-				err = old.Delete(txob[:36])
-				if err != nil {
-					return err
-				}
-			}
-		*/
 		log.Printf("Rollback db.  %d utxos lost\n", len(killOPs))
 
 		return nil

--- a/wallit/init.go
+++ b/wallit/init.go
@@ -119,6 +119,10 @@ func (w *Wallit) HeightHandler(incomingHeight chan int32) {
 		// detect reorg
 		if h < prevHeight {
 			log.Printf("HeightHandler: oh no, reorg!\n")
+			err := w.RollBack(h)
+			if err != nil {
+				log.Printf("Rollback crash  %s ", err.Error())
+			}
 		}
 
 		err := w.SetDBSyncHeight(h)

--- a/wallit/init.go
+++ b/wallit/init.go
@@ -58,7 +58,7 @@ func NewWallit(
 	log.Printf("DB height %d\n", height)
 	incomingTx, incomingBlockheight, err := w.Hook.Start(height, spvhost, wallitpath, p)
 	if err != nil {
-		log.Printf("NewWallit crash  %s ", err.Error())
+		log.Printf("NewWallit Hook.Start crash  %s ", err.Error())
 	}
 
 	// check if there are any addresses.  If there aren't (initial wallet setup)

--- a/wallit/init.go
+++ b/wallit/init.go
@@ -113,12 +113,19 @@ func (w *Wallit) TxHandler(incomingTxAndHeight chan lnutil.TxAndHeight) {
 }
 
 func (w *Wallit) HeightHandler(incomingHeight chan int32) {
+	var prevHeight int32
 	for {
 		h := <-incomingHeight
+		// detect reorg
+		if h < prevHeight {
+			log.Printf("HeightHandler: oh no, reorg!\n")
+		}
+
 		err := w.SetDBSyncHeight(h)
 		if err != nil {
 			log.Printf("HeightHandler crash  %s ", err.Error())
 		}
+		prevHeight = h
 	}
 }
 

--- a/wallit/wallit.go
+++ b/wallit/wallit.go
@@ -128,17 +128,26 @@ func (s *Stxo) ToBytes() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// Doesn't work
 // StxoFromBytes turns bytes into a Stxo.
-// first 36 bytes are how it's spent, after that is portxo
+// it's a portxo with a spendHeight and spendTxid at the end.
 func StxoFromBytes(b []byte) (Stxo, error) {
 	var s Stxo
-	if len(b) < 96 {
+
+	l := len(b)
+	if l < 96 {
 		return s, fmt.Errorf("Got %d bytes for stxo, expect a bunch", len(b))
 	}
-	buf := bytes.NewBuffer(b)
+
+	// last 36 bytes are height & spend txid.
+	u, err := portxo.PorTxoFromBytes(b[:l-36])
+	if err != nil {
+		log.Printf(" eof? ")
+		return s, err
+	}
+
+	buf := bytes.NewBuffer(b[l-36:])
 	// read 4 byte spend height
-	err := binary.Read(buf, binary.BigEndian, &s.SpendHeight)
+	err = binary.Read(buf, binary.BigEndian, &s.SpendHeight)
 	if err != nil {
 		return s, err
 	}
@@ -148,11 +157,6 @@ func StxoFromBytes(b []byte) (Stxo, error) {
 		return s, err
 	}
 
-	u, err := portxo.PorTxoFromBytes(buf.Bytes())
-	if err != nil {
-		log.Printf(" eof? ")
-		return s, err
-	}
 	s.PorTxo = *u // assign the utxo
 
 	return s, nil


### PR DESCRIPTION
Most of the diffs here are in uspv, changing the headers code.  Previously the flow was:

- get a block inv message
- request headers
- get a headers message
- append all those headers onto the headers.bin file
- verify the validity and work of newly appended headers
- if something goes wrong, basically just choke

This was simple and worked OK for test networks, but reorgs *do* happen.

New flow

- get headers message, but keep them in RAM, not on disk
- grab on-disk headers back to the last diff adjust, prepend in RAM
- the header validity check function takes the in-RAM headers, and checks them
- if the headers are OK, write them to disk

This allows reorgs to happen within a single headers message.  Headers messages are limited to 2000 headers, so this does not support reorgs deeper than 2000 blocks, which in bitcoin is about 2 weeks.  It'll break and lose synchronization with the network if such a reorg happens, which is probably OK as that would be a disaster requiring manual intervention.

Modifications to the wallit package:
when lower height signals come in, run through the utxo database, and remove all utxos higher than the reorg height.
It would be possible to replay transactions to regain the spent utxos, but this is not done.

This seems to work, but there are some things left for later:

- reorgs happen based on longest chain (only looks at height).  This is wrong as most work is the correct mechanism.  Wouldn't be too hard to switch, just a little bit of bigint math.

- Txs which are reorged out are not re-broadcast by the lit node.  This wouldn't be too hard to fix either.  In practice may not be needed, but would be nice to have.

- qln package doesn't deal with reorgs at all yet.  For small reorgs there shouldn't be any dangers, but large reorgs that revert fraudulent closing transactions can be harmful and will need to be dealt with in the qln pakage.

I can open issues for these after merging.