### PR TITLE
utxo import / export

### DIFF
--- a/cmd/lit-af/chancmds.go
+++ b/cmd/lit-af/chancmds.go
@@ -201,35 +201,3 @@ func (lc *litAfClient) Push(textArgs []string) error {
 
 	return nil
 }
-
-func (lc *litAfClient) Dump(textArgs []string) error {
-	pReply := new(litrpc.DumpReply)
-	pArgs := new(litrpc.NoArgs)
-
-	err := lc.rpccon.Call("LitRPC.DumpPrivs", pArgs, pReply)
-	if err != nil {
-		return err
-	}
-	fmt.Fprintf(color.Output, "Private keys for all channels and utxos:\n")
-
-	// Display DumpPriv info
-	for i, t := range pReply.Privs {
-		fmt.Fprintf(color.Output, "%d %s h:%d amt:%s %s ",
-			i, lnutil.OutPoint(t.OutPoint), t.Height,
-			lnutil.SatoshiColor(t.Amt), t.CoinType)
-		if t.Delay != 0 {
-			fmt.Fprintf(color.Output, " delay: %d", t.Delay)
-		}
-		if !t.Witty {
-			fmt.Fprintf(color.Output, " non-witness")
-		}
-		if len(t.PairKey) > 1 {
-			fmt.Fprintf(
-				color.Output, "\nPair Pubkey: %s", lnutil.Green(t.PairKey))
-		}
-		fmt.Fprintf(color.Output, "\n\tprivkey: %s", lnutil.Red(t.WIF))
-		fmt.Fprintf(color.Output, "\n")
-	}
-
-	return nil
-}

--- a/cmd/lit-af/shell.go
+++ b/cmd/lit-af/shell.go
@@ -165,10 +165,10 @@ func (lc *litAfClient) Shellparse(cmdslice []string) error {
 		}
 		return nil
 	}
-	if cmd == "dump" { // dump all private keys
-		err = lc.Dump(args)
+	if cmd == "dump" { // dump all private keys in utxo form
+		err = lc.DumpPriv(args)
 		if err != nil {
-			fmt.Fprintf(color.Output, "dump error: %s\n", err)
+			fmt.Fprintf(color.Output, "dumppriv error: %s\n", err)
 		}
 		return nil
 	}
@@ -176,6 +176,13 @@ func (lc *litAfClient) Shellparse(cmdslice []string) error {
 		err = lc.RawTx(args)
 		if err != nil {
 			fmt.Fprintf(color.Output, "rawtx error: %s\n", err)
+		}
+		return nil
+	}
+	if cmd == "import" { // import utxo
+		err = lc.ImporTxo(args)
+		if err != nil {
+			fmt.Fprintf(color.Output, "import error: %s\n", err)
 		}
 		return nil
 	}

--- a/cmd/lit-af/shell.go
+++ b/cmd/lit-af/shell.go
@@ -172,6 +172,13 @@ func (lc *litAfClient) Shellparse(cmdslice []string) error {
 		}
 		return nil
 	}
+	if cmd == "rawtx" { // send raw transaction
+		err = lc.RawTx(args)
+		if err != nil {
+			fmt.Fprintf(color.Output, "rawtx error: %s\n", err)
+		}
+		return nil
+	}
 
 	fmt.Fprintf(color.Output, "Command not recognized. type help for command list.\n")
 	return nil

--- a/cmd/lit-af/walletcmds.go
+++ b/cmd/lit-af/walletcmds.go
@@ -296,3 +296,27 @@ func (lc *litAfClient) Address(textArgs []string) error {
 	return nil
 
 }
+
+// ------------------ send raw tx
+func (lc *litAfClient) RawTx(textArgs []string) error {
+	args := new(litrpc.RawArgs)
+	reply := new(litrpc.TxidsReply)
+
+	// there is at least 1 argument; that should be the new fee rate
+	if len(textArgs) == 0 {
+		return fmt.Errorf("raw needs a hex string")
+	}
+
+	args.TxHex = textArgs[0]
+
+	err := lc.rpccon.Call("LitRPC.PushRawTx", args, reply)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(color.Output, "sent txid(s):\n")
+	for i, t := range reply.Txids {
+		fmt.Fprintf(color.Output, "\t%d %s\n", i, t)
+	}
+	return nil
+}

--- a/cmd/lit-af/walletcmds.go
+++ b/cmd/lit-af/walletcmds.go
@@ -320,3 +320,24 @@ func (lc *litAfClient) RawTx(textArgs []string) error {
 	}
 	return nil
 }
+
+// ------------------ imporTxo
+func (lc *litAfClient) ImporTxo(textArgs []string) error {
+	args := new(litrpc.RawArgs)
+	reply := new(litrpc.StatusReply)
+
+	// there is at least 1 argument; that should be the new fee rate
+	if len(textArgs) == 0 {
+		return fmt.Errorf("ImporTxo needs a hex string")
+	}
+
+	args.TxHex = textArgs[0]
+
+	err := lc.rpccon.Call("LitRPC.ImporTxo", args, reply)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(color.Output, "imported utxo:\n\t%s\n", reply.Status)
+	return nil
+}

--- a/cmd/lit-af/walletcmds.go
+++ b/cmd/lit-af/walletcmds.go
@@ -341,3 +341,55 @@ func (lc *litAfClient) ImporTxo(textArgs []string) error {
 	fmt.Fprintf(color.Output, "imported utxo:\n\t%s\n", reply.Status)
 	return nil
 }
+
+// DumpPriv exports all utxos with private keys
+func (lc *litAfClient) DumpPriv(textArgs []string) error {
+
+	args := new(litrpc.NoArgs)
+	// not actually txids, just a slice of strings...
+	reply := new(litrpc.TxidsReply)
+
+	err := lc.rpccon.Call("LitRPC.DumpPriv", args, reply)
+	if err != nil {
+		return err
+	}
+
+	for i, txoString := range reply.Txids {
+		fmt.Printf("\tutxo %d: %s\n", i, txoString)
+	}
+
+	return nil
+}
+
+// Dump is deprecated... should add options to dumppriv to allow wifs
+func (lc *litAfClient) DumpOld(textArgs []string) error {
+	pReply := new(litrpc.DumpReply)
+	pArgs := new(litrpc.NoArgs)
+
+	err := lc.rpccon.Call("LitRPC.DumpPrivs", pArgs, pReply)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(color.Output, "Private keys for all channels and utxos:\n")
+
+	// Display DumpPriv info
+	for i, t := range pReply.Privs {
+		fmt.Fprintf(color.Output, "%d %s h:%d amt:%s %s ",
+			i, lnutil.OutPoint(t.OutPoint), t.Height,
+			lnutil.SatoshiColor(t.Amt), t.CoinType)
+		if t.Delay != 0 {
+			fmt.Fprintf(color.Output, " delay: %d", t.Delay)
+		}
+		if !t.Witty {
+			fmt.Fprintf(color.Output, " non-witness")
+		}
+		if len(t.PairKey) > 1 {
+			fmt.Fprintf(
+				color.Output, "\nPair Pubkey: %s", lnutil.Green(t.PairKey))
+		}
+		fmt.Fprintf(color.Output, "\n\tprivkey: %s", lnutil.Red(t.WIF))
+		fmt.Fprintf(color.Output, "\n")
+	}
+
+	return nil
+}

--- a/litrpc/walletcmds.go
+++ b/litrpc/walletcmds.go
@@ -230,6 +230,40 @@ func (r *LitRPC) PushRawTx(args RawArgs, reply *TxidsReply) error {
 	return nil
 }
 
+// ImporTxo lets you import a portxo
+func (r *LitRPC) ImporTxo(args RawArgs, reply *StatusReply) error {
+	var err error
+
+	ptxoBytes, err := hex.DecodeString(args.TxHex)
+	if err != nil {
+		return err
+	}
+
+	ptx, err := portxo.PorTxoFromBytes(ptxoBytes)
+	if err != nil {
+		return err
+	}
+
+	// import to default wallet
+	// imports probably won't have a derivation path so we can't tell
+	// what the coin is.  But maybe we shoud detect that, and add cointype
+	// derivation paths even if there's nothing to derive from...
+	wal, ok := r.Node.SubWallet[r.Node.DefaultCoin]
+	if !ok {
+		return fmt.Errorf("no connnected wallet for default cointype %d",
+			r.Node.DefaultCoin)
+	}
+
+	log.Printf("import to raw wallet type %s\n", wal.Params().Name)
+	err = wal.PushTx(tx)
+	if err != nil {
+		return err
+	}
+
+	reply.Txids = []string{tx.TxHash().String()}
+	return nil
+}
+
 // ------------------------- sweep
 type SweepArgs struct {
 	DestAdr string

--- a/litrpc/walletcmds.go
+++ b/litrpc/walletcmds.go
@@ -1,7 +1,10 @@
 package litrpc
 
 import (
+	"bytes"
+	"encoding/hex"
 	"fmt"
+	"log"
 
 	"github.com/adiabat/bech32"
 	"github.com/adiabat/btcd/wire"
@@ -187,6 +190,43 @@ func (r *LitRPC) Send(args SendArgs, reply *TxidsReply) error {
 	}
 
 	reply.Txids = append(reply.Txids, ops[0].Hash.String())
+	return nil
+}
+
+// ------------------------- raw tx
+type RawArgs struct {
+	TxHex string
+}
+
+// PushRawTx takes some raw hex, turns it into a tx and tries to
+// push it out to the network, without any idea of what it is.
+func (r *LitRPC) PushRawTx(args RawArgs, reply *TxidsReply) error {
+	var err error
+
+	txBytes, err := hex.DecodeString(args.TxHex)
+	if err != nil {
+		return err
+	}
+
+	buf := bytes.NewBuffer(txBytes)
+	tx := wire.NewMsgTx()
+	err = tx.Deserialize(buf)
+	if err != nil {
+		return err
+	}
+	// just broadcast to default wallet
+	wal, ok := r.Node.SubWallet[r.Node.DefaultCoin]
+	if !ok {
+		return fmt.Errorf("no connnected wallet for default cointype %d",
+			r.Node.DefaultCoin)
+	}
+	log.Printf("push raw wallet type %s\n", wal.Params().Name)
+	err = wal.PushTx(tx)
+	if err != nil {
+		return err
+	}
+
+	reply.Txids = []string{tx.TxHash().String()}
 	return nil
 }
 

--- a/litrpc/walletcmds.go
+++ b/litrpc/walletcmds.go
@@ -254,13 +254,33 @@ func (r *LitRPC) ImporTxo(args RawArgs, reply *StatusReply) error {
 			r.Node.DefaultCoin)
 	}
 
-	log.Printf("import to raw wallet type %s\n", wal.Params().Name)
-	err = wal.PushTx(tx)
-	if err != nil {
-		return err
+	// no errors here, just hope it works...?
+	wal.ExportUtxo(ptx)
+
+	log.Printf("import %s to wallet %s\n", ptx.Op.String(), wal.Params().Name)
+
+	reply.Status = ptx.Op.String()
+	return nil
+}
+
+// DumpPriv returns a list of all portxos.
+// currently comes with empty derivation paths and populated private keys,
+// so watch out!
+// TODO: add options to give derivation paths and no keys
+func (r *LitRPC) DumpPriv(args NoArgs, reply *TxidsReply) error {
+
+	var allTxos []*portxo.PorTxo
+	// start off the same as TxoList
+	// TODO make this a separate function? because copy/paste...
+	for _, wal := range r.Node.SubWallet {
+		walTxos, err := wal.UtxoDump()
+		if err != nil {
+			return err
+		}
+		allTxos = append(allTxos, walTxos...)
 	}
 
-	reply.Txids = []string{tx.TxHash().String()}
+	//	reply.Txids = []
 	return nil
 }
 

--- a/lnutil/curvelib.go
+++ b/lnutil/curvelib.go
@@ -267,6 +267,7 @@ func CombinePrivKeyWithBytes(k *btcec.PrivateKey, b []byte) *btcec.PrivateKey {
 // CombinePrivateKeys, but once it gets the combined private key, it subtracts the
 // original base key.  It's weird, but it allows the porTxo standard to always add
 // private keys and not need to be aware of different derivation methods.
+// Weird / ugly mix of types here as they're all [32]byte... ah well.
 func CombinePrivKeyAndSubtract(k *btcec.PrivateKey, b []byte) [32]byte {
 	// create empty array to copy into
 	var diffKey [32]byte

--- a/lnutil/curvelib.go
+++ b/lnutil/curvelib.go
@@ -3,6 +3,7 @@ package lnutil
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"math/big"
 	"sort"
 
@@ -279,6 +280,22 @@ func CombinePrivKeyAndSubtract(k *btcec.PrivateKey, b []byte) [32]byte {
 	combinedKey.D.Mod(combinedKey.D, btcec.S256().N)
 	// copy this "difference key" and return it.
 	copy(diffKey[:], combinedKey.D.Bytes())
+	return diffKey
+}
+
+// SubtractPrivKeys returns the difference a - b mod n
+func SubtractPrivKeys(a, b [32]byte) [32]byte {
+	var diffKey [32]byte
+
+	privA, _ := btcec.PrivKeyFromBytes(btcec.S256(), a[:])
+	privB, _ := btcec.PrivKeyFromBytes(btcec.S256(), b[:])
+
+	privA.D.Sub(privA.D, privB.D)
+	privA.D.Mod(privA.D, btcec.S256().N)
+
+	copy(diffKey[:], privA.D.Bytes())
+	//
+	log.Printf("%x - %x =\n%x\n", a, b, diffKey)
 	return diffKey
 }
 

--- a/lnutil/curvelib.go
+++ b/lnutil/curvelib.go
@@ -3,7 +3,6 @@ package lnutil
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"math/big"
 	"sort"
 
@@ -294,8 +293,7 @@ func SubtractPrivKeys(a, b [32]byte) [32]byte {
 	privA.D.Mod(privA.D, btcec.S256().N)
 
 	copy(diffKey[:], privA.D.Bytes())
-	//
-	log.Printf("%x - %x =\n%x\n", a, b, diffKey)
+	// log.Printf("%x - %x =\n%x\n", a, b, diffKey)
 	return diffKey
 }
 

--- a/portxo/derive.go
+++ b/portxo/derive.go
@@ -42,7 +42,7 @@ func (kg *KeyGen) DerivePrivateKey(
 	}
 
 	// if porTxo's private key has something in it, combine that with derived key
-	// using the delinearization scheme
+	// by adding them
 	if kg.PrivKey != empty {
 		PrivKeyAddBytes(derivedPrivKey, kg.PrivKey[:])
 	}

--- a/portxo/portxo.go
+++ b/portxo/portxo.go
@@ -102,6 +102,17 @@ var modeStrings = map[TxoMode]string{
 	TxoP2WSHComp:   "witness script hash compressed",
 }
 
+var (
+	KeyGenForImports = KeyGen{
+		Depth: 5,
+		Step:  [5]uint32{0xfee154fe, 0, 0, 0, 0},
+	}
+	KeyGenEmpty = KeyGen{
+		Depth: 0,
+		Step:  [5]uint32{0, 0, 0, 0, 0},
+	}
+)
+
 // String returns the InvType in human-readable form.
 func (m TxoMode) String() string {
 	s, ok := modeStrings[m]

--- a/qln/basewallet.go
+++ b/qln/basewallet.go
@@ -66,14 +66,6 @@ type UWallet interface {
 	// Return current height the wallet is synced to
 	CurrentHeight() int32
 
-	// This is redundand... just use UtxoDump and figure it out yourself.
-	// Feels like helper functions shouldn't be in the interface.
-	// how much utxo the wallet has -- only confirmed segwit outputs
-	//	HowMuchWitConf() int64
-
-	// How much utxo the sub wallet has, including non-segwit, unconfirmed, immature
-	//	HowMuchTotal() int64
-
 	// WatchThis tells the basewallet to watch an outpoint
 	WatchThis(wire.OutPoint) error
 

--- a/qln/close.go
+++ b/qln/close.go
@@ -308,7 +308,6 @@ func (q *Qchan) GetCloseTxos(tx *wire.MsgTx) ([]portxo.PorTxo, error) {
 
 		// just return the elkScalar and let
 		// something modify it before export due to the seq=1 flag.
-
 		shTxo.PkScript = script
 		shTxo.Value = tx.TxOut[shIdx].Value
 		shTxo.Mode = portxo.TxoP2WSHComp

--- a/wallit/basewalletif.go
+++ b/wallit/basewalletif.go
@@ -88,8 +88,6 @@ func (w *Wallit) ExportUtxo(u *portxo.PorTxo) {
 		// not match up with the wallet derivation tree.  In this
 		// case we assign a fixed derivation path and subtract
 		if u.KeyGen.Depth == 0 {
-
-			log.Printf("raw priv import: %x\n", u.KeyGen.PrivKey)
 			impGen := portxo.KeyGenForImports
 			impGen.Step[1] = w.Param.HDCoinType
 
@@ -101,17 +99,6 @@ func (w *Wallit) ExportUtxo(u *portxo.PorTxo) {
 
 			u.KeyGen = impGen
 			u.KeyGen.PrivKey = mixedKey
-
-			log.Printf("keygen: %s\n", u.KeyGen.String())
-			log.Printf("modified to: %x\n", u.KeyGen.PrivKey)
-
-			// check that we can reconstruct the private key
-			log.Printf("%x + %x =\n", privMask.D.Bytes(), mixedKey)
-			lnutil.PrivKeyAddBytes(privMask, mixedKey[:])
-			log.Printf("%x\n", privMask.D.Bytes())
-
-			log.Printf("back? to %x\n", privMask.D.Bytes())
-
 		}
 		// either way, gain the utxo
 		err := w.GainUtxo(*u)

--- a/wallit/basewalletif.go
+++ b/wallit/basewalletif.go
@@ -32,6 +32,13 @@ type UWallet interface {
 }
 */
 
+var (
+	KeyGenForImports = portxo.KeyGen{
+		Depth: 3,
+		Step:  [5]uint32{0xfee154fe, 0, 0, 0, 0},
+	}
+)
+
 // --- implementation of BaseWallet interface ----
 
 func (w *Wallit) GetPriv(k portxo.KeyGen) *btcec.PrivateKey {
@@ -73,28 +80,39 @@ func (w *Wallit) ExportHook() uspv.ChainHook {
 }
 
 // ExportUtxo is really *IM*port utxo on this side.
-// Not implemented yet.  Fix "ingest many" at the same time eh?
 func (w *Wallit) ExportUtxo(u *portxo.PorTxo) {
 
-	// zero value utxo counts as an address exort, not utxo export.
+	// zero value utxo counts as an address export, not utxo export.
 	if u.Value == 0 {
 		err := w.AddPorTxoAdr(u.KeyGen)
 		if err != nil {
 			log.Printf(err.Error())
 		}
 	} else {
+		// if derivation path is 0, that means it's an import triggerd by
+		// the user, with a portxo with private key included that does
+		// not match up with the wallet derivation tree.  In this
+		// case we assign a fixed derivation path and subtract
+		if u.KeyGen.Depth == 0 {
+			privImport := u.KeyGen.PrivKey
+			impGen := KeyGenForImports
+			impGen.Step[1] = w.Param.HDCoinType
+			privMix := w.GetPriv(impGen)
+
+			u.KeyGen.PrivKey = lnutil.CombinePrivKeyAndSubtract(
+				privMix, privImport[:])
+		}
+		// either way, gain the utxo
 		err := w.GainUtxo(*u)
 		if err != nil {
 			log.Printf(err.Error())
 		}
 	}
 
-	// Register new address with chainhook
-	adr160 := w.PathPubHash160(u.KeyGen)
-	err := w.Hook.RegisterAddress(adr160)
-	if err != nil {
-		log.Printf(err.Error())
-	}
+	return
+	// don't register an address; utxo import does not imply we
+	// have control over that address and can accept new payments there
+	// (even though we probably could...)
 }
 
 // WatchThis registers an outpoint to watch.  Register as watched OP, and

--- a/wallit/dbio.go
+++ b/wallit/dbio.go
@@ -288,6 +288,9 @@ func (w *Wallit) RegisterWatchOP(op wire.OutPoint) error {
 func (w *Wallit) GainUtxo(u portxo.PorTxo) error {
 	log.Printf("gaining exported utxo %s at height %d\n",
 		u.Op.String(), u.Height)
+
+	log.Printf("gaining priv: %x\n", u.KeyGen.PrivKey)
+
 	// serialize porTxo
 	utxoBytes, err := u.Bytes()
 	if err != nil {

--- a/wallit/dbio.go
+++ b/wallit/dbio.go
@@ -289,8 +289,6 @@ func (w *Wallit) GainUtxo(u portxo.PorTxo) error {
 	log.Printf("gaining exported utxo %s at height %d\n",
 		u.Op.String(), u.Height)
 
-	log.Printf("gaining priv: %x\n", u.KeyGen.PrivKey)
-
 	// serialize porTxo
 	utxoBytes, err := u.Bytes()
 	if err != nil {

--- a/wallit/keyderiv.go
+++ b/wallit/keyderiv.go
@@ -1,7 +1,7 @@
 package wallit
 
 import (
-	"fmt"
+	"log"
 
 	"github.com/adiabat/btcd/btcec"
 	"github.com/adiabat/btcutil"
@@ -24,11 +24,12 @@ Channel refund keys are use 3, peer and index per peer / channel.
 func (w *Wallit) PathPrivkey(kg portxo.KeyGen) *btcec.PrivateKey {
 	// in uspv, we require path depth of 5
 	if kg.Depth != 5 {
+		log.Printf("bad keygen %s\n", kg.String())
 		return nil
 	}
 	priv, err := kg.DerivePrivateKey(w.rootPrivKey)
 	if err != nil {
-		fmt.Printf("PathPrivkey err %s", err.Error())
+		log.Printf("PathPrivkey err %s", err.Error())
 		return nil
 	}
 	return priv

--- a/wallit/signsend.go
+++ b/wallit/signsend.go
@@ -447,11 +447,11 @@ func (w *Wallit) BuildAndSign(
 	for i, _ := range tx.TxIn {
 		// get key
 		priv := w.PathPrivkey(utxos[i].KeyGen)
-		log.Printf("signing with privkey pub %x\n", priv.PubKey().SerializeCompressed())
 
 		if priv == nil {
 			return nil, fmt.Errorf("SendCoins: nil privkey")
 		}
+		log.Printf("signing with privkey pub %x\n", priv.PubKey().SerializeCompressed())
 
 		// sign into stash.  3 possibilities:  legacy PKH, WPKH, WSH
 		if utxos[i].Mode == portxo.TxoP2PKHComp { // legacy PKH

--- a/wallit/wallit.go
+++ b/wallit/wallit.go
@@ -19,6 +19,82 @@ import (
 	"github.com/mit-dci/lit/uspv"
 )
 
+/* implements the uwallet interface.  Which is much too large!
+... but for now works this way, with like 17 functions, bleh.
+
+// Ask for a pubkey based on a bip32 path
+GetPub(k portxo.KeyGen) *btcec.PublicKey
+
+// Have GetPriv for now.  Maybe later get rid of this and have
+// the underlying wallet sign?
+GetPriv(k portxo.KeyGen) *btcec.PrivateKey
+
+// Send a tx out to the network.  Maybe could replace?  Maybe not.
+// Needed for channel break / cooperative close.  Maybe grabs.
+
+// export the chainhook that the UWallet uses, for pushTx and fullblock
+ExportHook() uspv.ChainHook
+
+PushTx(tx *wire.MsgTx) error
+
+// ExportUtxo gives a utxo to the underlying wallet; that wallet saves it
+// and can spend it later.  Doesn't return errors; error will exist only in
+// base wallet.
+ExportUtxo(txo *portxo.PorTxo)
+
+// MaybeSend makes an unsigned tx, populated with inputs and outputs.
+// The specified txouts are in there somewhere.
+// Only segwit txins are in the generated tx. (txid won't change)
+// There's probably an extra change txout in there which is OK.
+// The inputs are "frozen" until ReallySend / NahDontSend / program restart.
+// Retruns the txid, and then the txout indexes of the specified txos.
+// The outpoints returned will all have the same hash (txid)
+// So if you (as usual) just give one txo, you basically get back an outpoint.
+MaybeSend(txos []*wire.TxOut, onlyWit bool) ([]*wire.OutPoint, error)
+
+// ReallySend really sends the transaction specified previously in MaybeSend.
+// Underlying wallet does all needed signing.
+// Once you call ReallySend, the outpoint is tracked and responses are
+// sent through LetMeKnow
+ReallySend(txid *chainhash.Hash) error
+
+// NahDontSend cancels the MaybeSend transaction.
+NahDontSend(txid *chainhash.Hash) error
+
+// Return a new address
+NewAdr() ([20]byte, error)
+
+// Dump all the utxos in the sub wallet
+UtxoDump() ([]*portxo.PorTxo, error)
+
+// Dump all the addresses the sub wallet is watching
+AdrDump() ([][20]byte, error)
+
+// Return current height the wallet is synced to
+CurrentHeight() int32
+
+// WatchThis tells the basewallet to watch an outpoint
+WatchThis(wire.OutPoint) error
+
+// LetMeKnow opens the chan where OutPointEvent flows from the underlying
+// wallet up to the LN module.
+LetMeKnow() chan lnutil.OutPointEvent
+
+// Ask for network parameters
+Params() *coinparam.Params
+
+// Get current fee rate.
+Fee() int64
+
+// Set fee rate
+SetFee(int64) int64
+
+// ===== TESTING / SPAMMING ONLY, these funcs will not be in the real interface
+// Sweep sends lots of txs (uint32 of them) to the specified address.
+Sweep([]byte, uint32) ([]*chainhash.Hash, error)
+
+*/
+
 // The Wallit is lit's main wallet struct.  It's got the root key, the dbs, and
 // contains the SPVhooks into the network.
 type Wallit struct {


### PR DESCRIPTION
This adds the import RPC command which imports a utxo with a private key.  It doesn't import the private key and rescan to find utxos, and as such it doesn't add a new address to watch for payments.

The dump RPC command has been changed to output utxos in this format.  

TODO: (after merging this I guess: add WIF format export alongside this, for compatibility)