### PR TITLE
Dockerized LIT for easy portability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:alpine
+
+RUN apk update && apk upgrade && \
+    apk add --no-cache bash git openssh gcc musl-dev
+ENV GOROOT=/usr/local/go
+RUN go get github.com/mit-dci/lit
+RUN go get github.com/mit-dci/lit/cmd/lit-af
+RUN rm -rf /usr/local/go/src/github.com/mit-dci/lit
+COPY . /usr/local/go/src/github.com/mit-dci/lit
+WORKDIR /usr/local/go/src/github.com/mit-dci/lit
+RUN go build
+WORKDIR /usr/local/go/src/github.com/mit-dci/lit/cmd/lit-af
+RUN go build
+EXPOSE 8001
+ENTRYPOINT ["/usr/local/go/src/github.com/mit-dci/lit/lit"]


### PR DESCRIPTION
I built a Dockerfile to be able to run LIT as a docker container. Not sure if this is something you guys see use for, but it makes it quite easy to run the LIT daemon on server/embedded Linux environments that are able to use docker.

What it currently does is it runs go get on the original repo to get the prerequisites and then copies in the source code files from the working directory. You could remove lines 8 and 9 to simply have it build a container out of the active master branch.