### PR TITLE
Implement LN node tracker for IP-less connection

### DIFF
--- a/lit.conf
+++ b/lit.conf
@@ -1,3 +1,3 @@
 ; Use this as a comment. Specify all parameters below similar to those what you would on the CLI
 rpcport=8012
-reg=localhost
+vtc=localhost

--- a/lit.conf
+++ b/lit.conf
@@ -1,3 +1,3 @@
 ; Use this as a comment. Specify all parameters below similar to those what you would on the CLI
-rpcport=8012
-vtc=localhost
+rpcport=8001
+reg=localhost

--- a/lit.go
+++ b/lit.go
@@ -34,6 +34,8 @@ type LitConfig struct {
 	rpcport    uint16
 	litHomeDir string
 
+	trackerURL string
+
 	Params *coinparam.Params
 }
 
@@ -54,6 +56,10 @@ func setConfig(lc *LitConfig) {
 
 	rpcportptr := flag.Int("rpcport", 8001, "port to listen for RPC")
 
+	trackerURL := flag.String("tracker",
+		"http://ni.media.mit.edu:46580",
+		"LN address tracker URL http|https://host:port")
+
 	litHomeDir := flag.String("dir",
 		filepath.Join(os.Getenv("HOME"), litHomeDirName), "lit home directory")
 
@@ -69,6 +75,8 @@ func setConfig(lc *LitConfig) {
 	lc.verbose = *verbptr
 
 	lc.rpcport = uint16(*rpcportptr)
+
+	lc.trackerURL = *trackerURL
 
 	lc.litHomeDir = *litHomeDir
 }
@@ -208,7 +216,7 @@ func main() {
 
 	// Setup LN node.  Activate Tower if in hard mode.
 	// give node and below file pathof lit home directoy
-	node, err := qln.NewLitNode(key, conf.litHomeDir)
+	node, err := qln.NewLitNode(key, conf.litHomeDir, conf.trackerURL)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/lndc/lnadr.go
+++ b/lndc/lnadr.go
@@ -43,14 +43,15 @@ func (l *LNAdr) String() string {
 // pkh part and network part, adding the network part if needed
 func SplitAdrString(adr string) (string, string) {
 
-	if !strings.ContainsRune(adr, '@') {
-		adr += "@localhost:2448"
-	}
-	if !strings.ContainsRune(adr, ':') {
+	if !strings.ContainsRune(adr, ':') && strings.ContainsRune(adr, '@') {
 		adr += ":2448"
 	}
 
 	idHost := strings.Split(adr, "@")
+
+	if len(idHost) == 1 {
+		return idHost[0], ""
+	}
 
 	return idHost[0], idHost[1]
 }

--- a/qln/init.go
+++ b/qln/init.go
@@ -15,7 +15,7 @@ import (
 
 // Init starts up a lit node.  Needs priv key, and a path.
 // Does not activate a subwallet; do that after init.
-func NewLitNode(privKey *[32]byte, path string) (*LitNode, error) {
+func NewLitNode(privKey *[32]byte, path string, trackerURL string) (*LitNode, error) {
 
 	nd := new(LitNode)
 	nd.LitFolder = path
@@ -44,6 +44,8 @@ func NewLitNode(privKey *[32]byte, path string) (*LitNode, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	nd.TrackerURL = trackerURL
 
 	// optional tower activation
 

--- a/qln/lndb.go
+++ b/qln/lndb.go
@@ -121,6 +121,9 @@ type LitNode struct {
 
 	// The port(s) in which it listens for incoming connections
 	LisIpPorts []string
+
+	// The URL from which lit attempts to resolve the LN address
+	TrackerURL string
 }
 
 type RemotePeer struct {

--- a/qln/netio.go
+++ b/qln/netio.go
@@ -41,6 +41,11 @@ func (nd *LitNode) TCPListener(
 
 	adr := lnutil.LitAdrFromPubkey(idPub)
 
+	err = Announce(idPriv, lisIpPort, adr)
+	if err != nil {
+		log.Printf("Announcement error %s", err.Error())
+	}
+
 	fmt.Printf("Listening on %s\n", listener.Addr().String())
 	fmt.Printf("Listening with ln address: %s \n", adr)
 
@@ -96,6 +101,14 @@ func (nd *LitNode) DialPeer(connectAdr string) error {
 	// sanity check the "who" pkh string
 	if !lnutil.LitAdrOK(who) {
 		return fmt.Errorf("ln address %s invalid", who)
+	}
+
+	// If we couldn't deduce a URL, look it up on the tracker
+	if where == "" {
+		where, err = Lookup(who)
+		if err != nil {
+			return err
+		}
 	}
 
 	// get my private ID key

--- a/qln/netio.go
+++ b/qln/netio.go
@@ -41,7 +41,7 @@ func (nd *LitNode) TCPListener(
 
 	adr := lnutil.LitAdrFromPubkey(idPub)
 
-	err = Announce(idPriv, lisIpPort, adr)
+	err = Announce(idPriv, lisIpPort, adr, nd.TrackerURL)
 	if err != nil {
 		log.Printf("Announcement error %s", err.Error())
 	}
@@ -105,7 +105,7 @@ func (nd *LitNode) DialPeer(connectAdr string) error {
 
 	// If we couldn't deduce a URL, look it up on the tracker
 	if where == "" {
-		where, err = Lookup(who)
+		where, err = Lookup(who, nd.TrackerURL)
 		if err != nil {
 			return err
 		}

--- a/qln/tracker.go
+++ b/qln/tracker.go
@@ -21,10 +21,10 @@ type announcement struct {
 }
 
 type nodeinfo struct {
-	success bool
-	node    struct {
-		url  string
-		addr string
+	Success bool
+	Node    struct {
+		Url  string
+		Addr string
 	}
 }
 
@@ -56,7 +56,7 @@ func Announce(priv *btcec.PrivateKey, litport string, litadr string) error {
 	ann.sig = hex.EncodeToString(urlSig.Serialize())
 	ann.pbk = hex.EncodeToString(priv.PubKey().SerializeCompressed())
 
-	_, err = http.PostForm("http://localhost:46580/announce",
+	_, err = http.PostForm("http://jlovejoy.mit.edu:46580/announce",
 		url.Values{"url": {ann.url},
 			"addr": {ann.addr},
 			"sig":  {ann.sig},
@@ -70,7 +70,7 @@ func Announce(priv *btcec.PrivateKey, litport string, litadr string) error {
 }
 
 func Lookup(litadr string) (string, error) {
-	resp, err := http.Get("http://localhost:46580/" + litadr)
+	resp, err := http.Get("http://jlovejoy.mit.edu:46580/" + litadr)
 	if err != nil {
 		return "", err
 	}
@@ -83,9 +83,9 @@ func Lookup(litadr string) (string, error) {
 		return "", err
 	}
 
-	if !node.success {
+	if !node.Success {
 		return "", errors.New("Node not found")
 	}
 
-	return node.node.url, nil
+	return node.Node.Url, nil
 }

--- a/qln/tracker.go
+++ b/qln/tracker.go
@@ -28,7 +28,7 @@ type nodeinfo struct {
 	}
 }
 
-func Announce(priv *btcec.PrivateKey, litport string, litadr string) error {
+func Announce(priv *btcec.PrivateKey, litport string, litadr string, trackerURL string) error {
 	resp, err := http.Get("http://myexternalip.com/raw")
 	if err != nil {
 		return err
@@ -56,7 +56,7 @@ func Announce(priv *btcec.PrivateKey, litport string, litadr string) error {
 	ann.sig = hex.EncodeToString(urlSig.Serialize())
 	ann.pbk = hex.EncodeToString(priv.PubKey().SerializeCompressed())
 
-	_, err = http.PostForm("http://jlovejoy.mit.edu:46580/announce",
+	_, err = http.PostForm(trackerURL+"/announce",
 		url.Values{"url": {ann.url},
 			"addr": {ann.addr},
 			"sig":  {ann.sig},
@@ -69,8 +69,8 @@ func Announce(priv *btcec.PrivateKey, litport string, litadr string) error {
 	return nil
 }
 
-func Lookup(litadr string) (string, error) {
-	resp, err := http.Get("http://jlovejoy.mit.edu:46580/" + litadr)
+func Lookup(litadr string, trackerURL string) (string, error) {
+	resp, err := http.Get(trackerURL + "/" + litadr)
 	if err != nil {
 		return "", err
 	}

--- a/qln/tracker.go
+++ b/qln/tracker.go
@@ -1,0 +1,91 @@
+package qln
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/adiabat/btcd/btcec"
+)
+
+type announcement struct {
+	url  string
+	addr string
+	sig  string
+	pbk  string
+}
+
+type nodeinfo struct {
+	success bool
+	node    struct {
+		url  string
+		addr string
+	}
+}
+
+func Announce(priv *btcec.PrivateKey, litport string, litadr string) error {
+	resp, err := http.Get("http://myexternalip.com/raw")
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(resp.Body)
+
+	liturl := strings.TrimSpace(buf.String()) + litport
+
+	urlBytes := []byte(liturl)
+
+	urlHash := sha256.Sum256(urlBytes)
+
+	urlSig, err := priv.Sign(urlHash[:])
+	if err != nil {
+		return err
+	}
+
+	var ann announcement
+
+	ann.url = liturl
+	ann.addr = litadr
+	ann.sig = hex.EncodeToString(urlSig.Serialize())
+	ann.pbk = hex.EncodeToString(priv.PubKey().SerializeCompressed())
+
+	_, err = http.PostForm("http://localhost:46580/announce",
+		url.Values{"url": {ann.url},
+			"addr": {ann.addr},
+			"sig":  {ann.sig},
+			"pbk":  {ann.pbk}})
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func Lookup(litadr string) (string, error) {
+	resp, err := http.Get("http://localhost:46580/" + litadr)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	decoder := json.NewDecoder(resp.Body)
+	var node nodeinfo
+	err = decoder.Decode(&node)
+	if err != nil {
+		return "", err
+	}
+
+	if !node.success {
+		return "", errors.New("Node not found")
+	}
+
+	return node.node.url, nil
+}


### PR DESCRIPTION
Uses this simple node.js script (https://github.com/metalicjames/lit-tracker) to announce its LN address and IP signed by its public key. The server can be configured using the `tracker` option in the config file.