### PR TITLE
Connect to DNS Seeds if user specifies 1/auto/true

### DIFF
--- a/lit.go
+++ b/lit.go
@@ -85,6 +85,7 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *config) error {
 			return err
 		}
 	}
+	// try testnet3
 	if conf.Tn3host != "" {
 		p := &coinparam.TestNet3Params
 		if !strings.Contains(conf.Tn3host, ":") {
@@ -108,7 +109,7 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *config) error {
 			return err
 		}
 	}
-	// try litecoin tn4
+	// try litecoin testnet4
 	if conf.Lt4host != "" {
 		p := &coinparam.LiteCoinTestNet4Params
 		if !strings.Contains(conf.Lt4host, ":") {
@@ -134,7 +135,6 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *config) error {
 			return err
 		}
 	}
-
 	// try vertcoin mainnet
 	if conf.Vtchost != "" {
 		p := &coinparam.VertcoinParams

--- a/lit.go
+++ b/lit.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -86,6 +87,21 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *config) error {
 		}
 	}
 	// try testnet3
+	if conf.Tn3host == "auto" || conf.Tn3host == "1" || conf.Tn3host == "true" {
+		fmt.Println("Auto option selected with testnet3")
+		for i := 0; i < len(coinparam.TestNet3Params.DNSSeeds); i++ {
+			addrs, err := net.LookupHost(coinparam.TestNet3Params.DNSSeeds[i])
+			if err != nil {
+				fmt.Println("Connecting to default testnet3 node failed. Trying again")
+				if i == len(coinparam.TestNet3Params.DNSSeeds)-1 {
+					fmt.Println("Connecting to all default testnet3 nodes failed. Please try again")
+					fmt.Println(addrs)
+					return err
+				}
+			}
+			conf.Tn3host = coinparam.TestNet3Params.DNSSeeds[i]
+		}
+	}
 	if conf.Tn3host != "" {
 		p := &coinparam.TestNet3Params
 		if !strings.Contains(conf.Tn3host, ":") {
@@ -109,8 +125,23 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *config) error {
 			return err
 		}
 	}
-
 	// try litecoin testnet4
+	if conf.Lt4host == "auto" || conf.Lt4host == "1" || conf.Lt4host == "true" {
+		fmt.Println("Auto option selected with litecoin")
+		for i := 0; i < len(coinparam.LiteCoinTestNet4Params.DNSSeeds); i++ {
+			addrs, err := net.LookupHost(coinparam.LiteCoinTestNet4Params.DNSSeeds[i])
+			if err != nil {
+				fmt.Println("Connecting to default lt4 node failed. Trying again")
+				if i == len(coinparam.LiteCoinTestNet4Params.DNSSeeds)-1 {
+					fmt.Println("Connecting to all default lt4 nodes failed. Please try again")
+					fmt.Println(addrs)
+					return err
+				}
+			}
+			conf.Lt4host = coinparam.LiteCoinTestNet4Params.DNSSeeds[i]
+		}
+	}
+
 	if conf.Lt4host != "" {
 		p := &coinparam.LiteCoinTestNet4Params
 		if !strings.Contains(conf.Lt4host, ":") {
@@ -124,6 +155,22 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *config) error {
 		}
 	}
 	// try vertcoin testnet
+	if conf.Tvtchost == "auto" || conf.Tvtchost == "1" || conf.Tvtchost == "true" {
+		fmt.Println("Auto option selected with testnet vertcoin")
+		for i := 0; i < len(coinparam.VertcoinTestNetParams.DNSSeeds); i++ {
+			addrs, err := net.LookupHost(coinparam.VertcoinTestNetParams.DNSSeeds[i])
+			if err != nil {
+				fmt.Println("Connecting to default test vtc node failed. Trying again")
+				if i == len(coinparam.VertcoinTestNetParams.DNSSeeds)-1 {
+					fmt.Println("Connecting to all default test vtc nodes failed. Please try again")
+					fmt.Println(addrs)
+					return err
+				}
+			}
+			conf.Tvtchost = coinparam.VertcoinTestNetParams.DNSSeeds[i]
+		}
+	}
+
 	if conf.Tvtchost != "" {
 		p := &coinparam.VertcoinTestNetParams
 		if !strings.Contains(conf.Tvtchost, ":") {
@@ -136,7 +183,24 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *config) error {
 			return err
 		}
 	}
+
 	// try vertcoin mainnet
+	if conf.Vtchost == "auto" || conf.Vtchost == "1" || conf.Vtchost == "1" {
+		fmt.Println("Auto option selected with Vertcoin")
+		for i := 0; i < len(coinparam.VertcoinParams.DNSSeeds); i++ {
+			addrs, err := net.LookupHost(coinparam.VertcoinParams.DNSSeeds[i])
+			if err != nil {
+				fmt.Println("Connecting to default vtc node failed. Trying again")
+				if i == len(coinparam.VertcoinParams.DNSSeeds)-1 {
+					fmt.Println("Connecting to all default vtc nodes failed. Please try again")
+					fmt.Println(addrs)
+					return err
+				}
+			}
+			conf.Vtchost = coinparam.VertcoinParams.DNSSeeds[i]
+		}
+	}
+
 	if conf.Vtchost != "" {
 		p := &coinparam.VertcoinParams
 		if !strings.Contains(conf.Vtchost, ":") {

--- a/lit.go
+++ b/lit.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -86,22 +85,6 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *config) error {
 			return err
 		}
 	}
-	// try testnet3
-	if conf.Tn3host == "auto" || conf.Tn3host == "1" || conf.Tn3host == "true" {
-		fmt.Println("Auto option selected with testnet3")
-		for i := 0; i < len(coinparam.TestNet3Params.DNSSeeds); i++ {
-			addrs, err := net.LookupHost(coinparam.TestNet3Params.DNSSeeds[i])
-			if err != nil {
-				fmt.Println("Connecting to default testnet3 node failed. Trying again")
-				if i == len(coinparam.TestNet3Params.DNSSeeds)-1 {
-					fmt.Println("Connecting to all default testnet3 nodes failed. Please try again")
-					fmt.Println(addrs)
-					return err
-				}
-			}
-			conf.Tn3host = coinparam.TestNet3Params.DNSSeeds[i]
-		}
-	}
 	if conf.Tn3host != "" {
 		p := &coinparam.TestNet3Params
 		if !strings.Contains(conf.Tn3host, ":") {
@@ -125,23 +108,7 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *config) error {
 			return err
 		}
 	}
-	// try litecoin testnet4
-	if conf.Lt4host == "auto" || conf.Lt4host == "1" || conf.Lt4host == "true" {
-		fmt.Println("Auto option selected with litecoin")
-		for i := 0; i < len(coinparam.LiteCoinTestNet4Params.DNSSeeds); i++ {
-			addrs, err := net.LookupHost(coinparam.LiteCoinTestNet4Params.DNSSeeds[i])
-			if err != nil {
-				fmt.Println("Connecting to default lt4 node failed. Trying again")
-				if i == len(coinparam.LiteCoinTestNet4Params.DNSSeeds)-1 {
-					fmt.Println("Connecting to all default lt4 nodes failed. Please try again")
-					fmt.Println(addrs)
-					return err
-				}
-			}
-			conf.Lt4host = coinparam.LiteCoinTestNet4Params.DNSSeeds[i]
-		}
-	}
-
+	// try litecoin tn4
 	if conf.Lt4host != "" {
 		p := &coinparam.LiteCoinTestNet4Params
 		if !strings.Contains(conf.Lt4host, ":") {
@@ -155,22 +122,6 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *config) error {
 		}
 	}
 	// try vertcoin testnet
-	if conf.Tvtchost == "auto" || conf.Tvtchost == "1" || conf.Tvtchost == "true" {
-		fmt.Println("Auto option selected with testnet vertcoin")
-		for i := 0; i < len(coinparam.VertcoinTestNetParams.DNSSeeds); i++ {
-			addrs, err := net.LookupHost(coinparam.VertcoinTestNetParams.DNSSeeds[i])
-			if err != nil {
-				fmt.Println("Connecting to default test vtc node failed. Trying again")
-				if i == len(coinparam.VertcoinTestNetParams.DNSSeeds)-1 {
-					fmt.Println("Connecting to all default test vtc nodes failed. Please try again")
-					fmt.Println(addrs)
-					return err
-				}
-			}
-			conf.Tvtchost = coinparam.VertcoinTestNetParams.DNSSeeds[i]
-		}
-	}
-
 	if conf.Tvtchost != "" {
 		p := &coinparam.VertcoinTestNetParams
 		if !strings.Contains(conf.Tvtchost, ":") {
@@ -185,22 +136,6 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *config) error {
 	}
 
 	// try vertcoin mainnet
-	if conf.Vtchost == "auto" || conf.Vtchost == "1" || conf.Vtchost == "1" {
-		fmt.Println("Auto option selected with Vertcoin")
-		for i := 0; i < len(coinparam.VertcoinParams.DNSSeeds); i++ {
-			addrs, err := net.LookupHost(coinparam.VertcoinParams.DNSSeeds[i])
-			if err != nil {
-				fmt.Println("Connecting to default vtc node failed. Trying again")
-				if i == len(coinparam.VertcoinParams.DNSSeeds)-1 {
-					fmt.Println("Connecting to all default vtc nodes failed. Please try again")
-					fmt.Println(addrs)
-					return err
-				}
-			}
-			conf.Vtchost = coinparam.VertcoinParams.DNSSeeds[i]
-		}
-	}
-
 	if conf.Vtchost != "" {
 		p := &coinparam.VertcoinParams
 		if !strings.Contains(conf.Vtchost, ":") {

--- a/lit.go
+++ b/lit.go
@@ -109,6 +109,7 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *config) error {
 			return err
 		}
 	}
+	
 	// try litecoin testnet4
 	if conf.Lt4host != "" {
 		p := &coinparam.LiteCoinTestNet4Params

--- a/uspv/chainhook.go
+++ b/uspv/chainhook.go
@@ -105,6 +105,7 @@ func (s *SPVCon) Start(
 	s.CurrentHeightChan = make(chan int32, 1)
 
 	s.syncHeight = startHeight
+	s.nodeFile = filepath.Join(path, "peers.json")
 
 	headerFilePath := filepath.Join(path, "header.bin")
 	// open header file
@@ -116,6 +117,12 @@ func (s *SPVCon) Start(
 	err = s.Connect(host)
 	if err != nil {
 		log.Printf("Can't connect to host %s\n", host)
+		return nil, nil, err
+	}
+
+	err = s.AskForNodes()
+	if err != nil{
+		log.Printf("Can't ask for nodes. Sorry")
 		return nil, nil, err
 	}
 

--- a/uspv/eight333.go
+++ b/uspv/eight333.go
@@ -328,6 +328,14 @@ func (s *SPVCon) AskForHeaders() error {
 	return nil
 }
 
+// AskForNodes asks for the list of connected peers from a remote node.
+// This should then result in istuff being tored in the peers.json file
+func (s *SPVCon) AskForNodes() error {
+	message := wire.NewMsgGetAddr()
+	s.outMsgQueue <- message
+	return nil
+}
+
 // AskForMerkBlocks requests blocks from current to last
 // right now this asks for 1 block per getData message.
 // Maybe it's faster to ask for many in a each message?

--- a/uspv/eight333.go
+++ b/uspv/eight333.go
@@ -136,8 +136,6 @@ func (s *SPVCon) AskForTx(txid chainhash.Hash) {
 	//	}
 	gdata.AddInvVect(inv)
 	log.Printf("asking for tx %s\n", txid.String())
-	s.outMsgQueue <- wire.NewMsgGetAddr() // get list of all peers connected to the remote node
-	log.Printf("Ask for silver!!")
 	s.outMsgQueue <- gdata
 }
 

--- a/uspv/eight333.go
+++ b/uspv/eight333.go
@@ -136,6 +136,8 @@ func (s *SPVCon) AskForTx(txid chainhash.Hash) {
 	//	}
 	gdata.AddInvVect(inv)
 	log.Printf("asking for tx %s\n", txid.String())
+	s.outMsgQueue <- wire.NewMsgGetAddr() // get list of all peers connected to the remote node
+	log.Printf("Ask for silver!!")
 	s.outMsgQueue <- gdata
 }
 

--- a/uspv/eight333.go
+++ b/uspv/eight333.go
@@ -136,6 +136,7 @@ func (s *SPVCon) AskForTx(txid chainhash.Hash) {
 	//	}
 	gdata.AddInvVect(inv)
 	log.Printf("asking for tx %s\n", txid.String())
+	// s.outMsgQueue <- wire.NewMsgGetAddr() // get list of all peers connected to the remote node
 	s.outMsgQueue <- gdata
 }
 

--- a/uspv/init.go
+++ b/uspv/init.go
@@ -13,6 +13,19 @@ import (
 // Connect dials out and connects to full nodes.
 func (s *SPVCon) Connect(remoteNode string) error {
 	var err error
+	if len(s.Param.DNSSeeds) != 0 {
+		if remoteNode[:4] == "auto" {
+			addrs, err := net.LookupHost(s.Param.DNSSeeds[0])
+			if err != nil {
+				log.Println("Fatal Error while connecting to remote node. Exiting.")
+			}
+			remoteNode = addrs[0] + ":" + s.Param.DefaultPort
+			log.Println(remoteNode)
+		}
+		log.Println(s.Param)
+	} else {
+		log.Println("There are no default nodes for the mode you specified")
+	}
 	// open TCP connection
 	s.con, err = net.Dial("tcp", remoteNode)
 	if err != nil {

--- a/uspv/init.go
+++ b/uspv/init.go
@@ -37,13 +37,11 @@ func GetNodes(s *SPVCon) []wire.NetAddress {
 
 // Connect dials out and connects to full nodes.
 func (s *SPVCon) Connect(remoteNode string) error {
-	log.Println("Keep an eye out for this")
 	log.Println(s.nodeFile)
-	log.Println("END")
 	var err error
 	flag := 0
 	if len(s.Param.DNSSeeds) != 0 {
-		if remoteNode[:4] == "auto" {
+		if remoteNode[:4] == "auto" || (remoteNode[:1] == "1" && len(remoteNode) == 7) {
 			if _, errNotExists := os.Stat(s.nodeFile); os.IsNotExist(errNotExists) {
 				log.Println("Peers file doesn't exist") // set flag to 1 sicne peers doesn't exist
 			} else {

--- a/uspv/init.go
+++ b/uspv/init.go
@@ -20,9 +20,7 @@ func (s *SPVCon) Connect(remoteNode string) error {
 				log.Println("Fatal Error while connecting to remote node. Exiting.")
 			}
 			remoteNode = addrs[0] + ":" + s.Param.DefaultPort
-			log.Println(remoteNode)
 		}
-		log.Println(s.Param)
 	} else {
 		log.Println("There are no default nodes for the mode you specified")
 	}

--- a/uspv/init.go
+++ b/uspv/init.go
@@ -11,7 +11,20 @@ import (
 	"strconv"
 )
 
-func getNodes(s *SPVCon) []wire.NetAddress {
+func CreateFile(s *SPVCon) error{
+	if _, err := os.Stat(s.nodeFile); os.IsNotExist(err) {
+		os.Mkdir("./peers", 0700)
+		crfile, err := os.Create(s.nodeFile)
+		crfile.Close()
+		if err != nil {
+			log.Println("File creation error. Exiting")
+			return err
+		}
+		return nil
+	}
+	return nil
+}
+func GetNodes(s *SPVCon) []wire.NetAddress {
 	addresses := make([]wire.NetAddress, 3)
 	raw, err := ioutil.ReadFile(s.nodeFile)
 	if err != nil {
@@ -34,7 +47,7 @@ func (s *SPVCon) Connect(remoteNode string) error {
 			if _, errNotExists := os.Stat(s.nodeFile); os.IsNotExist(errNotExists) {
 				log.Println("Peers file doesn't exist") // set flag to 1 sicne peers doesn't exist
 			} else {
-				readvalues := getNodes(s)
+				readvalues := GetNodes(s)
 				log.Println(readvalues)
 				for _, ve := range readvalues {
 					// do what we want with the IPs, which is to try connecting to them.

--- a/uspv/init.go
+++ b/uspv/init.go
@@ -11,9 +11,9 @@ import (
 	"strconv"
 )
 
-func getNodes() []wire.NetAddress {
+func getNodes(s *SPVCon) []wire.NetAddress {
 	addresses := make([]wire.NetAddress, 3)
-	raw, err := ioutil.ReadFile("./peers/peers.json")
+	raw, err := ioutil.ReadFile(s.nodeFile)
 	if err != nil {
 		log.Println(err.Error())
 		return nil
@@ -24,14 +24,17 @@ func getNodes() []wire.NetAddress {
 
 // Connect dials out and connects to full nodes.
 func (s *SPVCon) Connect(remoteNode string) error {
+	log.Println("Keep an eye out for this")
+	log.Println(s.nodeFile)
+	log.Println("END")
 	var err error
 	flag := 0
 	if len(s.Param.DNSSeeds) != 0 {
 		if remoteNode[:4] == "auto" {
-			if _, errNotExists := os.Stat("./peers/peers.json"); os.IsNotExist(errNotExists) {
+			if _, errNotExists := os.Stat(s.nodeFile); os.IsNotExist(errNotExists) {
 				log.Println("Peers file doesn't exist") // set flag to 1 sicne peers doesn't exist
 			} else {
-				readvalues := getNodes()
+				readvalues := getNodes(s)
 				log.Println(readvalues)
 				for _, ve := range readvalues {
 					// do what we want with the IPs, which is to try connecting to them.

--- a/uspv/init.go
+++ b/uspv/init.go
@@ -114,18 +114,18 @@ func (s *SPVCon) openHeaderFile(hfn string) error {
 		if os.IsNotExist(err) {
 			var b bytes.Buffer
 			// if StartHeader is defined, start with hardcoded height
-            if s.Param.StartHeight != 0 {
-              hdr := s.Param.StartHeader
-	          _, err := b.Write(hdr[:])
-	          if err != nil {
-	           return err
-	          }
-            } else {
-	            err = s.Param.GenesisBlock.Header.Serialize(&b)
-	            if err != nil {
-		            return err
-	            }
-            }
+			if s.Param.StartHeight != 0 {
+				hdr := s.Param.StartHeader
+				_, err := b.Write(hdr[:])
+				if err != nil {
+					return err
+				}
+			} else {
+				err = s.Param.GenesisBlock.Header.Serialize(&b)
+				if err != nil {
+					return err
+				}
+			}
 			err = ioutil.WriteFile(hfn, b.Bytes(), 0600)
 			if err != nil {
 				return err
@@ -135,10 +135,10 @@ func (s *SPVCon) openHeaderFile(hfn string) error {
 			log.Printf("created hardcoded genesis header at %s\n", hfn)
 		}
 	}
-  
-    if s.Param.StartHeight != 0 {
-        s.headerStartHeight = s.Param.StartHeight
-    }
+
+	if s.Param.StartHeight != 0 {
+		s.headerStartHeight = s.Param.StartHeight
+	}
 
 	s.headerFile, err = os.OpenFile(hfn, os.O_RDWR, 0600)
 	if err != nil {

--- a/uspv/msghandler.go
+++ b/uspv/msghandler.go
@@ -1,10 +1,13 @@
 package uspv
 
 import (
-	"log"
+	"encoding/json"
 	"github.com/adiabat/btcd/wire"
 	"github.com/adiabat/btcutil/bloom"
 	"github.com/mit-dci/lit/lnutil"
+	"log"
+	"os"
+	"time"
 )
 
 func (s *SPVCon) incomingMessageHandler() {
@@ -29,10 +32,116 @@ func (s *SPVCon) incomingMessageHandler() {
 			// read this info and store somewhere.
 		case *wire.MsgAddr:
 			log.Printf("got %d addresses.\n", len(m.AddrList))
+			readvalues := getNodes()
+			log.Println(readvalues)
+
+			flag := 0
+			var ips [100]string
+			var ports [100]int
+			var ve [150]wire.NetAddress
+			for i, vals := range readvalues {
+				// do what we want with the IPs, which is to try connecting to them.
+				ve[i] = vals
+				ips[i] = vals.IP.String()
+				ports[i] = int(vals.Port)
+			}
+			log.Println(ve) // ve has all the addressses read from the file. We just have to create a new file if needed.
 			log.Printf("start ip list")
+			var a wire.NetAddress // limit to 125 like bitcoind?
 			// refer https://github.com/btcsuite/btcd/blob/master/wire/netaddress.go for *wire.NetAddr struct
-			for i:=0 ; i<len(m.AddrList); i++ {
-				log.Println(m.AddrList[i].IP)
+			for i, addresses := range m.AddrList {
+				log.Printf("IP: %s", addresses.IP)
+				now := time.Now()
+				if addresses.Timestamp.After(now.Add(time.Minute * 10)) {
+					addresses.Timestamp = now.Add(-1 * time.Hour * 24 * 5)
+				}
+				log.Printf("Timestamp: %s", addresses.Timestamp)
+				a.IP = addresses.IP
+				a.Port = addresses.Port
+				for _, addr := range ips { // for a list of all IPs in the file
+					if addr == "<nil>" { // if its nil, stop execution
+						flag = 0
+						break
+					}
+					if addr == a.IP.String() { // is the address is already present in the file, ignore
+						for _, port := range ports { // if we are connecting to the same host with a different port, we should still save it
+							if port == int(a.Port) {
+								flag = 1
+								break
+							}
+						}
+						if flag == 1 {
+							break
+						}
+					}
+				}
+				// log.Println("The elusive flag")
+				// log.Println(flag)
+				if flag != 1 {
+					//log.Println("This should get executed in case we can't load the ips from the file")
+					a.Timestamp = addresses.Timestamp
+					a.Services = addresses.Services
+
+					// attach a to ve
+					ve[99+i] = a
+					for j, values := range ve {
+
+						dest, err := json.Marshal(values)
+						if err != nil {
+							log.Println("Converting to a JSON object failed")
+						}
+						if j == 0 {
+							errdel := os.Remove("./dnsseeds/seeds.json")
+							crfile, errcreate := os.Create("./dnsseeds/seeds.json")
+							if errdel != nil {
+								log.Println("File doesn't exist or is deleted already. Continuing")
+							}
+							if errcreate != nil {
+								log.Println("File creation error. Exiting")
+								break
+							}
+							crfile.Close()
+						}
+						file, err2 := os.OpenFile("./dnsseeds/seeds.json", os.O_APPEND|os.O_WRONLY, 0644)
+						if err2 != nil {
+							log.Println(err2)
+						}
+						// defer file.Close()
+
+						if j == 0 {
+							_, rnd := file.WriteString("[")
+							if rnd != nil {
+								log.Println("Saving starting character failed. Quitting")
+								break
+							}
+						}
+
+						if values.IP.String() != "<nil>" {
+							_, err1 := file.WriteString(string(dest))
+
+							if err1 != nil {
+								log.Println("Appending to a file failed")
+							}
+
+							if j < 99+i {
+								_, err3 := file.WriteString(",\n")
+								if err3 != nil {
+									log.Println("Failed to write Newline")
+								}
+							}
+							if j == 99+i {
+								_, rnd1 := file.WriteString("\n]")
+								if rnd1 != nil {
+									log.Println("Saving ending characters failed. Quitting")
+									break
+								}
+							}
+						}
+					}
+					// log.Println(string(json.Marshal(a[0].IP)))
+				} else {
+					break
+				}
 			}
 			log.Printf("end ip list")
 		case *wire.MsgPing:
@@ -184,7 +293,7 @@ func (s *SPVCon) TxHandler(tx *wire.MsgTx) {
 	//	}
 	//	if len(dubs) > 0 {
 	//		for i, dub := range dubs {
-	//			fmt.Printf("dub %d known tx %s and new tx %s are exclusive!!!\n",
+	//			log.Printf("dub %d known tx %s and new tx %s are exclusive!!!\n",
 	//				i, dub.String(), m.TxSha().String())
 	//		}
 	//	}

--- a/uspv/msghandler.go
+++ b/uspv/msghandler.go
@@ -25,10 +25,13 @@ func (s *SPVCon) incomingMessageHandler() {
 		case *wire.MsgVerAck:
 			log.Printf("Got verack.  Whatever.\n")
 		case *wire.MsgGetAddr: // what case is this?
-			log.Printf("Struck gold, good.")
+			log.Printf("Got getaddr. Do nothing since we aren't a full node.")
 			// read this info and store somewhere.
 		case *wire.MsgAddr:
 			log.Printf("got %d addresses.\n", len(m.AddrList))
+			log.Printf("START OF REMOTE PEERS LIST STRUCTS")
+			log.Println(m.AddrList)
+			log.Printf("END OF REMOTE PEERS LIST STRUCTS")
 		case *wire.MsgPing:
 			// log.Printf("Got a ping message.  We should pong back or they will kick us off.")
 			go s.PongBack(m.Nonce)

--- a/uspv/msghandler.go
+++ b/uspv/msghandler.go
@@ -253,23 +253,23 @@ func (s *SPVCon) InvHandler(m *wire.MsgInv) {
 }
 
 func (s *SPVCon) AddrListHandler(m *wire.MsgAddr) {
-	if _, errNotExists := os.Stat("./peers/peers.json"); os.IsNotExist(errNotExists) {
+	if _, errNotExists := os.Stat(s.nodeFile); os.IsNotExist(errNotExists) {
 		os.Mkdir("./peers", 0700)
-		crfile, errcreate := os.Create("./peers/peers.json")
+		crfile, errcreate := os.Create(s.nodeFile)
 		crfile.Close()
 		if errcreate != nil {
 			log.Println("File creation error. Exiting")
 			return
 		}
 	}
-	readvalues := getNodes()
+	readvalues := getNodes(s)
 	log.Println("Its coming in here")
 	// log.Println(readvalues)
 
 	flag := 0
 	var ips [100]string
 	var ports [100]int
-	var ve [150]wire.NetAddress
+	var ve [1500]wire.NetAddress
 	for i, vals := range readvalues {
 		// do what we want with the IPs, which is to try connecting to them.
 		ve[i] = vals
@@ -322,19 +322,19 @@ func (s *SPVCon) AddrListHandler(m *wire.MsgAddr) {
 					log.Println("Converting to a JSON object failed")
 				}
 				if j == 0 {
-					errdel := os.Remove("./peers/peers.json")
+					errdel := os.Remove(s.nodeFile)
 					if errdel != nil {
 						log.Println("File deletion error. Exiting")
 						break
 					}
-					crfile, errcreate := os.Create("./peers/peers.json")
+					crfile, errcreate := os.Create(s.nodeFile)
 					if errcreate != nil {
 						log.Println("File creation error. Exiting")
 						break
 					}
 					crfile.Close()
 				}
-				file, err2 := os.OpenFile("./peers/peers.json", os.O_APPEND|os.O_WRONLY, 0644)
+				file, err2 := os.OpenFile(s.nodeFile, os.O_APPEND|os.O_WRONLY, 0644)
 				if err2 != nil {
 					log.Println(err2)
 				}
@@ -369,6 +369,7 @@ func (s *SPVCon) AddrListHandler(m *wire.MsgAddr) {
 						}
 					}
 				}
+				file.Close()
 			}
 			// log.Println(string(json.Marshal(a[0].IP)))
 		} else {

--- a/uspv/msghandler.go
+++ b/uspv/msghandler.go
@@ -2,7 +2,6 @@ package uspv
 
 import (
 	"log"
-
 	"github.com/adiabat/btcd/wire"
 	"github.com/adiabat/btcutil/bloom"
 	"github.com/mit-dci/lit/lnutil"
@@ -25,6 +24,9 @@ func (s *SPVCon) incomingMessageHandler() {
 			s.remoteVersion = uint32(m.ProtocolVersion) // weird cast! bug?
 		case *wire.MsgVerAck:
 			log.Printf("Got verack.  Whatever.\n")
+		case *wire.MsgGetAddr: // what case is this?
+			log.Printf("Struck gold, good.")
+			// read this info and store somewhere.
 		case *wire.MsgAddr:
 			log.Printf("got %d addresses.\n", len(m.AddrList))
 		case *wire.MsgPing:

--- a/uspv/msghandler.go
+++ b/uspv/msghandler.go
@@ -29,9 +29,12 @@ func (s *SPVCon) incomingMessageHandler() {
 			// read this info and store somewhere.
 		case *wire.MsgAddr:
 			log.Printf("got %d addresses.\n", len(m.AddrList))
-			log.Printf("START OF REMOTE PEERS LIST STRUCTS")
-			log.Println(m.AddrList)
-			log.Printf("END OF REMOTE PEERS LIST STRUCTS")
+			log.Printf("start ip list")
+			// refer https://github.com/btcsuite/btcd/blob/master/wire/netaddress.go for *wire.NetAddr struct
+			for i:=0 ; i<len(m.AddrList); i++ {
+				log.Println(m.AddrList[i].IP)
+			}
+			log.Printf("end ip list")
 		case *wire.MsgPing:
 			// log.Printf("Got a ping message.  We should pong back or they will kick us off.")
 			go s.PongBack(m.Nonce)

--- a/uspv/spvcon.go
+++ b/uspv/spvcon.go
@@ -21,7 +21,8 @@ type SPVCon struct {
 
 	headerMutex       sync.Mutex
 	headerFile        *os.File // file for SPV headers
-	headerStartHeight int32    // first header on disk is nth header in chain
+	nodeFile          string // remember to change this
+	headerStartHeight int32 // first header on disk is nth header in chain
 
 	syncHeight int32 // internal, in memory synchronization height
 


### PR DESCRIPTION
Kinda basic, but putting out here so that I know that this behaviour is intended. Regarding pinging a remote node for info, I just added a single line one `eight333.go` for now for testing but it looks like I didn't get the switch right with `wire.MsgGetAddr` in `msghandler.go`. Since there are no docs attached for this, all I did was trial and error. Right now, the DNSSeeding stuff is located over at `lit.go` and not `init` in uspv (since not all the chains actually have elements in the dns seeds). I'll move it to a better place to avoid the repeating lines once everything's cool. @adiabat 