### PR TITLE
Include data with push command, and provide a history command to view previous payments

### DIFF
--- a/cmd/lit-af/chancmds.go
+++ b/cmd/lit-af/chancmds.go
@@ -69,7 +69,7 @@ func (lc *litAfClient) History(textArgs []string) error {
 	}
 
 	for _, tx := range reply.Txs {
-		fmt.Fprintf(color.Output, "Sig: %x, Txid: %x, Data: %x, Amt: %d\n", tx.Sig, tx.Txid, tx.Data, tx.Amt)
+		fmt.Fprintf(color.Output, "Pkh: %x, Idx: %d, Sig: %x, Txid: %x, Data: %x, Amt: %d\n", tx.Pkh, tx.Idx, tx.Sig, tx.Txid, tx.Data, tx.Amt)
 	}
 
 	return nil

--- a/cmd/lit-af/chancmds.go
+++ b/cmd/lit-af/chancmds.go
@@ -47,6 +47,31 @@ var breakCommand = &Command{
 	ShortDescription: "Forcibly break the given channel.\n",
 }
 
+var historyCommand = &Command{
+	Format:           lnutil.White("history"),
+	Description:      "Show all the metadata for justice txs",
+	ShortDescription: "Show all the metadata for justice txs.\n",
+}
+
+func (lc *litAfClient) History(textArgs []string) error {
+	if len(textArgs) > 0 && textArgs[0] == "-h" {
+		fmt.Fprintf(color.Output, historyCommand.Format)
+		fmt.Fprintf(color.Output, historyCommand.Description)
+		return nil
+	}
+
+	args := new(litrpc.StateDumpArgs)
+	reply := new(litrpc.StateDumpReply)
+
+	err := lc.rpccon.Call("LitRPC.StateDump", args, reply)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(color.Output, "%s\n", reply.States)
+	return nil
+}
+
 func (lc *litAfClient) FundChannel(textArgs []string) error {
 	if len(textArgs) > 0 && textArgs[0] == "-h" {
 		fmt.Fprintf(color.Output, fundCommand.Format)

--- a/cmd/lit-af/chancmds.go
+++ b/cmd/lit-af/chancmds.go
@@ -68,7 +68,10 @@ func (lc *litAfClient) History(textArgs []string) error {
 		return err
 	}
 
-	fmt.Fprintf(color.Output, "%s\n", reply.States)
+	for _, tx := range reply.Txs {
+		fmt.Fprintf(color.Output, "Sig: %x, Txid: %x, Data: %x, Amt: %d\n", tx.Sig, tx.Txid, tx.Data, tx.Amt)
+	}
+
 	return nil
 }
 

--- a/cmd/lit-af/shell.go
+++ b/cmd/lit-af/shell.go
@@ -172,6 +172,13 @@ func (lc *litAfClient) Shellparse(cmdslice []string) error {
 		}
 		return nil
 	}
+	if cmd == "history" { // dump justice tx history
+		err = lc.History(args)
+		if err != nil {
+			fmt.Fprintf(color.Output, "history error: %s\n", err)
+		}
+		return nil
+	}
 
 	fmt.Fprintf(color.Output, "Command not recognized. type help for command list.\n")
 	return nil
@@ -353,6 +360,7 @@ func (lc *litAfClient) Help(textArgs []string) error {
 		fmt.Fprintf(color.Output, "%s\t%s", pushCommand.Format, pushCommand.ShortDescription)
 		fmt.Fprintf(color.Output, "%s\t%s", closeCommand.Format, closeCommand.ShortDescription)
 		fmt.Fprintf(color.Output, "%s\t%s", breakCommand.Format, breakCommand.ShortDescription)
+		fmt.Fprintf(color.Output, "%s\t%s", historyCommand.Format, historyCommand.ShortDescription)
 		fmt.Fprintf(color.Output, "%s\t%s", offCommand.Format, offCommand.ShortDescription)
 		fmt.Fprintf(color.Output, "%s\t%s", exitCommand.Format, exitCommand.ShortDescription)
 		return nil

--- a/cmd/lit-af/shell.go
+++ b/cmd/lit-af/shell.go
@@ -256,11 +256,11 @@ func (lc *litAfClient) Ls(textArgs []string) error {
 		}
 		fmt.Fprintf(
 			color.Output,
-			"%s (peer %d) type %d %s\n\t cap: %s bal: %s h: %d state: %d\n",
+			"%s (peer %d) type %d %s\n\t cap: %s bal: %s h: %d state: %d data: %x\n",
 			lnutil.White(c.CIdx), c.PeerIdx, c.CoinType,
 			lnutil.OutPoint(c.OutPoint),
 			lnutil.SatoshiColor(c.Capacity), lnutil.SatoshiColor(c.MyBalance),
-			c.Height, c.StateNum)
+			c.Height, c.StateNum, c.Data)
 	}
 
 	err = lc.rpccon.Call("LitRPC.TxoList", nil, tReply)

--- a/litrpc/chancmds.go
+++ b/litrpc/chancmds.go
@@ -123,6 +123,7 @@ func (r *LitRPC) FundChannel(args FundArgs, reply *StatusReply) error {
 type PushArgs struct {
 	ChanIdx uint32
 	Amt     int64
+	Data    [32]byte
 }
 type PushReply struct {
 	StateIndex uint64
@@ -139,7 +140,7 @@ func (r *LitRPC) Push(args PushArgs, reply *PushReply) error {
 			"can't push %d max is 1 coin (100000000), min is 1", args.Amt)
 	}
 
-	fmt.Printf("push %d to chan %d\n", args.Amt, args.ChanIdx)
+	fmt.Printf("push %d to chan %d with data %x\n", args.Amt, args.ChanIdx, args.Data)
 
 	// load the whole channel from disk just to see who the peer is
 	// (pretty inefficient)
@@ -180,7 +181,7 @@ func (r *LitRPC) Push(args PushArgs, reply *PushReply) error {
 	// to the Node.Func() calls.  For now though, set the height here...
 	qc.Height = dummyqc.Height
 
-	err = r.Node.PushChannel(qc, uint32(args.Amt))
+	err = r.Node.PushChannel(qc, uint32(args.Amt), args.Data)
 	if err != nil {
 		return err
 	}

--- a/litrpc/chancmds.go
+++ b/litrpc/chancmds.go
@@ -119,6 +119,26 @@ func (r *LitRPC) FundChannel(args FundArgs, reply *StatusReply) error {
 	return nil
 }
 
+// ------------------------- statedump
+type StateDumpArgs struct {
+	// none
+}
+
+type StateDumpReply struct {
+	States string
+}
+
+// StateDump dumps all of the meta data for the state commitments of a channel
+func (r *LitRPC) StateDump(args StateDumpArgs, reply *StateDumpReply) error {
+	var err error
+	reply.States, err = r.Node.ShowJusticeDB()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // ------------------------- push
 type PushArgs struct {
 	ChanIdx uint32

--- a/litrpc/chancmds.go
+++ b/litrpc/chancmds.go
@@ -19,6 +19,7 @@ type ChannelInfo struct {
 	StateNum      uint64 // Most recent commit number
 	PeerIdx, CIdx uint32
 	PeerID        string
+	Data          [32]byte
 }
 type ChannelListReply struct {
 	Channels []ChannelInfo
@@ -55,6 +56,7 @@ func (r *LitRPC) ChannelList(args ChanArgs, reply *ChannelListReply) error {
 		reply.Channels[i].StateNum = q.State.StateIdx
 		reply.Channels[i].PeerIdx = q.KeyGen.Step[3] & 0x7fffffff
 		reply.Channels[i].CIdx = q.KeyGen.Step[4] & 0x7fffffff
+		reply.Channels[i].Data = q.State.Data
 	}
 	return nil
 }

--- a/litrpc/chancmds.go
+++ b/litrpc/chancmds.go
@@ -125,13 +125,13 @@ type StateDumpArgs struct {
 }
 
 type StateDumpReply struct {
-	States string
+	Txs []qln.JusticeTx
 }
 
 // StateDump dumps all of the meta data for the state commitments of a channel
 func (r *LitRPC) StateDump(args StateDumpArgs, reply *StateDumpReply) error {
 	var err error
-	reply.States, err = r.Node.ShowJusticeDB()
+	reply.Txs, err = r.Node.DumpJusticeDB()
 	if err != nil {
 		return err
 	}

--- a/lnutil/msglib.go
+++ b/lnutil/msglib.go
@@ -512,6 +512,7 @@ func NewDeltaSigMsgFromBytes(b []byte, peerid uint32) (DeltaSigMsg, error) {
 	// deserialize DeltaSig
 	ds.Delta = BtI32(buf.Next(4))
 	copy(ds.Signature[:], buf.Next(64))
+	copy(ds.Data[:], buf.Next(32))
 	return *ds, nil
 }
 

--- a/lnutil/msglib.go
+++ b/lnutil/msglib.go
@@ -482,14 +482,16 @@ type DeltaSigMsg struct {
 	Outpoint  wire.OutPoint
 	Delta     int32
 	Signature [64]byte
+	Data      [32]byte
 }
 
-func NewDeltaSigMsg(peerid uint32, OP wire.OutPoint, DELTA int32, SIG [64]byte) DeltaSigMsg {
+func NewDeltaSigMsg(peerid uint32, OP wire.OutPoint, DELTA int32, SIG [64]byte, data [32]byte) DeltaSigMsg {
 	d := new(DeltaSigMsg)
 	d.PeerIdx = peerid
 	d.Outpoint = OP
 	d.Delta = DELTA
 	d.Signature = SIG
+	d.Data = data
 	return *d
 }
 

--- a/lnutil/msglib.go
+++ b/lnutil/msglib.go
@@ -523,6 +523,7 @@ func (self DeltaSigMsg) Bytes() []byte {
 	msg = append(msg, opArr[:]...)
 	msg = append(msg, I32tB(self.Delta)...)
 	msg = append(msg, self.Signature[:]...)
+	msg = append(msg, self.Data[:]...)
 	return msg
 }
 

--- a/qln/justicetx.go
+++ b/qln/justicetx.go
@@ -24,6 +24,8 @@ type JusticeTx struct {
 	Txid [16]byte
 	Amt  int64
 	Data [32]byte
+	Pkh  [20]byte
+	Idx  uint64
 }
 
 func (jte *JusticeTx) ToBytes() ([]byte, error) {
@@ -255,6 +257,10 @@ func (nd *LitNode) DumpJusticeDB() ([]JusticeTx, error) {
 				if err != nil {
 					return err
 				}
+
+				copy(jtx.Pkh[:], k[:20])
+				jtx.Idx = lnutil.BtU64(idx)
+
 				txs = append(txs, jtx)
 
 				return nil

--- a/qln/lnchannels.go
+++ b/qln/lnchannels.go
@@ -55,6 +55,8 @@ type StatCom struct {
 
 	Fee int64 // symmetric fee in absolute satoshis
 
+	Data [32]byte
+
 	// their Amt is the utxo.Value minus this
 	Delta int32 // fund amount in-transit; is negative for the pusher
 	// Delta for when the channel is in a collision state which needs to be resolved

--- a/qln/pushpull.go
+++ b/qln/pushpull.go
@@ -225,6 +225,7 @@ func (nd LitNode) PushChannel(qc *Qchan, amt uint32, data [32]byte) error {
 	}
 
 	qc.State.Data = data
+	fmt.Printf("Sending message %x", data)
 
 	qc.State.Delta = int32(-amt)
 	// save to db with ONLY delta changed
@@ -368,6 +369,7 @@ func (nd *LitNode) DeltaSigHandler(msg lnutil.DeltaSigMsg, qc *Qchan) error {
 	// regardless of collision, raise amt
 	qc.State.MyAmt += int64(incomingDelta)
 
+	fmt.Printf("Got message %x", msg.Data)
 	qc.State.Data = msg.Data
 
 	// verify sig for the next state. only save if this works

--- a/qln/serdes.go
+++ b/qln/serdes.go
@@ -102,7 +102,7 @@ func (s *StatCom) ToBytes() ([]byte, error) {
 // StatComFromBytes turns 192 bytes into a StatCom
 func StatComFromBytes(b []byte) (*StatCom, error) {
 	var s StatCom
-	if len(b) < 203 || len(b) > 203 {
+	if len(b) < 235 || len(b) > 235 {
 		return nil, fmt.Errorf("StatComFromBytes got %d bytes, expect 203",
 			len(b))
 	}

--- a/qln/serdes.go
+++ b/qln/serdes.go
@@ -89,6 +89,13 @@ func (s *StatCom) ToBytes() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// write their data
+	_, err = buf.Write(s.Data[:])
+	if err != nil {
+		return nil, err
+	}
+
 	return buf.Bytes(), nil
 }
 
@@ -140,6 +147,9 @@ func StatComFromBytes(b []byte) (*StatCom, error) {
 
 	// the rest is their sig
 	copy(s.sig[:], buf.Next(64))
+
+	// copy data
+	copy(s.Data[:], buf.Next(32))
 
 	return &s, nil
 }


### PR DESCRIPTION
This pull request adds an extra parameter to the channel push command so you can include a 32 byte data payload with the push. This allows recipients so associate a payment with a data payload that is communicated out-of-band. 

It also include a `history` RPC and `lit-af` command to allow users to see the data payload for each push, as well as their relative amounts.

These changes breaks existing databases so you'll need a new one (delete `ln.db`).