### PR TITLE
Add data field to fund operation

### DIFF
--- a/cmd/lit-af/chancmds.go
+++ b/cmd/lit-af/chancmds.go
@@ -112,9 +112,11 @@ func (lc *litAfClient) FundChannel(textArgs []string) error {
 	if len(textArgs) > 4 {
 		data, err := hex.DecodeString(textArgs[4])
 		if err != nil {
-			return err
+			// Wasn't valid hex, copy directly and truncate
+			copy(args.Data[:], textArgs[3])
+		} else {
+			copy(args.Data[:], data[:])
 		}
-		copy(args.Data[:], data[:32])
 	}
 
 	args.Peer = uint32(peer)
@@ -231,9 +233,11 @@ func (lc *litAfClient) Push(textArgs []string) error {
 	if len(textArgs) > 3 {
 		data, err := hex.DecodeString(textArgs[3])
 		if err != nil {
-			return err
+			// Wasn't valid hex, copy directly and truncate
+			copy(args.Data[:], textArgs[3])
+		} else {
+			copy(args.Data[:], data[:])
 		}
-		copy(args.Data[:], data[:32])
 	}
 
 	args.ChanIdx = uint32(cIdx)

--- a/cmd/lit-af/chancmds.go
+++ b/cmd/lit-af/chancmds.go
@@ -11,12 +11,14 @@ import (
 )
 
 var fundCommand = &Command{
-	Format: fmt.Sprintf("%s%s\n", lnutil.White("fund"),
-		lnutil.ReqColor("peer", "coinType", "capacity", "initialSend")),
-	Description: fmt.Sprintf("%s\n%s\n%s\n",
+	Format: fmt.Sprintf("%s%s%s\n", lnutil.White("fund"),
+		lnutil.ReqColor("peer", "coinType", "capacity", "initialSend"), lnutil.OptColor("data")),
+	Description: fmt.Sprintf("%s\n%s\n%s\n%s\n",
 		"Establish and fund a new lightning channel with the given peer.",
 		"The capacity is the amount of satoshi we insert into the channel,",
-		"and initialSend is the amount we initially hand over to the other party."),
+		"and initialSend is the amount we initially hand over to the other party.",
+		"data is an optional field that can contain 32 bytes of hex to send as part of the channel fund",
+	),
 	ShortDescription: "Establish and fund a new lightning channel with the given peer.\n",
 }
 
@@ -106,6 +108,15 @@ func (lc *litAfClient) FundChannel(textArgs []string) error {
 	if err != nil {
 		return err
 	}
+
+	if len(textArgs) > 4 {
+		data, err := hex.DecodeString(textArgs[4])
+		if err != nil {
+			return err
+		}
+		copy(args.Data[:], data[:32])
+	}
+
 	args.Peer = uint32(peer)
 	args.CoinType = uint32(coinType)
 	args.Capacity = int64(cCap)
@@ -217,10 +228,6 @@ func (lc *litAfClient) Push(textArgs []string) error {
 		}
 	}
 
-	var data [32]byte
-	for i := range data {
-		data[i] = 0
-	}
 	if len(textArgs) > 3 {
 		data, err := hex.DecodeString(textArgs[3])
 		if err != nil {

--- a/cmd/lit-af/shell.go
+++ b/cmd/lit-af/shell.go
@@ -256,11 +256,11 @@ func (lc *litAfClient) Ls(textArgs []string) error {
 		}
 		fmt.Fprintf(
 			color.Output,
-			"%s (peer %d) type %d %s\n\t cap: %s bal: %s h: %d state: %d data: %x\n",
+			"%s (peer %d) type %d %s\n\t cap: %s bal: %s h: %d state: %d data: %x pkh: %x\n",
 			lnutil.White(c.CIdx), c.PeerIdx, c.CoinType,
 			lnutil.OutPoint(c.OutPoint),
 			lnutil.SatoshiColor(c.Capacity), lnutil.SatoshiColor(c.MyBalance),
-			c.Height, c.StateNum, c.Data)
+			c.Height, c.StateNum, c.Data, c.Pkh)
 	}
 
 	err = lc.rpccon.Call("LitRPC.TxoList", nil, tReply)

--- a/litrpc/chancmds.go
+++ b/litrpc/chancmds.go
@@ -68,6 +68,7 @@ type FundArgs struct {
 	Capacity    int64  // later can be minimum capacity
 	Roundup     int64  // ignore for now; can be used to round-up capacity
 	InitialSend int64  // Initial send of -1 means "ALL"
+	Data        [32]byte
 }
 
 func (r *LitRPC) FundChannel(args FundArgs, reply *StatusReply) error {
@@ -111,7 +112,7 @@ func (r *LitRPC) FundChannel(args FundArgs, reply *StatusReply) error {
 	}
 
 	idx, err := r.Node.FundChannel(
-		args.Peer, args.CoinType, args.Capacity, args.InitialSend)
+		args.Peer, args.CoinType, args.Capacity, args.InitialSend, args.Data)
 	if err != nil {
 		return err
 	}

--- a/litrpc/chancmds.go
+++ b/litrpc/chancmds.go
@@ -20,6 +20,7 @@ type ChannelInfo struct {
 	PeerIdx, CIdx uint32
 	PeerID        string
 	Data          [32]byte
+	Pkh           [20]byte
 }
 type ChannelListReply struct {
 	Channels []ChannelInfo
@@ -57,6 +58,7 @@ func (r *LitRPC) ChannelList(args ChanArgs, reply *ChannelListReply) error {
 		reply.Channels[i].PeerIdx = q.KeyGen.Step[3] & 0x7fffffff
 		reply.Channels[i].CIdx = q.KeyGen.Step[4] & 0x7fffffff
 		reply.Channels[i].Data = q.State.Data
+		reply.Channels[i].Pkh = q.WatchRefundAdr
 	}
 	return nil
 }

--- a/lnutil/msglib.go
+++ b/lnutil/msglib.go
@@ -158,12 +158,14 @@ func (self ChatMsg) MsgType() uint8 { return MSGID_TEXTCHAT }
 type PointReqMsg struct {
 	PeerIdx  uint32
 	Cointype uint32
+	Data     [32]byte
 }
 
-func NewPointReqMsg(peerid uint32, cointype uint32) PointReqMsg {
+func NewPointReqMsg(peerid uint32, cointype uint32, data [32]byte) PointReqMsg {
 	p := new(PointReqMsg)
 	p.PeerIdx = peerid
 	p.Cointype = cointype
+	p.Data = data
 	return *p
 }
 
@@ -180,6 +182,8 @@ func NewPointReqMsgFromBytes(b []byte, peerid uint32) (PointReqMsg, error) {
 	coin := buf.Next(4)
 	pr.Cointype = BtU32(coin)
 
+	copy(pr.Data[:], buf.Next(32))
+
 	return *pr, nil
 }
 
@@ -188,6 +192,7 @@ func (self PointReqMsg) Bytes() []byte {
 	msg = append(msg, self.MsgType())
 	coin := U32tB(self.Cointype)
 	msg = append(msg, coin[:]...)
+	msg = append(msg, self.Data[:]...)
 	return msg
 }
 

--- a/lnutil/msglib.go
+++ b/lnutil/msglib.go
@@ -158,14 +158,12 @@ func (self ChatMsg) MsgType() uint8 { return MSGID_TEXTCHAT }
 type PointReqMsg struct {
 	PeerIdx  uint32
 	Cointype uint32
-	Data     [32]byte
 }
 
-func NewPointReqMsg(peerid uint32, cointype uint32, data [32]byte) PointReqMsg {
+func NewPointReqMsg(peerid uint32, cointype uint32) PointReqMsg {
 	p := new(PointReqMsg)
 	p.PeerIdx = peerid
 	p.Cointype = cointype
-	p.Data = data
 	return *p
 }
 
@@ -182,8 +180,6 @@ func NewPointReqMsgFromBytes(b []byte, peerid uint32) (PointReqMsg, error) {
 	coin := buf.Next(4)
 	pr.Cointype = BtU32(coin)
 
-	copy(pr.Data[:], buf.Next(32))
-
 	return *pr, nil
 }
 
@@ -192,7 +188,6 @@ func (self PointReqMsg) Bytes() []byte {
 	msg = append(msg, self.MsgType())
 	coin := U32tB(self.Cointype)
 	msg = append(msg, coin[:]...)
-	msg = append(msg, self.Data[:]...)
 	return msg
 }
 
@@ -259,6 +254,8 @@ type ChanDescMsg struct {
 	ElkZero [33]byte //consider changing into array in future
 	ElkOne  [33]byte
 	ElkTwo  [33]byte
+
+	Data [32]byte
 }
 
 func NewChanDescMsg(
@@ -266,7 +263,7 @@ func NewChanDescMsg(
 	pubkey, refund, hakd [33]byte,
 	cointype uint32,
 	capacity int64, payment int64,
-	ELKZero, ELKOne, ELKTwo [33]byte) ChanDescMsg {
+	ELKZero, ELKOne, ELKTwo [33]byte, data [32]byte) ChanDescMsg {
 
 	cd := new(ChanDescMsg)
 	cd.PeerIdx = peerid
@@ -280,6 +277,7 @@ func NewChanDescMsg(
 	cd.ElkZero = ELKZero
 	cd.ElkOne = ELKOne
 	cd.ElkTwo = ELKTwo
+	cd.Data = data
 	return *cd
 }
 
@@ -287,8 +285,8 @@ func NewChanDescMsgFromBytes(b []byte, peerid uint32) (ChanDescMsg, error) {
 	cm := new(ChanDescMsg)
 	cm.PeerIdx = peerid
 
-	if len(b) < 251 {
-		return *cm, fmt.Errorf("got %d byte channel description, expect 251", len(b))
+	if len(b) < 283 {
+		return *cm, fmt.Errorf("got %d byte channel description, expect 283", len(b))
 	}
 
 	buf := bytes.NewBuffer(b[1:]) // get rid of messageType
@@ -304,6 +302,7 @@ func NewChanDescMsgFromBytes(b []byte, peerid uint32) (ChanDescMsg, error) {
 	copy(cm.ElkZero[:], buf.Next(33))
 	copy(cm.ElkOne[:], buf.Next(33))
 	copy(cm.ElkTwo[:], buf.Next(33))
+	copy(cm.Data[:], buf.Next(32))
 
 	return *cm, nil
 }
@@ -326,6 +325,7 @@ func (self ChanDescMsg) Bytes() []byte {
 	msg = append(msg, self.ElkZero[:]...)
 	msg = append(msg, self.ElkOne[:]...)
 	msg = append(msg, self.ElkTwo[:]...)
+	msg = append(msg, self.Data[:]...)
 	return msg
 }
 

--- a/lnutil/msglib_test.go
+++ b/lnutil/msglib_test.go
@@ -144,9 +144,11 @@ func TestChanDescMsg(t *testing.T) {
 
 	op := *OutPointFromBytes(outPoint)
 
+	var data [32]byte
+
 	msg := NewChanDescMsg(peerid, op,
 		pubKey, refundPub, hakd,
-		cointype, capacity, payment, elkZero, elkOne, elkTwo)
+		cointype, capacity, payment, elkZero, elkOne, elkTwo, data)
 	b := msg.Bytes()
 
 	msg2, err := NewChanDescMsgFromBytes(b, peerid)

--- a/qln/fund.go
+++ b/qln/fund.go
@@ -100,7 +100,7 @@ an exact timing for the payment.
 // FundChannel opens a channel with a peer.  Doesn't return until the channel
 // has been created.  Maybe timeout if it takes too long?
 func (nd *LitNode) FundChannel(
-	peerIdx, cointype uint32, ccap, initSend int64) (uint32, error) {
+	peerIdx, cointype uint32, ccap, initSend int64, data [32]byte) (uint32, error) {
 
 	_, ok := nd.SubWallet[cointype]
 	if !ok {
@@ -143,11 +143,12 @@ func (nd *LitNode) FundChannel(
 	nd.InProg.PeerIdx = peerIdx
 	nd.InProg.Amt = ccap
 	nd.InProg.InitSend = initSend
+	nd.InProg.Data = data
 
 	nd.InProg.Coin = cointype
 	nd.InProg.mtx.Unlock() // switch to defer
 
-	outMsg := lnutil.NewPointReqMsg(peerIdx, cointype)
+	outMsg := lnutil.NewPointReqMsg(peerIdx, cointype, data)
 
 	nd.OmniOut <- outMsg
 

--- a/qln/fund.go
+++ b/qln/fund.go
@@ -148,7 +148,7 @@ func (nd *LitNode) FundChannel(
 	nd.InProg.Coin = cointype
 	nd.InProg.mtx.Unlock() // switch to defer
 
-	outMsg := lnutil.NewPointReqMsg(peerIdx, cointype, data)
+	outMsg := lnutil.NewPointReqMsg(peerIdx, cointype)
 
 	nd.OmniOut <- outMsg
 
@@ -303,6 +303,8 @@ func (nd LitNode) PointRespHandler(msg lnutil.PointRespMsg) error {
 	// based on size
 	q.State.Fee = nd.SubWallet[q.Coin()].Fee() * 1000
 
+	q.State.Data = nd.InProg.Data
+
 	// save channel to db
 	err = nd.SaveQChan(q)
 	if err != nil {
@@ -331,7 +333,7 @@ func (nd LitNode) PointRespHandler(msg lnutil.PointRespMsg) error {
 	outMsg := lnutil.NewChanDescMsg(
 		msg.Peer(), *nd.InProg.op, q.MyPub, q.MyRefundPub, q.MyHAKDBase,
 		nd.InProg.Coin, nd.InProg.Amt, nd.InProg.InitSend,
-		elkPointZero, elkPointOne, elkPointTwo)
+		elkPointZero, elkPointOne, elkPointTwo, nd.InProg.Data)
 
 	nd.OmniOut <- outMsg
 
@@ -397,6 +399,8 @@ func (nd *LitNode) QChanDescHandler(msg lnutil.ChanDescMsg) {
 	// TODO assumes both parties use same fee
 	qc.State.Fee = wal.Fee() * 1000
 	qc.State.MyAmt = msg.InitPayment
+
+	qc.State.Data = msg.Data
 
 	qc.State.StateIdx = 0
 	// use new ElkPoint for signing

--- a/qln/lndb.go
+++ b/qln/lndb.go
@@ -144,6 +144,8 @@ type InFlightFund struct {
 	done chan uint32
 	// use this to avoid crashiness
 	mtx sync.Mutex
+
+	Data [32]byte
 }
 
 func (inff *InFlightFund) Clear() {


### PR DESCRIPTION
Similarly to this PR: https://github.com/mit-dci/lit/pull/136, add a data field to the fund command.

This change does not break existing databases but is not backwards compatible protocol-wise.