### PR TITLE
Optimized docker image size 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine
+FROM golang:alpine as build
 
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git openssh gcc musl-dev
@@ -11,5 +11,13 @@ WORKDIR /usr/local/go/src/github.com/mit-dci/lit
 RUN go build
 WORKDIR /usr/local/go/src/github.com/mit-dci/lit/cmd/lit-af
 RUN go build
+
+FROM alpine
+WORKDIR /app
+RUN cd /app
+COPY --from=build /usr/local/go/src/github.com/mit-dci/lit/lit /app/bin/lit
+COPY --from=build /usr/local/go/src/github.com/mit-dci/lit/cmd/lit-af/lit-af /app/bin/lit-af
+
 EXPOSE 8001
-ENTRYPOINT ["/usr/local/go/src/github.com/mit-dci/lit/lit"]
+
+CMD ["bin/lit"]


### PR DESCRIPTION
Implemented a two-stage build so that the final Docker image does not have the full Golang stack on it. Image size went from ~550MB to ~30MB