### PR TITLE
Make sure empty wallets' privkeys don't cause something weird

### DIFF
--- a/litrpc/chancmds.go
+++ b/litrpc/chancmds.go
@@ -290,7 +290,10 @@ func (r *LitRPC) DumpPrivs(args NoArgs, reply *DumpReply) error {
 		thisTxo.Witty = true
 		thisTxo.PairKey = fmt.Sprintf("%x", qc.TheirPub)
 
-		priv := wal.GetPriv(qc.KeyGen)
+		priv, err := wal.GetPriv(qc.KeyGen)
+		if err != nil {
+			return err
+		}
 		wif := btcutil.WIF{priv, true, wal.Params().PrivateKeyID}
 		thisTxo.WIF = wif.String()
 
@@ -317,7 +320,10 @@ func (r *LitRPC) DumpPrivs(args NoArgs, reply *DumpReply) error {
 				theseTxos[i].Delay = u.Height + int32(u.Seq) - syncHeight
 			}
 			theseTxos[i].Witty = u.Mode&portxo.FlagTxoWitness != 0
-			priv := wal.GetPriv(u.KeyGen)
+			priv, err := wal.GetPriv(u.KeyGen)
+			if err != nil {
+				return err
+			}
 			wif := btcutil.WIF{priv, true, wal.Params().PrivateKeyID}
 
 			theseTxos[i].WIF = wif.String()

--- a/qln/basewallet.go
+++ b/qln/basewallet.go
@@ -20,7 +20,7 @@ type UWallet interface {
 
 	// Have GetPriv for now.  Maybe later get rid of this and have
 	// the underlying wallet sign?
-	GetPriv(k portxo.KeyGen) *btcec.PrivateKey
+	GetPriv(k portxo.KeyGen) (*btcec.PrivateKey, error)
 
 	// Send a tx out to the network.  Maybe could replace?  Maybe not.
 	// Needed for channel break / cooperative close.  Maybe grabs.

--- a/qln/justicetx.go
+++ b/qln/justicetx.go
@@ -131,7 +131,10 @@ func (nd *LitNode) BuildJusticeSig(q *Qchan) error {
 	kg := q.KeyGen
 	kg.Step[2] = UseChannelHAKDBase
 	// get HAKD base scalar
-	privBase := nd.SubWallet[q.Coin()].GetPriv(kg)
+	privBase, err := nd.SubWallet[q.Coin()].GetPriv(kg)
+	if err != nil {
+		return err
+	}
 	// combine elk & HAKD base to make signing key
 	combinedPrivKey := lnutil.CombinePrivKeyWithBytes(privBase, elkScalar[:])
 

--- a/qln/lnchannels.go
+++ b/qln/lnchannels.go
@@ -211,8 +211,11 @@ func (nd *LitNode) GetDHSecret(q *Qchan) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	priv := nd.SubWallet[q.Coin()].GetPriv(q.KeyGen)
-	// not sure what happens if this breaks.  Maybe it always works.
+	priv, err := nd.SubWallet[q.Coin()].GetPriv(q.KeyGen)
+	// if this breaks, return
+	if err != nil {
+		return nil, err
+	}
 
 	return btcec.GenerateSharedSecret(priv, theirPub), nil
 }

--- a/qln/msghandler.go
+++ b/qln/msghandler.go
@@ -315,8 +315,10 @@ func (nd *LitNode) OPEventHandler(OPEventChan chan lnutil.OutPointEvent) {
 					elkScalar, portxo.KeyGen.PrivKey =
 						portxo.KeyGen.PrivKey, elkScalar
 
-					// TODO make sure this doesn't crash on nil wallet
-					privBase := nd.SubWallet[theQ.Coin()].GetPriv(portxo.KeyGen)
+					privBase, err := nd.SubWallet[theQ.Coin()].GetPriv(portxo.KeyGen)
+					if err != nil {
+						continue // or return?
+					}
 
 					portxo.PrivKey = lnutil.CombinePrivKeyAndSubtract(
 						privBase, elkScalar[:])

--- a/qln/signtx.go
+++ b/qln/signtx.go
@@ -27,7 +27,10 @@ func (nd *LitNode) SignBreakTx(q *Qchan) (*wire.MsgTx, error) {
 	}
 
 	// get private signing key
-	priv := nd.SubWallet[q.Coin()].GetPriv(q.KeyGen)
+	priv, err := nd.SubWallet[q.Coin()].GetPriv(q.KeyGen)
+	if err != nil {
+		return nil, err
+	}
 	// generate sig.
 	mySig, err := txscript.RawTxInWitnessSignature(
 		tx, hCache, 0, q.Value, pre, txscript.SigHashAll, priv)
@@ -69,7 +72,10 @@ func (nd *LitNode) SignSimpleClose(q *Qchan, tx *wire.MsgTx) ([64]byte, error) {
 		return sig, err
 	}
 	// get private signing key
-	priv := nd.SubWallet[q.Coin()].GetPriv(q.KeyGen)
+	priv, err := nd.SubWallet[q.Coin()].GetPriv(q.KeyGen)
+	if err != nil {
+		return sig, err
+	}
 	// generate sig
 	mySig, err := txscript.RawTxInWitnessSignature(
 		tx, hCache, 0, q.Value, pre, txscript.SigHashAll, priv)
@@ -110,7 +116,10 @@ func (nd *LitNode) SignState(q *Qchan) ([64]byte, error) {
 	}
 
 	// get private signing key
-	priv := nd.SubWallet[q.Coin()].GetPriv(q.KeyGen)
+	priv, err := nd.SubWallet[q.Coin()].GetPriv(q.KeyGen)
+		if err != nil {
+		return sig, err
+	}
 
 	// generate sig.
 	bigSig, err := txscript.RawTxInWitnessSignature(

--- a/wallit/basewalletif.go
+++ b/wallit/basewalletif.go
@@ -1,6 +1,7 @@
 package wallit
 
 import (
+	"fmt"
 	"log"
 	"sort"
 
@@ -34,8 +35,12 @@ type UWallet interface {
 
 // --- implementation of BaseWallet interface ----
 
-func (w *Wallit) GetPriv(k portxo.KeyGen) *btcec.PrivateKey {
-	return w.PathPrivkey(k)
+func (w *Wallit) GetPriv(k portxo.KeyGen) (*btcec.PrivateKey, error) {
+	if w.PathPrivkey(k) != nil {
+		return w.PathPrivkey(k), nil
+	} else {
+		return nil, fmt.Errorf("Nil Wallet Error")
+	}
 }
 
 func (w *Wallit) GetPub(k portxo.KeyGen) *btcec.PublicKey {


### PR DESCRIPTION
In most (if not all cases), the wallet shouldn't be nil, but in the rare case (if any) that it does, we must make sure we catch and return.