### PR TITLE
Cleanup lit.go

### DIFF
--- a/lit.go
+++ b/lit.go
@@ -176,7 +176,7 @@ func main() {
 	if _, err := os.Stat(filepath.Join(filepath.Join(preconf.LitHomeDir), "lit.conf")); os.IsNotExist(err) {
 		// if there is no config file found over at the directory, create one
 		if err != nil {
-			log.Fatal(err)
+			log.Println(err)
 		}
 		log.Println("Creating a new config file")
 		err := createDefaultConfigFile(filepath.Join(preconf.LitHomeDir)) // Source of error


### PR DESCRIPTION
1. --help no longer prints twice
Remove fmt. statements and use log. wherever appropriate
Incorrect args now show "Use ./lit -h to show usage"

2. Creating a config file at new home directories does not require a sample lit.conf