### PR TITLE
Basic Link-State channel graph generation

### DIFF
--- a/cmd/lit-af/netcmds.go
+++ b/cmd/lit-af/netcmds.go
@@ -31,6 +31,33 @@ var conCommand = &Command{
 	ShortDescription: "Make a connection to another host by connecting to their pubkeyhash\n",
 }
 
+var graphCommand = &Command{
+	Format:           fmt.Sprintf("%s\n", lnutil.White("graph")),
+	Description:      fmt.Sprintf("Dump the channel graph in graphviz DOT format\n"),
+	ShortDescription: "Shows the channel map\n",
+}
+
+// graph gets the channel map
+func (lc *litAfClient) Graph(textArgs []string) error {
+	if len(textArgs) > 0 && textArgs[0] == "-h" {
+		fmt.Fprintf(color.Output, graphCommand.Format)
+		fmt.Fprintf(color.Output, graphCommand.Description)
+		return nil
+	}
+
+	args := new(litrpc.NoArgs)
+	reply := new(litrpc.ChannelGraphReply)
+
+	err := lc.rpccon.Call("LitRPC.GetChannelMap", args, reply)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(color.Output, "%s\n", reply.Graph)
+
+	return nil
+}
+
 // RequestAsync keeps requesting messages from the server.  The server blocks
 // and will send a response once it gets one.  Once the rpc client receives a
 // response, it will immediately request another.

--- a/cmd/lit-af/shell.go
+++ b/cmd/lit-af/shell.go
@@ -179,6 +179,13 @@ func (lc *litAfClient) Shellparse(cmdslice []string) error {
 		}
 		return nil
 	}
+	if cmd == "graph" { // dump graphviz for channels
+		err = lc.Graph(args)
+		if err != nil {
+			fmt.Fprintf(color.Output, "graph error: %s\n", err)
+		}
+		return nil
+	}
 
 	fmt.Fprintf(color.Output, "Command not recognized. type help for command list.\n")
 	return nil
@@ -356,6 +363,7 @@ func (lc *litAfClient) Help(textArgs []string) error {
 		fmt.Fprintf(color.Output, "%s\t%s", sweepCommand.Format, sweepCommand.ShortDescription)
 		fmt.Fprintf(color.Output, "%s\t%s", lisCommand.Format, lisCommand.ShortDescription)
 		fmt.Fprintf(color.Output, "%s\t%s", conCommand.Format, conCommand.ShortDescription)
+		fmt.Fprintf(color.Output, "%s\t%s", graphCommand.Format, graphCommand.ShortDescription)
 		fmt.Fprintf(color.Output, "%s\t%s", fundCommand.Format, fundCommand.ShortDescription)
 		fmt.Fprintf(color.Output, "%s\t%s", pushCommand.Format, pushCommand.ShortDescription)
 		fmt.Fprintf(color.Output, "%s\t%s", closeCommand.Format, closeCommand.ShortDescription)

--- a/litrpc/netcmds.go
+++ b/litrpc/netcmds.go
@@ -136,3 +136,14 @@ func (r *LitRPC) Stop(args NoArgs, reply *StatusReply) error {
 	r.OffButton <- true
 	return nil
 }
+
+// ------------ Dump channel map
+type ChannelGraphReply struct {
+	Graph string
+}
+
+func (r *LitRPC) GetChannelMap(args NoArgs, reply *ChannelGraphReply) error {
+	reply.Graph = r.Node.VisualiseGraph()
+
+	return nil
+}

--- a/lnutil/msglib.go
+++ b/lnutil/msglib.go
@@ -893,8 +893,8 @@ func NewLinkMsgFromBytes(b []byte, peerIDX uint32) (LinkMsg, error) {
 	sm := new(LinkMsg)
 	sm.PeerIdx = peerIDX
 
-	if len(b) < 80 {
-		return *sm, fmt.Errorf("LinkMsg %d bytes, expect 80", len(b))
+	if len(b) < 76 {
+		return *sm, fmt.Errorf("LinkMsg %d bytes, expect 76", len(b))
 	}
 
 	buf := bytes.NewBuffer(b[1:]) // get rid of messageType

--- a/lnutil/msglib.go
+++ b/lnutil/msglib.go
@@ -884,17 +884,17 @@ type LinkMsg struct {
 	APKH      [20]byte // APKH (A's LN address)
 	ACapacity int64    // ACapacity (A's channel balance)
 	BPKH      [20]byte // BPKH (B's LN address)
-	BCapacity int64    // BCapacity (B's channel balance)
 	CoinType  uint32   // CoinType (Network of the channel)
 	Seq       uint32   // seq (Link state sequence #)
+	Timestamp int64
 }
 
 func NewLinkMsgFromBytes(b []byte, peerIDX uint32) (LinkMsg, error) {
 	sm := new(LinkMsg)
 	sm.PeerIdx = peerIDX
 
-	if len(b) < 88 {
-		return *sm, fmt.Errorf("LinkMsg %d bytes, expect 88", len(b))
+	if len(b) < 80 {
+		return *sm, fmt.Errorf("LinkMsg %d bytes, expect 80", len(b))
 	}
 
 	buf := bytes.NewBuffer(b[1:]) // get rid of messageType
@@ -903,7 +903,6 @@ func NewLinkMsgFromBytes(b []byte, peerIDX uint32) (LinkMsg, error) {
 	copy(sm.APKH[:], buf.Next(20))
 	_ = binary.Read(buf, binary.BigEndian, &sm.ACapacity)
 	copy(sm.BPKH[:], buf.Next(20))
-	_ = binary.Read(buf, binary.BigEndian, &sm.BCapacity)
 	_ = binary.Read(buf, binary.BigEndian, &sm.CoinType)
 	_ = binary.Read(buf, binary.BigEndian, &sm.Seq)
 
@@ -922,7 +921,6 @@ func (self LinkMsg) Bytes() []byte {
 	binary.Write(&buf, binary.BigEndian, self.ACapacity)
 
 	buf.Write(self.BPKH[:])
-	binary.Write(&buf, binary.BigEndian, self.BCapacity)
 
 	binary.Write(&buf, binary.BigEndian, self.CoinType)
 	binary.Write(&buf, binary.BigEndian, self.Seq)

--- a/qln/init.go
+++ b/qln/init.go
@@ -47,6 +47,8 @@ func NewLitNode(privKey *[32]byte, path string, trackerURL string) (*LitNode, er
 
 	nd.TrackerURL = trackerURL
 
+	nd.InitRouting()
+
 	// optional tower activation
 
 	nd.Tower = new(watchtower.WatchTower)

--- a/qln/lndb.go
+++ b/qln/lndb.go
@@ -3,6 +3,7 @@ package qln
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/adiabat/btcd/btcec"
 	"github.com/adiabat/btcd/wire"
@@ -124,6 +125,9 @@ type LitNode struct {
 
 	// The URL from which lit attempts to resolve the LN address
 	TrackerURL string
+
+	ChannelMap map[[20]byte][]lnutil.LinkMsg
+	AdvTimeout *time.Ticker
 }
 
 type RemotePeer struct {

--- a/qln/msghandler.go
+++ b/qln/msghandler.go
@@ -53,6 +53,12 @@ func (nd *LitNode) PeerHandler(msg lnutil.LitMsg, q *Qchan, peer *RemotePeer) er
 		if msg.MsgType() == lnutil.MSGID_WATCH_DELETE {
 			nd.Tower.DeleteChannel(msg.(lnutil.WatchDelMsg))
 		}
+
+	case 0x70: // Routing messages
+		if msg.MsgType() == lnutil.MSGID_LINK_DESC {
+			nd.LinkMsgHandler(msg.(lnutil.LinkMsg))
+		}
+
 	default:
 		return fmt.Errorf("Unknown message id byte %x &f0", msg.MsgType())
 

--- a/qln/routing.go
+++ b/qln/routing.go
@@ -1,0 +1,113 @@
+package qln
+
+import (
+	"bytes"
+	"time"
+
+	"github.com/btcsuite/fastsha256"
+	"github.com/mit-dci/lit/lnutil"
+)
+
+func (nd *LitNode) InitRouting() {
+	nd.ChannelMap = make(map[[20]byte][]lnutil.LinkMsg)
+
+	nd.AdvTimeout = time.NewTicker(time.Duration(300) * time.Second)
+
+	go func() {
+		seq := uint32(0)
+
+		for {
+			nd.cleanStaleChannels()
+			nd.advertiseLinks(seq)
+			seq++
+			<-nd.AdvTimeout.C
+		}
+	}()
+}
+
+func (nd *LitNode) cleanStaleChannels() {
+	newChannelMap := make(map[[20]byte][]lnutil.LinkMsg)
+
+	now := time.Now().Unix()
+
+	for pkh, node := range nd.ChannelMap {
+		for _, channel := range node {
+			if channel.Timestamp+600 >= now {
+				newChannelMap[pkh] = append(newChannelMap[pkh], channel)
+			}
+		}
+	}
+
+	nd.ChannelMap = newChannelMap
+}
+
+func (nd *LitNode) advertiseLinks(seq uint32) {
+	for peerIdx, peer := range nd.RemoteCons {
+		for _, q := range peer.QCs {
+			if !q.CloseData.Closed && q.State.MyAmt > 0 {
+				var outmsg lnutil.LinkMsg
+				outmsg.CoinType = q.Coin()
+				outmsg.Seq = seq
+
+				var idPub [33]byte
+				copy(idPub[:], nd.IdKey().PubKey().SerializeCompressed())
+
+				var theirIdPub [33]byte
+				copy(theirIdPub[:], peer.Con.RemotePub.SerializeCompressed())
+
+				outHash := fastsha256.Sum256(idPub[:])
+				copy(outmsg.APKH[:], outHash[:20])
+
+				outHash = fastsha256.Sum256(theirIdPub[:])
+				copy(outmsg.BPKH[:], outHash[:20])
+
+				outmsg.ACapacity = q.State.MyAmt
+				copy(outmsg.PKHScript[:], q.Op.Hash.CloneBytes()[:20])
+
+				outmsg.PeerIdx = peerIdx
+
+				nd.OmniOut <- outmsg
+			}
+		}
+	}
+}
+
+func (nd *LitNode) LinkMsgHandler(msg lnutil.LinkMsg) {
+	msg.Timestamp = time.Now().Unix()
+	newChan := true
+
+	// Check if node exists as a router
+	if _, ok := nd.ChannelMap[msg.APKH]; ok {
+		// Check if link state is most recent (seq)
+		for i, v := range nd.ChannelMap[msg.APKH] {
+			if bytes.Compare(v.PKHScript[:], msg.PKHScript[:]) == 0 {
+				// This is the link we've been looking for
+				if msg.Seq <= v.Seq {
+					// Old advert
+					return
+				}
+
+				// Update channel map
+				nd.ChannelMap[msg.APKH][i] = msg
+
+				newChan = false
+				break
+			}
+		}
+	}
+
+	if newChan {
+		// New peer or new channel
+		nd.ChannelMap[msg.APKH] = append(nd.ChannelMap[msg.APKH], msg)
+	}
+
+	// Rebroadcast
+	origIdx := msg.PeerIdx
+
+	for peerIdx, _ := range nd.RemoteCons {
+		if peerIdx != origIdx {
+			msg.PeerIdx = peerIdx
+			nd.OmniOut <- msg
+		}
+	}
+}

--- a/qln/routing.go
+++ b/qln/routing.go
@@ -2,7 +2,6 @@ package qln
 
 import (
 	"bytes"
-	"fmt"
 	"math"
 	"strconv"
 	"time"
@@ -24,7 +23,6 @@ func (nd *LitNode) InitRouting() {
 		for {
 			nd.cleanStaleChannels()
 			nd.advertiseLinks(seq)
-			fmt.Printf("ChannelMap: %+v", nd.ChannelMap)
 			seq++
 			<-nd.AdvTimeout.C
 		}


### PR DESCRIPTION
This PR implements a form of Link-State routing for Lit. Peers send each other information about their open and connected channels periodically and rebroadcast such advertisements from other peers. This allows each Lit node to build its own channel graph. Once multi-hop is implemented, this graph could be used in conjunction with Dijkstra's algorithm to find a route for a payment. 

This also adds the command `graph` to `lit-af` which dumps a Graphviz DOT encoded version of the channel graph. e.g. ![image 1](https://user-images.githubusercontent.com/4153717/35706694-b97f2f82-0774-11e8-916d-b01924d1a978.png)
