### PR TITLE
Remove lit.conf since we auto generate conf file

### DIFF
--- a/lit.conf
+++ b/lit.conf
@@ -1,3 +1,0 @@
-; Use this as a comment. Specify all parameters below similar to those what you would on the CLI
-rpcport=8001
-reg=localhost


### PR DESCRIPTION
Since we now handle conf stuff in lit.go, doesn't make sense to have this hanging around.