### PR TITLE
First version of Discreet Log Contracts

### DIFF
--- a/cmd/lit-af/dlccmds.go
+++ b/cmd/lit-af/dlccmds.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/fatih/color"
+	"github.com/mit-dci/lit/litrpc"
+	"github.com/mit-dci/lit/lnutil"
+)
+
+var dlcCommand = &Command{
+	Format: fmt.Sprintf("%s%s%s\n", lnutil.White("dlc"),
+		lnutil.ReqColor("subcommand"), lnutil.OptColor("parameters...")),
+	Description: fmt.Sprintf("%s\n%s\n",
+		"Command for working with discreet log contracts. Subcommand can be one of:",
+		fmt.Sprintf("%-10s %s", lnutil.White("oracle"), "Command to manage oracles"),
+	),
+	ShortDescription: "Command for working with Discreet Log Contracts.\n",
+}
+
+var oracleCommand = &Command{
+	Format: fmt.Sprintf("%s%s%s\n", lnutil.White("dlc oracle"),
+		lnutil.ReqColor("subcommand"), lnutil.OptColor("parameters...")),
+	Description: fmt.Sprintf("%s\n%s\n%s\n%s\n",
+		"Command for managing oracles. Subcommand can be one of:",
+		fmt.Sprintf("%s\t%s", lnutil.White("add"), "Adds a new oracle by manually providing the pubkeys"),
+		fmt.Sprintf("%s\t%s", lnutil.White("import"), "Imports a new oracle using a URL to its REST interface"),
+		fmt.Sprintf("%s\t%s", lnutil.White("ls"), "Shows a list of known oracles"),
+	),
+	ShortDescription: "Manages oracles for the Discreet Log Contracts.\n",
+}
+
+var listOraclesCommand = &Command{
+	Format:           fmt.Sprintf("%s\n", lnutil.White("dlc oracle ls")),
+	Description:      "Shows a list of known oracles\n",
+	ShortDescription: "Shows a list of known oracles\n",
+}
+
+func (lc *litAfClient) Dlc(textArgs []string) error {
+	if len(textArgs) > 0 && textArgs[0] == "-h" {
+		fmt.Fprintf(color.Output, dlcCommand.Format)
+		fmt.Fprintf(color.Output, dlcCommand.Description)
+		return nil
+	}
+
+	if len(textArgs) > 0 && textArgs[0] == "oracle" {
+		return lc.Oracle(textArgs[1:])
+	}
+
+	return fmt.Errorf(dlcCommand.Format)
+}
+
+func (lc *litAfClient) Oracle(textArgs []string) error {
+	if len(textArgs) > 0 && textArgs[0] == "-h" {
+		fmt.Fprintf(color.Output, oracleCommand.Format)
+		fmt.Fprintf(color.Output, oracleCommand.Description)
+		return nil
+	}
+
+	if len(textArgs) > 0 && textArgs[0] == "ls" {
+		return lc.ListOracles(textArgs[1:])
+	}
+
+	/*
+		if len(textArgs) > 0 && textArgs[0] == "add" {
+			return lc.AddOracle(textArgs[1:])
+		}*/
+
+	if len(textArgs) > 0 && textArgs[0] == "import" {
+		return lc.ImportOracle(textArgs[1:])
+	}
+
+	return fmt.Errorf(oracleCommand.Format)
+}
+
+func (lc *litAfClient) ListOracles(textArgs []string) error {
+	args := new(litrpc.ListOraclesArgs)
+	reply := new(litrpc.ListOraclesReply)
+
+	err := lc.rpccon.Call("LitRPC.ListOracles", args, reply)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(color.Output, "System knows %d oracles\n", len(reply.Oracles))
+	return nil
+}
+
+func (lc *litAfClient) ImportOracle(textArgs []string) error {
+	args := new(litrpc.ImportOracleArgs)
+	reply := new(litrpc.ImportOracleReply)
+
+	args.Url = textArgs[0]
+	args.Name = textArgs[1]
+
+	err := lc.rpccon.Call("LitRPC.ImportOracle", args, reply)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(color.Output, "Oracle succesfully registered under ID %d\n", reply.Oracle.Idx)
+	return nil
+}

--- a/cmd/lit-af/dlccmds.go
+++ b/cmd/lit-af/dlccmds.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"fmt"
+	"strconv"
+	"time"
 
 	"github.com/fatih/color"
+	"github.com/mit-dci/lit/dlc"
 	"github.com/mit-dci/lit/litrpc"
 	"github.com/mit-dci/lit/lnutil"
 )
@@ -11,9 +14,10 @@ import (
 var dlcCommand = &Command{
 	Format: fmt.Sprintf("%s%s%s\n", lnutil.White("dlc"),
 		lnutil.ReqColor("subcommand"), lnutil.OptColor("parameters...")),
-	Description: fmt.Sprintf("%s\n%s\n",
+	Description: fmt.Sprintf("%s\n%s\n%s\n",
 		"Command for working with discreet log contracts. Subcommand can be one of:",
 		fmt.Sprintf("%-10s %s", lnutil.White("oracle"), "Command to manage oracles"),
+		fmt.Sprintf("%-10s %s", lnutil.White("contract"), "Command to manage contracts"),
 	),
 	ShortDescription: "Command for working with Discreet Log Contracts.\n",
 }
@@ -36,6 +40,117 @@ var listOraclesCommand = &Command{
 	ShortDescription: "Shows a list of known oracles\n",
 }
 
+var importOracleCommand = &Command{
+	Format: fmt.Sprintf("%s%s%s\n", lnutil.White("dlc oracle import"),
+		lnutil.ReqColor("url"), lnutil.ReqColor("name")),
+	Description: fmt.Sprintf("%s\n%s\n%s\n",
+		"Imports a new oracle using a URL to its REST interface",
+		fmt.Sprintf("%s", lnutil.White("url"), "URL to the root of the publishes dlcoracle REST interface"),
+		fmt.Sprintf("%s", lnutil.White("name"), "Name under which to register the oracle in LIT"),
+	),
+	ShortDescription: "Imports a new oracle into LIT from a REST interface\n",
+}
+
+var addOracleCommand = &Command{
+	Format: fmt.Sprintf("%s%s%s\n", lnutil.White("dlc oracle add"),
+		lnutil.ReqColor("keys"), lnutil.ReqColor("name")),
+	Description: fmt.Sprintf("%s\n%s\n%s\n",
+		"Adds a new oracle by entering the pubkeys manually",
+		fmt.Sprintf("%s", lnutil.White("keys"), "Concatenated A,B and Q keys for the oracle"),
+		fmt.Sprintf("%s", lnutil.White("name"), "Name under which to register the oracle in LIT"),
+	),
+	ShortDescription: "Adds a new oracle into LIT\n",
+}
+
+var contractCommand = &Command{
+	Format: fmt.Sprintf("%s%s%s\n", lnutil.White("dlc contract"),
+		lnutil.ReqColor("subcommand"), lnutil.OptColor("parameters...")),
+	Description: fmt.Sprintf("%s\n%s\n%s\n%s\n%s\n%s\n%s\n",
+		"Command for managing contracts. Subcommand can be one of:",
+		fmt.Sprintf("%-20s\t%s", lnutil.White("new"), "Adds a new draft contract"),
+		fmt.Sprintf("%-20s\t%s", lnutil.White("view"), "Views a contract"),
+		fmt.Sprintf("%-20s\t%s", lnutil.White("setoracle"), "Sets a contract to use a particular oracle"),
+		fmt.Sprintf("%-20s\t%s", lnutil.White("setdatafeed"), "Sets the data feed to use for the contract"),
+		fmt.Sprintf("%-20s\t%s", lnutil.White("settime"), "Sets the settlement time of a contract"),
+		fmt.Sprintf("%-20s\t%s", lnutil.White("ls"), "Shows a list of known contracts"),
+	),
+	ShortDescription: "Manages oracles for the Discreet Log Contracts.\n",
+}
+
+var listContractsCommand = &Command{
+	Format:           fmt.Sprintf("%s\n", lnutil.White("dlc contract ls")),
+	Description:      "Shows a list of known contracts\n",
+	ShortDescription: "Shows a list of known contracts\n",
+}
+
+var addContractCommand = &Command{
+	Format:           fmt.Sprintf("%s\n", lnutil.White("dlc contract add")),
+	Description:      "Adds a new draft contract\n",
+	ShortDescription: "Adds a new draft contract\n",
+}
+
+var viewContractCommand = &Command{
+	Format: fmt.Sprintf("%s%s\n", lnutil.White("dlc contract view"),
+		lnutil.ReqColor("id")),
+	Description: fmt.Sprintf("%s\n%s\n",
+		"Views the current status of a contract",
+		fmt.Sprintf("%-10s %s", lnutil.White("id"), "The ID of the contract to view"),
+	),
+	ShortDescription: "Views the current status of a contract\n",
+}
+
+var setContractOracleCommand = &Command{
+	Format: fmt.Sprintf("%s%s\n", lnutil.White("dlc contract setoracle"),
+		lnutil.ReqColor("cid", "oid")),
+	Description: fmt.Sprintf("%s\n%s\n%s\n",
+		"Configures a contract for using a specific oracle",
+		fmt.Sprintf("%-10s %s", lnutil.White("cid"), "The ID of the contract"),
+		fmt.Sprintf("%-10s %s", lnutil.White("oid"), "The ID of the oracle"),
+	),
+	ShortDescription: "Configures a contract for using a specific oracle\n",
+}
+
+var setContractDatafeedCommand = &Command{
+	Format: fmt.Sprintf("%s%s\n", lnutil.White("dlc contract setdatafeed"),
+		lnutil.ReqColor("cid", "feed")),
+	Description: fmt.Sprintf("%s\n%s\n%s\n",
+		"Sets the data feed to use for the contract",
+		fmt.Sprintf("%-10s %s", lnutil.White("cid"), "The ID of the contract"),
+		fmt.Sprintf("%-10s %s", lnutil.White("feed"), "The ID of the data feed (provided by the oracle)"),
+	),
+	ShortDescription: "Configures a contract for using a specific oracle\n",
+}
+var setContractSettlementTimeCommand = &Command{
+	Format: fmt.Sprintf("%s%s\n", lnutil.White("dlc contract settime"),
+		lnutil.ReqColor("cid", "time")),
+	Description: fmt.Sprintf("%s\n%s\n%s\n",
+		"Sets the settlement time for the contract",
+		fmt.Sprintf("%-10s %s", lnutil.White("cid"), "The ID of the contract"),
+		fmt.Sprintf("%-10s %s", lnutil.White("time"), "The settlement time (unix timestamp)"),
+	),
+	ShortDescription: "Sets the settlement time for the contract\n",
+}
+var setContractFundingCommand = &Command{
+	Format: fmt.Sprintf("%s%s\n", lnutil.White("dlc contract setfunding"),
+		lnutil.ReqColor("ourAmount", "theirAmount")),
+	Description: fmt.Sprintf("%s\n%s\n%s\n",
+		"Sets the amounts both parties in the contract will fund",
+		fmt.Sprintf("%-10s %s", lnutil.White("ourAmount"), "The amount we will fund"),
+		fmt.Sprintf("%-10s %s", lnutil.White("theirAmount"), "The amount our peer will fund"),
+	),
+	ShortDescription: "Sets the amounts both parties in the contract will fund\n",
+}
+var setContractSettlementDivisionCommand = &Command{
+	Format: fmt.Sprintf("%s%s\n", lnutil.White("dlc contract setdivision"),
+		lnutil.ReqColor("valueAllForUs", "valueAllForThem")),
+	Description: fmt.Sprintf("%s\n%s\n%s\n",
+		"Sets the values of the oracle data that will result in the full contract funds being paid to either peer",
+		fmt.Sprintf("%-10s %s", lnutil.White("valueAllForUs"), "The outcome with which we will be entitled to the full contract value"),
+		fmt.Sprintf("%-10s %s", lnutil.White("valueAllForThem"), "The outcome with which our peer will be entitled to the full contract value"),
+	),
+	ShortDescription: "Sets the edge values of the oracle data for dividing the funds\n",
+}
+
 func (lc *litAfClient) Dlc(textArgs []string) error {
 	if len(textArgs) > 0 && textArgs[0] == "-h" {
 		fmt.Fprintf(color.Output, dlcCommand.Format)
@@ -44,13 +159,15 @@ func (lc *litAfClient) Dlc(textArgs []string) error {
 	}
 
 	if len(textArgs) > 0 && textArgs[0] == "oracle" {
-		return lc.Oracle(textArgs[1:])
+		return lc.DlcOracle(textArgs[1:])
 	}
-
+	if len(textArgs) > 0 && textArgs[0] == "contract" {
+		return lc.DlcContract(textArgs[1:])
+	}
 	return fmt.Errorf(dlcCommand.Format)
 }
 
-func (lc *litAfClient) Oracle(textArgs []string) error {
+func (lc *litAfClient) DlcOracle(textArgs []string) error {
 	if len(textArgs) > 0 && textArgs[0] == "-h" {
 		fmt.Fprintf(color.Output, oracleCommand.Format)
 		fmt.Fprintf(color.Output, oracleCommand.Description)
@@ -58,22 +175,21 @@ func (lc *litAfClient) Oracle(textArgs []string) error {
 	}
 
 	if len(textArgs) > 0 && textArgs[0] == "ls" {
-		return lc.ListOracles(textArgs[1:])
+		return lc.DlcListOracles(textArgs[1:])
 	}
 
-	/*
-		if len(textArgs) > 0 && textArgs[0] == "add" {
-			return lc.AddOracle(textArgs[1:])
-		}*/
+	if len(textArgs) > 0 && textArgs[0] == "add" {
+		return lc.DlcAddOracle(textArgs[1:])
+	}
 
 	if len(textArgs) > 0 && textArgs[0] == "import" {
-		return lc.ImportOracle(textArgs[1:])
+		return lc.DlcImportOracle(textArgs[1:])
 	}
 
 	return fmt.Errorf(oracleCommand.Format)
 }
 
-func (lc *litAfClient) ListOracles(textArgs []string) error {
+func (lc *litAfClient) DlcListOracles(textArgs []string) error {
 	args := new(litrpc.ListOraclesArgs)
 	reply := new(litrpc.ListOraclesReply)
 
@@ -81,12 +197,27 @@ func (lc *litAfClient) ListOracles(textArgs []string) error {
 	if err != nil {
 		return err
 	}
+	if len(reply.Oracles) == 0 {
+		fmt.Println("No oracles found")
+	}
+	for _, o := range reply.Oracles {
+		fmt.Fprintf(color.Output, "%04d: [%x...%x] [%x...%x] [%x...%x] %s\n", o.Idx, o.A[:2], o.A[31:], o.B[:2], o.B[31:], o.Q[:2], o.Q[31:], o.Name)
+	}
 
-	fmt.Fprintf(color.Output, "System knows %d oracles\n", len(reply.Oracles))
 	return nil
 }
 
-func (lc *litAfClient) ImportOracle(textArgs []string) error {
+func (lc *litAfClient) DlcImportOracle(textArgs []string) error {
+	if len(textArgs) > 0 && textArgs[0] == "-h" {
+		fmt.Fprintf(color.Output, importOracleCommand.Format)
+		fmt.Fprintf(color.Output, importOracleCommand.Description)
+		return nil
+	}
+
+	if len(textArgs) < 2 {
+		return fmt.Errorf(importOracleCommand.Format)
+	}
+
 	args := new(litrpc.ImportOracleArgs)
 	reply := new(litrpc.ImportOracleReply)
 
@@ -100,4 +231,255 @@ func (lc *litAfClient) ImportOracle(textArgs []string) error {
 
 	fmt.Fprintf(color.Output, "Oracle succesfully registered under ID %d\n", reply.Oracle.Idx)
 	return nil
+}
+
+func (lc *litAfClient) DlcAddOracle(textArgs []string) error {
+	if len(textArgs) > 0 && textArgs[0] == "-h" {
+		fmt.Fprintf(color.Output, addOracleCommand.Format)
+		fmt.Fprintf(color.Output, addOracleCommand.Description)
+		return nil
+	}
+
+	if len(textArgs) < 2 {
+		return fmt.Errorf(addOracleCommand.Format)
+	}
+
+	args := new(litrpc.AddOracleArgs)
+	reply := new(litrpc.AddOracleReply)
+
+	args.Keys = textArgs[0]
+	args.Name = textArgs[1]
+
+	err := lc.rpccon.Call("LitRPC.AddOracle", args, reply)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(color.Output, "Oracle succesfully registered under ID %d\n", reply.Oracle.Idx)
+	return nil
+}
+
+func (lc *litAfClient) DlcContract(textArgs []string) error {
+	if len(textArgs) > 0 && textArgs[0] == "-h" {
+		fmt.Fprintf(color.Output, contractCommand.Format)
+		fmt.Fprintf(color.Output, contractCommand.Description)
+		return nil
+	}
+
+	if len(textArgs) > 0 && textArgs[0] == "ls" {
+		return lc.DlcListContracts(textArgs[1:])
+	}
+
+	if len(textArgs) > 0 && textArgs[0] == "new" {
+		return lc.DlcNewContract(textArgs[1:])
+	}
+
+	if len(textArgs) > 0 && textArgs[0] == "view" {
+		return lc.DlcViewContract(textArgs[1:])
+	}
+
+	if len(textArgs) > 0 && textArgs[0] == "setoracle" {
+		return lc.DlcSetContractOracle(textArgs[1:])
+	}
+
+	if len(textArgs) > 0 && textArgs[0] == "setdatafeed" {
+		return lc.DlcSetContractDatafeed(textArgs[1:])
+	}
+
+	if len(textArgs) > 0 && textArgs[0] == "settime" {
+		return lc.DlcSetContractSettlementTime(textArgs[1:])
+	}
+	return fmt.Errorf(contractCommand.Format)
+}
+
+func (lc *litAfClient) DlcListContracts(textArgs []string) error {
+	args := new(litrpc.ListContractsArgs)
+	reply := new(litrpc.ListContractsReply)
+
+	err := lc.rpccon.Call("LitRPC.ListContracts", args, reply)
+	if err != nil {
+		return err
+	}
+
+	if len(reply.Contracts) == 0 {
+		fmt.Println("No contracts found")
+	}
+
+	for _, c := range reply.Contracts {
+		fmt.Fprintf(color.Output, "%04d: \n", c.Idx)
+	}
+
+	return nil
+}
+
+func (lc *litAfClient) DlcNewContract(textArgs []string) error {
+	args := new(litrpc.NewContractArgs)
+	reply := new(litrpc.NewContractReply)
+
+	err := lc.rpccon.Call("LitRPC.NewContract", args, reply)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprint(color.Output, "Contract succesfully created\n\n")
+	PrintContract(reply.Contract)
+	return nil
+}
+
+func (lc *litAfClient) DlcViewContract(textArgs []string) error {
+	if len(textArgs) > 0 && textArgs[0] == "-h" {
+		fmt.Fprintf(color.Output, viewContractCommand.Format)
+		fmt.Fprintf(color.Output, viewContractCommand.Description)
+		return nil
+	}
+
+	if len(textArgs) < 1 {
+		return fmt.Errorf(viewContractCommand.Format)
+	}
+
+	args := new(litrpc.GetContractArgs)
+	reply := new(litrpc.GetContractReply)
+
+	cIdx, err := strconv.ParseUint(textArgs[0], 10, 64)
+	if err != nil {
+		return err
+	}
+	args.Idx = cIdx
+
+	err = lc.rpccon.Call("LitRPC.GetContract", args, reply)
+	if err != nil {
+		return err
+	}
+
+	PrintContract(reply.Contract)
+	return nil
+}
+
+func (lc *litAfClient) DlcSetContractOracle(textArgs []string) error {
+	if len(textArgs) > 0 && textArgs[0] == "-h" {
+		fmt.Fprintf(color.Output, setContractOracleCommand.Format)
+		fmt.Fprintf(color.Output, setContractOracleCommand.Description)
+		return nil
+	}
+
+	if len(textArgs) < 1 {
+		return fmt.Errorf(setContractOracleCommand.Format)
+	}
+
+	args := new(litrpc.SetContractOracleArgs)
+	reply := new(litrpc.SetContractOracleReply)
+
+	cIdx, err := strconv.ParseUint(textArgs[0], 10, 64)
+	if err != nil {
+		return err
+	}
+	oIdx, err := strconv.ParseUint(textArgs[1], 10, 64)
+	if err != nil {
+		return err
+	}
+	args.CIdx = cIdx
+	args.OIdx = oIdx
+
+	err = lc.rpccon.Call("LitRPC.SetContractOracle", args, reply)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprint(color.Output, "Oracle set succesfully\n")
+
+	return nil
+}
+
+func (lc *litAfClient) DlcSetContractDatafeed(textArgs []string) error {
+	if len(textArgs) > 0 && textArgs[0] == "-h" {
+		fmt.Fprintf(color.Output, setContractDatafeedCommand.Format)
+		fmt.Fprintf(color.Output, setContractDatafeedCommand.Description)
+		return nil
+	}
+
+	if len(textArgs) < 1 {
+		return fmt.Errorf(setContractDatafeedCommand.Format)
+	}
+
+	args := new(litrpc.SetContractDatafeedArgs)
+	reply := new(litrpc.SetContractDatafeedReply)
+
+	cIdx, err := strconv.ParseUint(textArgs[0], 10, 64)
+	if err != nil {
+		return err
+	}
+	feed, err := strconv.ParseUint(textArgs[1], 10, 64)
+	if err != nil {
+		return err
+	}
+	args.CIdx = cIdx
+	args.Feed = feed
+
+	err = lc.rpccon.Call("LitRPC.SetContractDatafeed", args, reply)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprint(color.Output, "Datafeed set succesfully\n")
+
+	return nil
+}
+
+func (lc *litAfClient) DlcSetContractSettlementTime(textArgs []string) error {
+	if len(textArgs) > 0 && textArgs[0] == "-h" {
+		fmt.Fprintf(color.Output, setContractSettlementTimeCommand.Format)
+		fmt.Fprintf(color.Output, setContractSettlementTimeCommand.Description)
+		return nil
+	}
+
+	if len(textArgs) < 1 {
+		return fmt.Errorf(setContractSettlementTimeCommand.Format)
+	}
+
+	args := new(litrpc.SetContractSettlementTimeArgs)
+	reply := new(litrpc.SetContractSettlementTimeReply)
+
+	cIdx, err := strconv.ParseUint(textArgs[0], 10, 64)
+	if err != nil {
+		return err
+	}
+	time, err := strconv.ParseUint(textArgs[1], 10, 64)
+	if err != nil {
+		return err
+	}
+	args.CIdx = cIdx
+	args.Time = time
+
+	err = lc.rpccon.Call("LitRPC.SetContractSettlementTime", args, reply)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprint(color.Output, "Settlement time set succesfully\n")
+
+	return nil
+}
+
+func PrintContract(c *dlc.DlcContract) {
+	fmt.Fprintf(color.Output, "%-30s : %d\n", lnutil.White("Index"), c.Idx)
+	fmt.Fprintf(color.Output, "%-30s : [%x...%x] [%x...%x] [%x...%x]\n", lnutil.White("Oracle keys"), c.OracleA[:2], c.OracleA[31:], c.OracleB[:2], c.OracleB[31:], c.OracleQ[:2], c.OracleQ[31:])
+	fmt.Fprintf(color.Output, "%-30s : %04x\n", lnutil.White("Oracle feed"), c.OracleDataFeed)
+	fmt.Fprintf(color.Output, "%-30s : %s\n", lnutil.White("Settlement time"), time.Unix(int64(c.OracleTimestamp), 0).UTC().Format(time.UnixDate))
+	fmt.Fprintf(color.Output, "%-30s : %d\n", lnutil.White("Funded by us"), c.OurFundingAmount)
+	fmt.Fprintf(color.Output, "%-30s : %d\n", lnutil.White("Funded by peer"), c.TheirFundingAmount)
+	fmt.Fprintf(color.Output, "%-30s : %d\n", lnutil.White("Value 100% us"), c.ValueAllOurs)
+	fmt.Fprintf(color.Output, "%-30s : %d\n", lnutil.White("Value 100% peer"), c.ValueAllTheirs)
+
+	status := "Draft"
+	switch c.Status {
+	case dlc.ContractStatusActive:
+		status = "Active"
+	case dlc.ContractStatusClosed:
+		status = "Closed"
+	case dlc.ContractStatusOffered:
+		status = "Offered, awaiting reply"
+	}
+
+	fmt.Fprintf(color.Output, "%-30s : %s\n", lnutil.White("Status"), status)
+
 }

--- a/cmd/lit-af/dlccmds.go
+++ b/cmd/lit-af/dlccmds.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"bytes"
+	"encoding/hex"
 	"fmt"
 	"strconv"
 	"time"
@@ -27,9 +27,9 @@ var oracleCommand = &Command{
 		lnutil.ReqColor("subcommand"), lnutil.OptColor("parameters...")),
 	Description: fmt.Sprintf("%s\n%s\n%s\n%s\n",
 		"Command for managing oracles. Subcommand can be one of:",
-		fmt.Sprintf("%s\t%s", lnutil.White("add"), "Adds a new oracle by manually providing the pubkeys"),
-		fmt.Sprintf("%s\t%s", lnutil.White("import"), "Imports a new oracle using a URL to its REST interface"),
-		fmt.Sprintf("%s\t%s", lnutil.White("ls"), "Shows a list of known oracles"),
+		fmt.Sprintf("%-20s %s", lnutil.White("add"), "Adds a new oracle by manually providing the pubkey"),
+		fmt.Sprintf("%-20s %s", lnutil.White("import"), "Imports a new oracle using a URL to its REST interface"),
+		fmt.Sprintf("%-20s %s", lnutil.White("ls"), "Shows a list of known oracles"),
 	),
 	ShortDescription: "Manages oracles for the Discreet Log Contracts.\n",
 }
@@ -45,8 +45,8 @@ var importOracleCommand = &Command{
 		lnutil.ReqColor("url"), lnutil.ReqColor("name")),
 	Description: fmt.Sprintf("%s\n%s\n%s\n",
 		"Imports a new oracle using a URL to its REST interface",
-		fmt.Sprintf("%s", lnutil.White("url"), "URL to the root of the publishes dlcoracle REST interface"),
-		fmt.Sprintf("%s", lnutil.White("name"), "Name under which to register the oracle in LIT"),
+		fmt.Sprintf("%-20s %s", lnutil.White("url"), "URL to the root of the publishes dlcoracle REST interface"),
+		fmt.Sprintf("%-20s %s", lnutil.White("name"), "Name under which to register the oracle in LIT"),
 	),
 	ShortDescription: "Imports a new oracle into LIT from a REST interface\n",
 }
@@ -56,8 +56,8 @@ var addOracleCommand = &Command{
 		lnutil.ReqColor("keys"), lnutil.ReqColor("name")),
 	Description: fmt.Sprintf("%s\n%s\n%s\n",
 		"Adds a new oracle by entering the pubkeys manually",
-		fmt.Sprintf("%s", lnutil.White("keys"), "Concatenated A,B and Q keys for the oracle"),
-		fmt.Sprintf("%s", lnutil.White("name"), "Name under which to register the oracle in LIT"),
+		fmt.Sprintf("%-20s %s", lnutil.White("keys"), "Public key for the oracle (33 bytes in hex)"),
+		fmt.Sprintf("%-20s %s", lnutil.White("name"), "Name under which to register the oracle in LIT"),
 	),
 	ShortDescription: "Adds a new oracle into LIT\n",
 }
@@ -65,19 +65,20 @@ var addOracleCommand = &Command{
 var contractCommand = &Command{
 	Format: fmt.Sprintf("%s%s%s\n", lnutil.White("dlc contract"),
 		lnutil.ReqColor("subcommand"), lnutil.OptColor("parameters...")),
-	Description: fmt.Sprintf("%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n",
+	Description: fmt.Sprintf("%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n",
 		"Command for managing contracts. Subcommand can be one of:",
-		fmt.Sprintf("%-20s\t%s", lnutil.White("new"), "Adds a new draft contract"),
-		fmt.Sprintf("%-20s\t%s", lnutil.White("view"), "Views a contract"),
-		fmt.Sprintf("%-20s\t%s", lnutil.White("setoracle"), "Sets a contract to use a particular oracle"),
-		fmt.Sprintf("%-20s\t%s", lnutil.White("setdatafeed"), "Sets the data feed to use for the contract"),
-		fmt.Sprintf("%-20s\t%s", lnutil.White("settime"), "Sets the settlement time of a contract"),
-		fmt.Sprintf("%-20s\t%s", lnutil.White("setfunding"), "Sets the funding parameters of a contract"),
-		fmt.Sprintf("%-20s\t%s", lnutil.White("setdivision"), "Sets the settlement division of a contract"),
-		fmt.Sprintf("%-20s\t%s", lnutil.White("setcointype"), "Sets the cointype of a contract"),
-		fmt.Sprintf("%-20s\t%s", lnutil.White("offer"), "Offer a draft contract to one of your peers"),
-		fmt.Sprintf("%-20s\t%s", lnutil.White("decline"), "Decline a contract sent to you"),
-		fmt.Sprintf("%-20s\t%s", lnutil.White("ls"), "Shows a list of known contracts"),
+		fmt.Sprintf("%-20s %s", lnutil.White("new"), "Adds a new draft contract"),
+		fmt.Sprintf("%-20s %s", lnutil.White("view"), "Views a contract"),
+		fmt.Sprintf("%-20s %s", lnutil.White("setoracle"), "Sets a contract to use a particular oracle"),
+		fmt.Sprintf("%-20s %s", lnutil.White("settime"), "Sets the settlement time of a contract"),
+		fmt.Sprintf("%-20s %s", lnutil.White("setdatafeed"), "Sets the data feed to use for the contract, will fetch the R point"),
+		fmt.Sprintf("%-20s %s", lnutil.White("setrpoint"), "Sets the R point manually"),
+		fmt.Sprintf("%-20s %s", lnutil.White("setfunding"), "Sets the funding parameters of a contract"),
+		fmt.Sprintf("%-20s %s", lnutil.White("setdivision"), "Sets the settlement division of a contract"),
+		fmt.Sprintf("%-20s %s", lnutil.White("setcointype"), "Sets the cointype of a contract"),
+		fmt.Sprintf("%-20s %s", lnutil.White("offer"), "Offer a draft contract to one of your peers"),
+		fmt.Sprintf("%-20s %s", lnutil.White("decline"), "Decline a contract sent to you"),
+		fmt.Sprintf("%-20s %s", lnutil.White("ls"), "Shows a list of known contracts"),
 	),
 	ShortDescription: "Manages oracles for the Discreet Log Contracts.\n",
 }
@@ -123,8 +124,20 @@ var setContractDatafeedCommand = &Command{
 		fmt.Sprintf("%-10s %s", lnutil.White("cid"), "The ID of the contract"),
 		fmt.Sprintf("%-10s %s", lnutil.White("feed"), "The ID of the data feed (provided by the oracle)"),
 	),
-	ShortDescription: "Configures a contract for using a specific oracle\n",
+	ShortDescription: "Sets the data feed to use for the contract\n",
 }
+
+var setContractRPointCommand = &Command{
+	Format: fmt.Sprintf("%s%s\n", lnutil.White("dlc contract setrpoint"),
+		lnutil.ReqColor("cid", "rpoint")),
+	Description: fmt.Sprintf("%s\n%s\n%s\n",
+		"Sets the R point to use for the contract",
+		fmt.Sprintf("%-10s %s", lnutil.White("cid"), "The ID of the contract"),
+		fmt.Sprintf("%-10s %s", lnutil.White("rpoint"), "The Rpoint of the publication to use (33 byte in hex)"),
+	),
+	ShortDescription: "Sets the R point to use for the contract\n",
+}
+
 var setContractSettlementTimeCommand = &Command{
 	Format: fmt.Sprintf("%s%s\n", lnutil.White("dlc contract settime"),
 		lnutil.ReqColor("cid", "time")),
@@ -175,6 +188,15 @@ var declineContractCommand = &Command{
 		fmt.Sprintf("%-10s %s", lnutil.White("cid"), "The ID of the contract to decline"),
 	),
 	ShortDescription: "Declines a contract offered to you\n",
+}
+var acceptContractCommand = &Command{
+	Format: fmt.Sprintf("%s%s\n", lnutil.White("dlc contract accept"),
+		lnutil.ReqColor("cid")),
+	Description: fmt.Sprintf("%s\n%s\n",
+		"Accepts a contract offered to you",
+		fmt.Sprintf("%-10s %s", lnutil.White("cid"), "The ID of the contract to accept"),
+	),
+	ShortDescription: "Accepts a contract offered to you\n",
 }
 var offerContractCommand = &Command{
 	Format: fmt.Sprintf("%s%s\n", lnutil.White("dlc contract offer"),
@@ -237,7 +259,7 @@ func (lc *litAfClient) DlcListOracles(textArgs []string) error {
 		fmt.Println("No oracles found")
 	}
 	for _, o := range reply.Oracles {
-		fmt.Fprintf(color.Output, "%04d: [%x...%x] [%x...%x] [%x...%x] %s\n", o.Idx, o.A[:2], o.A[31:], o.B[:2], o.B[31:], o.Q[:2], o.Q[31:], o.Name)
+		fmt.Fprintf(color.Output, "%04d: [%x...%x...%x]  %s\n", o.Idx, o.A[:2], o.A[15:16], o.A[31:], o.Name)
 	}
 
 	return nil
@@ -283,7 +305,7 @@ func (lc *litAfClient) DlcAddOracle(textArgs []string) error {
 	args := new(litrpc.AddOracleArgs)
 	reply := new(litrpc.AddOracleReply)
 
-	args.Keys = textArgs[0]
+	args.Key = textArgs[0]
 	args.Name = textArgs[1]
 
 	err := lc.rpccon.Call("LitRPC.AddOracle", args, reply)
@@ -322,6 +344,10 @@ func (lc *litAfClient) DlcContract(textArgs []string) error {
 		return lc.DlcSetContractDatafeed(textArgs[1:])
 	}
 
+	if len(textArgs) > 0 && textArgs[0] == "setrpoint" {
+		return lc.DlcSetContractRPoint(textArgs[1:])
+	}
+
 	if len(textArgs) > 0 && textArgs[0] == "settime" {
 		return lc.DlcSetContractSettlementTime(textArgs[1:])
 	}
@@ -344,6 +370,10 @@ func (lc *litAfClient) DlcContract(textArgs []string) error {
 
 	if len(textArgs) > 0 && textArgs[0] == "decline" {
 		return lc.DlcDeclineContract(textArgs[1:])
+	}
+
+	if len(textArgs) > 0 && textArgs[0] == "accept" {
+		return lc.DlcAcceptContract(textArgs[1:])
 	}
 	return fmt.Errorf(contractCommand.Format)
 }
@@ -477,6 +507,41 @@ func (lc *litAfClient) DlcSetContractDatafeed(textArgs []string) error {
 	}
 
 	fmt.Fprint(color.Output, "Datafeed set succesfully\n")
+
+	return nil
+}
+
+func (lc *litAfClient) DlcSetContractRPoint(textArgs []string) error {
+	if len(textArgs) > 0 && textArgs[0] == "-h" {
+		fmt.Fprintf(color.Output, setContractRPointCommand.Format)
+		fmt.Fprintf(color.Output, setContractRPointCommand.Description)
+		return nil
+	}
+
+	if len(textArgs) < 2 {
+		return fmt.Errorf(setContractRPointCommand.Format)
+	}
+
+	args := new(litrpc.SetContractRPointArgs)
+	reply := new(litrpc.SetContractRPointReply)
+
+	cIdx, err := strconv.ParseUint(textArgs[0], 10, 64)
+	if err != nil {
+		return err
+	}
+	rPoint, err := hex.DecodeString(textArgs[1])
+	if err != nil {
+		return err
+	}
+	args.CIdx = cIdx
+	copy(args.RPoint[:], rPoint[:])
+
+	err = lc.rpccon.Call("LitRPC.SetContractRPoint", args, reply)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprint(color.Output, "R-point set succesfully\n")
 
 	return nil
 }
@@ -699,10 +764,42 @@ func (lc *litAfClient) DlcDeclineContract(textArgs []string) error {
 	return nil
 }
 
+func (lc *litAfClient) DlcAcceptContract(textArgs []string) error {
+	if len(textArgs) > 0 && textArgs[0] == "-h" {
+		fmt.Fprintf(color.Output, acceptContractCommand.Format)
+		fmt.Fprintf(color.Output, acceptContractCommand.Description)
+		return nil
+	}
+
+	if len(textArgs) < 1 {
+		return fmt.Errorf(acceptContractCommand.Format)
+	}
+
+	args := new(litrpc.AcceptContractArgs)
+	reply := new(litrpc.AcceptContractArgs)
+
+	cIdx, err := strconv.ParseUint(textArgs[0], 10, 64)
+	if err != nil {
+		return err
+	}
+
+	args.CIdx = cIdx
+
+	err = lc.rpccon.Call("LitRPC.AcceptContract", args, reply)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprint(color.Output, "Offer accepted succesfully\n")
+
+	return nil
+}
+
 func PrintContract(c *lnutil.DlcContract) {
 	fmt.Fprintf(color.Output, "%-30s : %d\n", lnutil.White("Index"), c.Idx)
-	fmt.Fprintf(color.Output, "%-30s : [%x...%x] [%x...%x] [%x...%x]\n", lnutil.White("Oracle keys"), c.OracleA[:2], c.OracleA[31:], c.OracleB[:2], c.OracleB[31:], c.OracleQ[:2], c.OracleQ[31:])
-	fmt.Fprintf(color.Output, "%-30s : %04x\n", lnutil.White("Oracle feed"), c.OracleDataFeed)
+	fmt.Fprintf(color.Output, "%-30s : %x\n", lnutil.White("Pubkey"), c.PubKey)
+	fmt.Fprintf(color.Output, "%-30s : [%x...%x...%x]\n", lnutil.White("Oracle public key"), c.OracleA[:2], c.OracleA[15:16], c.OracleA[31:])
+	fmt.Fprintf(color.Output, "%-30s : [%x...%x...%x]\n", lnutil.White("Oracle R-point"), c.OracleR[:2], c.OracleR[15:16], c.OracleR[31:])
 	fmt.Fprintf(color.Output, "%-30s : %s\n", lnutil.White("Settlement time"), time.Unix(int64(c.OracleTimestamp), 0).UTC().Format(time.UnixDate))
 	fmt.Fprintf(color.Output, "%-30s : %d\n", lnutil.White("Funded by us"), c.OurFundingAmount)
 	fmt.Fprintf(color.Output, "%-30s : %d\n", lnutil.White("Funded by peer"), c.TheirFundingAmount)
@@ -711,8 +808,8 @@ func PrintContract(c *lnutil.DlcContract) {
 	fmt.Fprintf(color.Output, "%-30s : %d\n", lnutil.White("Coin type"), c.CoinType)
 
 	peer := "None"
-	if len(bytes.Trim(c.RemoteNodePub[:], "\x00")) > 0 {
-		peer = lnutil.LitAdrFromPubkey(c.RemoteNodePub)
+	if c.PeerIdx > 0 {
+		peer = fmt.Sprintf("Peer %d", c.PeerIdx)
 	}
 
 	fmt.Fprintf(color.Output, "%-30s : %s\n", lnutil.White("Peer"), peer)
@@ -727,6 +824,8 @@ func PrintContract(c *lnutil.DlcContract) {
 		status = "Sent offer, awaiting reply"
 	case lnutil.ContractStatusOfferedToMe:
 		status = "Received offer, awaiting reply"
+	case lnutil.ContractStatusAccepted:
+		status = "Accepted"
 	case lnutil.ContractStatusDeclined:
 		status = "Declined"
 	}

--- a/cmd/lit-af/dlccmds.go
+++ b/cmd/lit-af/dlccmds.go
@@ -568,8 +568,10 @@ func PrintContract(c *dlc.DlcContract) {
 		status = "Active"
 	case dlc.ContractStatusClosed:
 		status = "Closed"
-	case dlc.ContractStatusOffered:
-		status = "Offered, awaiting reply"
+	case dlc.ContractStatusOfferedByMe:
+		status = "Sent offer, awaiting reply"
+	case dlc.ContractStatusOfferedToMe:
+		status = "Received offer, awaiting reply"
 	}
 
 	fmt.Fprintf(color.Output, "%-30s : %s\n", lnutil.White("Status"), status)

--- a/cmd/lit-af/dlccmds.go
+++ b/cmd/lit-af/dlccmds.go
@@ -599,11 +599,11 @@ func (lc *litAfClient) DlcSetContractFunding(textArgs []string) error {
 	if err != nil {
 		return err
 	}
-	ourAmount, err := strconv.ParseUint(textArgs[1], 10, 64)
+	ourAmount, err := strconv.ParseInt(textArgs[1], 10, 64)
 	if err != nil {
 		return err
 	}
-	theirAmount, err := strconv.ParseUint(textArgs[2], 10, 64)
+	theirAmount, err := strconv.ParseInt(textArgs[2], 10, 64)
 	if err != nil {
 		return err
 	}
@@ -675,11 +675,11 @@ func (lc *litAfClient) DlcSetContractSettlementDivision(textArgs []string) error
 	if err != nil {
 		return err
 	}
-	fullyOurs, err := strconv.ParseUint(textArgs[1], 10, 64)
+	fullyOurs, err := strconv.ParseInt(textArgs[1], 10, 64)
 	if err != nil {
 		return err
 	}
-	fullyTheirs, err := strconv.ParseUint(textArgs[2], 10, 64)
+	fullyTheirs, err := strconv.ParseInt(textArgs[2], 10, 64)
 	if err != nil {
 		return err
 	}

--- a/cmd/lit-af/dlccmds.go
+++ b/cmd/lit-af/dlccmds.go
@@ -918,7 +918,6 @@ func (lc *litAfClient) DlcSettleContract(textArgs []string) error {
 
 func PrintContract(c *lnutil.DlcContract) {
 	fmt.Fprintf(color.Output, "%-30s : %d\n", lnutil.White("Index"), c.Idx)
-	fmt.Fprintf(color.Output, "%-30s : %x\n", lnutil.White("Pubkey"), c.PubKey)
 	fmt.Fprintf(color.Output, "%-30s : [%x...%x...%x]\n", lnutil.White("Oracle public key"), c.OracleA[:2], c.OracleA[15:16], c.OracleA[31:])
 	fmt.Fprintf(color.Output, "%-30s : [%x...%x...%x]\n", lnutil.White("Oracle R-point"), c.OracleR[:2], c.OracleR[15:16], c.OracleR[31:])
 	fmt.Fprintf(color.Output, "%-30s : %s\n", lnutil.White("Settlement time"), time.Unix(int64(c.OracleTimestamp), 0).UTC().Format(time.UnixDate))

--- a/cmd/lit-af/dlccmds.go
+++ b/cmd/lit-af/dlccmds.go
@@ -15,10 +15,13 @@ import (
 var dlcCommand = &Command{
 	Format: fmt.Sprintf("%s%s%s\n", lnutil.White("dlc"),
 		lnutil.ReqColor("subcommand"), lnutil.OptColor("parameters...")),
-	Description: fmt.Sprintf("%s\n%s\n%s\n",
-		"Command for working with discreet log contracts. Subcommand can be one of:",
-		fmt.Sprintf("%-10s %s", lnutil.White("oracle"), "Command to manage oracles"),
-		fmt.Sprintf("%-10s %s", lnutil.White("contract"), "Command to manage contracts"),
+	Description: fmt.Sprintf("%s%2\n%s\n%s\n",
+		"Command for working with discreet log contracts. ",
+		"Subcommand can be one of:",
+		fmt.Sprintf("%-10s %s",
+			lnutil.White("oracle"), "Command to manage oracles"),
+		fmt.Sprintf("%-10s %s",
+			lnutil.White("contract"), "Command to manage contracts"),
 	),
 	ShortDescription: "Command for working with Discreet Log Contracts.\n",
 }
@@ -28,9 +31,15 @@ var oracleCommand = &Command{
 		lnutil.ReqColor("subcommand"), lnutil.OptColor("parameters...")),
 	Description: fmt.Sprintf("%s\n%s\n%s\n%s\n",
 		"Command for managing oracles. Subcommand can be one of:",
-		fmt.Sprintf("%-20s %s", lnutil.White("add"), "Adds a new oracle by manually providing the pubkey"),
-		fmt.Sprintf("%-20s %s", lnutil.White("import"), "Imports a new oracle using a URL to its REST interface"),
-		fmt.Sprintf("%-20s %s", lnutil.White("ls"), "Shows a list of known oracles"),
+		fmt.Sprintf("%-20s %s",
+			lnutil.White("add"),
+			"Adds a new oracle by manually providing the pubkey"),
+		fmt.Sprintf("%-20s %s",
+			lnutil.White("import"),
+			"Imports a new oracle using a URL to its REST interface"),
+		fmt.Sprintf("%-20s %s",
+			lnutil.White("ls"),
+			"Shows a list of known oracles"),
 	),
 	ShortDescription: "Manages oracles for the Discreet Log Contracts.\n",
 }
@@ -46,8 +55,12 @@ var importOracleCommand = &Command{
 		lnutil.ReqColor("url"), lnutil.ReqColor("name")),
 	Description: fmt.Sprintf("%s\n%s\n%s\n",
 		"Imports a new oracle using a URL to its REST interface",
-		fmt.Sprintf("%-20s %s", lnutil.White("url"), "URL to the root of the publishes dlcoracle REST interface"),
-		fmt.Sprintf("%-20s %s", lnutil.White("name"), "Name under which to register the oracle in LIT"),
+		fmt.Sprintf("%-20s %s",
+			lnutil.White("url"),
+			"URL to the root of the publishes dlcoracle REST interface"),
+		fmt.Sprintf("%-20s %s",
+			lnutil.White("name"),
+			"Name under which to register the oracle in LIT"),
 	),
 	ShortDescription: "Imports a new oracle into LIT from a REST interface\n",
 }
@@ -57,8 +70,12 @@ var addOracleCommand = &Command{
 		lnutil.ReqColor("keys"), lnutil.ReqColor("name")),
 	Description: fmt.Sprintf("%s\n%s\n%s\n",
 		"Adds a new oracle by entering the pubkeys manually",
-		fmt.Sprintf("%-20s %s", lnutil.White("keys"), "Public key for the oracle (33 bytes in hex)"),
-		fmt.Sprintf("%-20s %s", lnutil.White("name"), "Name under which to register the oracle in LIT"),
+		fmt.Sprintf("%-20s %s",
+			lnutil.White("keys"),
+			"Public key for the oracle (33 bytes in hex)"),
+		fmt.Sprintf("%-20s %s",
+			lnutil.White("name"),
+			"Name under which to register the oracle in LIT"),
 	),
 	ShortDescription: "Adds a new oracle into LIT\n",
 }
@@ -66,22 +83,51 @@ var addOracleCommand = &Command{
 var contractCommand = &Command{
 	Format: fmt.Sprintf("%s%s%s\n", lnutil.White("dlc contract"),
 		lnutil.ReqColor("subcommand"), lnutil.OptColor("parameters...")),
-	Description: fmt.Sprintf("%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n",
+	Description: fmt.Sprintf("%s\n%s\n%s\n%s\n%s\n%s\n"+
+		"%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n",
 		"Command for managing contracts. Subcommand can be one of:",
-		fmt.Sprintf("%-20s %s", lnutil.White("new"), "Adds a new draft contract"),
-		fmt.Sprintf("%-20s %s", lnutil.White("view"), "Views a contract"),
-		fmt.Sprintf("%-20s %s", lnutil.White("viewpayout"), "Views the payout table of a contract"),
-		fmt.Sprintf("%-20s %s", lnutil.White("setoracle"), "Sets a contract to use a particular oracle"),
-		fmt.Sprintf("%-20s %s", lnutil.White("settime"), "Sets the settlement time of a contract"),
-		fmt.Sprintf("%-20s %s", lnutil.White("setdatafeed"), "Sets the data feed to use for the contract, will fetch the R point"),
-		fmt.Sprintf("%-20s %s", lnutil.White("setrpoint"), "Sets the R point manually"),
-		fmt.Sprintf("%-20s %s", lnutil.White("setfunding"), "Sets the funding parameters of a contract"),
-		fmt.Sprintf("%-20s %s", lnutil.White("setdivision"), "Sets the settlement division of a contract"),
-		fmt.Sprintf("%-20s %s", lnutil.White("setcointype"), "Sets the cointype of a contract"),
-		fmt.Sprintf("%-20s %s", lnutil.White("offer"), "Offer a draft contract to one of your peers"),
-		fmt.Sprintf("%-20s %s", lnutil.White("decline"), "Decline a contract sent to you"),
-		fmt.Sprintf("%-20s %s", lnutil.White("settle"), "Settles the contract"),
-		fmt.Sprintf("%-20s %s", lnutil.White("ls"), "Shows a list of known contracts"),
+		fmt.Sprintf("%-20s %s",
+			lnutil.White("new"),
+			"Adds a new draft contract"),
+		fmt.Sprintf("%-20s %s",
+			lnutil.White("view"),
+			"Views a contract"),
+		fmt.Sprintf("%-20s %s",
+			lnutil.White("viewpayout"),
+			"Views the payout table of a contract"),
+		fmt.Sprintf("%-20s %s",
+			lnutil.White("setoracle"),
+			"Sets a contract to use a particular oracle"),
+		fmt.Sprintf("%-20s %s",
+			lnutil.White("settime"),
+			"Sets the settlement time of a contract"),
+		fmt.Sprintf("%-20s %s",
+			lnutil.White("setdatafeed"),
+			"Sets the data feed to use, will fetch the R point"),
+		fmt.Sprintf("%-20s %s",
+			lnutil.White("setrpoint"),
+			"Sets the R point manually"),
+		fmt.Sprintf("%-20s %s",
+			lnutil.White("setfunding"),
+			"Sets the funding parameters of a contract"),
+		fmt.Sprintf("%-20s %s",
+			lnutil.White("setdivision"),
+			"Sets the settlement division of a contract"),
+		fmt.Sprintf("%-20s %s",
+			lnutil.White("setcointype"),
+			"Sets the cointype of a contract"),
+		fmt.Sprintf("%-20s %s",
+			lnutil.White("offer"),
+			"Offer a draft contract to one of your peers"),
+		fmt.Sprintf("%-20s %s",
+			lnutil.White("decline"),
+			"Decline a contract sent to you"),
+		fmt.Sprintf("%-20s %s",
+			lnutil.White("settle"),
+			"Settles the contract"),
+		fmt.Sprintf("%-20s %s",
+			lnutil.White("ls"),
+			"Shows a list of known contracts"),
 	),
 	ShortDescription: "Manages oracles for the Discreet Log Contracts.\n",
 }
@@ -103,20 +149,31 @@ var viewContractCommand = &Command{
 		lnutil.ReqColor("id")),
 	Description: fmt.Sprintf("%s\n%s\n",
 		"Views the current status of a contract",
-		fmt.Sprintf("%-10s %s", lnutil.White("id"), "The ID of the contract to view"),
+		fmt.Sprintf("%-10s %s",
+			lnutil.White("id"),
+			"The ID of the contract to view"),
 	),
 	ShortDescription: "Views the current status of a contract\n",
 }
 
 var viewContractPayoutCommand = &Command{
 	Format: fmt.Sprintf("%s%s%s%s\n", lnutil.White("dlc contract viewpayout"),
-		lnutil.ReqColor("id"), lnutil.ReqColor("start"), lnutil.ReqColor("end"), lnutil.ReqColor("increment")),
+		lnutil.ReqColor("id"), lnutil.ReqColor("start"),
+		lnutil.ReqColor("end"), lnutil.ReqColor("increment")),
 	Description: fmt.Sprintf("%s\n%s\n%s\n%s\n",
 		"Views the payout table of a contract",
-		fmt.Sprintf("%-10s %s", lnutil.White("id"), "The ID of the contract to view"),
-		fmt.Sprintf("%-10s %s", lnutil.White("start"), "The start value to print payout data for"),
-		fmt.Sprintf("%-10s %s", lnutil.White("end"), "The end value to print payout data for"),
-		fmt.Sprintf("%-10s %s", lnutil.White("increment"), "Print every X oracle value (1 = all)"),
+		fmt.Sprintf("%-10s %s",
+			lnutil.White("id"),
+			"The ID of the contract to view"),
+		fmt.Sprintf("%-10s %s",
+			lnutil.White("start"),
+			"The start value to print payout data for"),
+		fmt.Sprintf("%-10s %s",
+			lnutil.White("end"),
+			"The end value to print payout data for"),
+		fmt.Sprintf("%-10s %s",
+			lnutil.White("increment"),
+			"Print every X oracle value (1 = all)"),
 	),
 	ShortDescription: "Views the payout table of a contract\n",
 }
@@ -126,8 +183,12 @@ var setContractOracleCommand = &Command{
 		lnutil.ReqColor("cid", "oid")),
 	Description: fmt.Sprintf("%s\n%s\n%s\n",
 		"Configures a contract for using a specific oracle",
-		fmt.Sprintf("%-10s %s", lnutil.White("cid"), "The ID of the contract"),
-		fmt.Sprintf("%-10s %s", lnutil.White("oid"), "The ID of the oracle"),
+		fmt.Sprintf("%-10s %s",
+			lnutil.White("cid"),
+			"The ID of the contract"),
+		fmt.Sprintf("%-10s %s",
+			lnutil.White("oid"),
+			"The ID of the oracle"),
 	),
 	ShortDescription: "Configures a contract for using a specific oracle\n",
 }
@@ -137,8 +198,12 @@ var setContractDatafeedCommand = &Command{
 		lnutil.ReqColor("cid", "feed")),
 	Description: fmt.Sprintf("%s\n%s\n%s\n",
 		"Sets the data feed to use for the contract",
-		fmt.Sprintf("%-10s %s", lnutil.White("cid"), "The ID of the contract"),
-		fmt.Sprintf("%-10s %s", lnutil.White("feed"), "The ID of the data feed (provided by the oracle)"),
+		fmt.Sprintf("%-10s %s",
+			lnutil.White("cid"),
+			"The ID of the contract"),
+		fmt.Sprintf("%-10s %s",
+			lnutil.White("feed"),
+			"The ID of the data feed (provided by the oracle)"),
 	),
 	ShortDescription: "Sets the data feed to use for the contract\n",
 }
@@ -148,8 +213,12 @@ var setContractRPointCommand = &Command{
 		lnutil.ReqColor("cid", "rpoint")),
 	Description: fmt.Sprintf("%s\n%s\n%s\n",
 		"Sets the R point to use for the contract",
-		fmt.Sprintf("%-10s %s", lnutil.White("cid"), "The ID of the contract"),
-		fmt.Sprintf("%-10s %s", lnutil.White("rpoint"), "The Rpoint of the publication to use (33 byte in hex)"),
+		fmt.Sprintf("%-10s %s",
+			lnutil.White("cid"),
+			"The ID of the contract"),
+		fmt.Sprintf("%-10s %s",
+			lnutil.White("rpoint"),
+			"The Rpoint of the publication to use (33 byte in hex)"),
 	),
 	ShortDescription: "Sets the R point to use for the contract\n",
 }
@@ -159,8 +228,12 @@ var setContractSettlementTimeCommand = &Command{
 		lnutil.ReqColor("cid", "time")),
 	Description: fmt.Sprintf("%s\n%s\n%s\n",
 		"Sets the settlement time for the contract",
-		fmt.Sprintf("%-10s %s", lnutil.White("cid"), "The ID of the contract"),
-		fmt.Sprintf("%-10s %s", lnutil.White("time"), "The settlement time (unix timestamp)"),
+		fmt.Sprintf("%-10s %s",
+			lnutil.White("cid"),
+			"The ID of the contract"),
+		fmt.Sprintf("%-10s %s",
+			lnutil.White("time"),
+			"The settlement time (unix timestamp)"),
 	),
 	ShortDescription: "Sets the settlement time for the contract\n",
 }
@@ -169,39 +242,60 @@ var setContractFundingCommand = &Command{
 		lnutil.ReqColor("cid", "ourAmount", "theirAmount")),
 	Description: fmt.Sprintf("%s\n%s\n%s\n%s\n",
 		"Sets the amounts both parties in the contract will fund",
-		fmt.Sprintf("%-10s %s", lnutil.White("cid"), "The ID of the contract"),
-		fmt.Sprintf("%-10s %s", lnutil.White("ourAmount"), "The amount we will fund"),
-		fmt.Sprintf("%-10s %s", lnutil.White("theirAmount"), "The amount our peer will fund"),
+		fmt.Sprintf("%-10s %s",
+			lnutil.White("cid"),
+			"The ID of the contract"),
+		fmt.Sprintf("%-10s %s",
+			lnutil.White("ourAmount"),
+			"The amount we will fund"),
+		fmt.Sprintf("%-10s %s",
+			lnutil.White("theirAmount"),
+			"The amount our peer will fund"),
 	),
-	ShortDescription: "Sets the amounts both parties in the contract will fund\n",
+	ShortDescription: "Sets the amount both parties will fund\n",
 }
-var setContractSettlementDivisionCommand = &Command{
+var setContractDivisionCommand = &Command{
 	Format: fmt.Sprintf("%s%s\n", lnutil.White("dlc contract setdivision"),
 		lnutil.ReqColor("cid", "valueAllForUs", "valueAllForThem")),
 	Description: fmt.Sprintf("%s\n%s\n%s\n%s\n",
-		"Sets the values of the oracle data that will result in the full contract funds being paid to either peer",
-		fmt.Sprintf("%-10s %s", lnutil.White("cid"), "The ID of the contract"),
-		fmt.Sprintf("%-10s %s", lnutil.White("valueAllForUs"), "The outcome with which we will be entitled to the full contract value"),
-		fmt.Sprintf("%-10s %s", lnutil.White("valueAllForThem"), "The outcome with which our peer will be entitled to the full contract value"),
+		"Sets the values of the oracle data that will result in the full"+
+			"contract funds being paid to either peer",
+		fmt.Sprintf("%-10s %s",
+			lnutil.White("cid"),
+			"The ID of the contract"),
+		fmt.Sprintf("%-10s %s",
+			lnutil.White("valueAllForUs"),
+			"The outcome with which we will be entitled to the full"+
+				" contract value"),
+		fmt.Sprintf("%-10s %s",
+			lnutil.White("valueAllForThem"),
+			"The outcome with which our peer will be entitled to the full"+
+				" contract value"),
 	),
-	ShortDescription: "Sets the edge values of the oracle data for dividing the funds\n",
+	ShortDescription: "Sets the edge values for dividing the funds\n",
 }
 var setContractCoinTypeCommand = &Command{
 	Format: fmt.Sprintf("%s%s\n", lnutil.White("dlc contract setcointype"),
 		lnutil.ReqColor("cid", "cointype")),
 	Description: fmt.Sprintf("%s\n%s\n%s\n",
-		"Sets the values of the oracle data that will result in the full contract funds being paid to either peer",
-		fmt.Sprintf("%-10s %s", lnutil.White("cid"), "The ID of the contract"),
-		fmt.Sprintf("%-10s %s", lnutil.White("cointype"), "The ID of the coin type to use for the contract"),
+		"Sets the coin type to use for the contract",
+		fmt.Sprintf("%-10s %s",
+			lnutil.White("cid"),
+			"The ID of the contract"),
+		fmt.Sprintf("%-10s %s",
+			lnutil.White("cointype"),
+			"The ID of the coin type to use for the contract"),
 	),
-	ShortDescription: "Sets the edge values of the oracle data for dividing the funds\n",
+	ShortDescription: "Sets the coin type to use for the contract\n",
 }
 var declineContractCommand = &Command{
 	Format: fmt.Sprintf("%s%s\n", lnutil.White("dlc contract decline"),
 		lnutil.ReqColor("cid")),
 	Description: fmt.Sprintf("%s\n%s\n",
 		"Declines a contract offered to you",
-		fmt.Sprintf("%-10s %s", lnutil.White("cid"), "The ID of the contract to decline"),
+		fmt.Sprintf("%-10s %s",
+			lnutil.White("cid"),
+			"The ID of the contract to decline"),
 	),
 	ShortDescription: "Declines a contract offered to you\n",
 }
@@ -210,7 +304,9 @@ var acceptContractCommand = &Command{
 		lnutil.ReqColor("cid")),
 	Description: fmt.Sprintf("%s\n%s\n",
 		"Accepts a contract offered to you",
-		fmt.Sprintf("%-10s %s", lnutil.White("cid"), "The ID of the contract to accept"),
+		fmt.Sprintf("%-10s %s",
+			lnutil.White("cid"),
+			"The ID of the contract to accept"),
 	),
 	ShortDescription: "Accepts a contract offered to you\n",
 }
@@ -219,8 +315,12 @@ var offerContractCommand = &Command{
 		lnutil.ReqColor("cid", "peer")),
 	Description: fmt.Sprintf("%s\n%s\n%s\n",
 		"Offers a contract to one of your peers",
-		fmt.Sprintf("%-10s %s", lnutil.White("cid"), "The ID of the contract"),
-		fmt.Sprintf("%-10s %s", lnutil.White("cointype"), "The ID of the peer to offer the contract to"),
+		fmt.Sprintf("%-10s %s",
+			lnutil.White("cid"),
+			"The ID of the contract"),
+		fmt.Sprintf("%-10s %s",
+			lnutil.White("cointype"),
+			"The ID of the peer to offer the contract to"),
 	),
 	ShortDescription: "Offers a contract to one of your peers\n",
 }
@@ -229,11 +329,17 @@ var settleContractCommand = &Command{
 		lnutil.ReqColor("cid", "oracleValue", "oracleSig")),
 	Description: fmt.Sprintf("%s\n%s\n%s\n%s\n",
 		"Settles the contract based on a value and signature from the oracle",
-		fmt.Sprintf("%-20s %s", lnutil.White("cid"), "The ID of the contract"),
-		fmt.Sprintf("%-20s %s", lnutil.White("oracleValue"), "The value the oracle published"),
-		fmt.Sprintf("%-20s %s", lnutil.White("oracleSig"), "The signature from the oracle"),
+		fmt.Sprintf("%-20s %s",
+			lnutil.White("cid"),
+			"The ID of the contract"),
+		fmt.Sprintf("%-20s %s",
+			lnutil.White("oracleValue"),
+			"The value the oracle published"),
+		fmt.Sprintf("%-20s %s",
+			lnutil.White("oracleSig"),
+			"The signature from the oracle"),
 	),
-	ShortDescription: "Settles the contract based on a value and signature from the oracle\n",
+	ShortDescription: "Settles the contract\n",
 }
 
 func (lc *litAfClient) Dlc(textArgs []string) error {
@@ -286,7 +392,8 @@ func (lc *litAfClient) DlcListOracles(textArgs []string) error {
 		fmt.Println("No oracles found")
 	}
 	for _, o := range reply.Oracles {
-		fmt.Fprintf(color.Output, "%04d: [%x...%x...%x]  %s\n", o.Idx, o.A[:2], o.A[15:16], o.A[31:], o.Name)
+		fmt.Fprintf(color.Output, "%04d: [%x...%x...%x]  %s\n",
+			o.Idx, o.A[:2], o.A[15:16], o.A[31:], o.Name)
 	}
 
 	return nil
@@ -314,7 +421,8 @@ func (lc *litAfClient) DlcImportOracle(textArgs []string) error {
 		return err
 	}
 
-	fmt.Fprintf(color.Output, "Oracle succesfully registered under ID %d\n", reply.Oracle.Idx)
+	fmt.Fprintf(color.Output, "Oracle succesfully registered under ID %d\n",
+		reply.Oracle.Idx)
 	return nil
 }
 
@@ -340,7 +448,8 @@ func (lc *litAfClient) DlcAddOracle(textArgs []string) error {
 		return err
 	}
 
-	fmt.Fprintf(color.Output, "Oracle succesfully registered under ID %d\n", reply.Oracle.Idx)
+	fmt.Fprintf(color.Output, "Oracle succesfully registered under ID %d\n",
+		reply.Oracle.Idx)
 	return nil
 }
 
@@ -388,7 +497,7 @@ func (lc *litAfClient) DlcContract(textArgs []string) error {
 	}
 
 	if len(textArgs) > 0 && textArgs[0] == "setdivision" {
-		return lc.DlcSetContractSettlementDivision(textArgs[1:])
+		return lc.DlcSetContractDivision(textArgs[1:])
 	}
 
 	if len(textArgs) > 0 && textArgs[0] == "setcointype" {
@@ -734,19 +843,19 @@ func (lc *litAfClient) DlcSetContractCoinType(textArgs []string) error {
 	return nil
 }
 
-func (lc *litAfClient) DlcSetContractSettlementDivision(textArgs []string) error {
+func (lc *litAfClient) DlcSetContractDivision(textArgs []string) error {
 	if len(textArgs) > 0 && textArgs[0] == "-h" {
-		fmt.Fprintf(color.Output, setContractSettlementDivisionCommand.Format)
-		fmt.Fprintf(color.Output, setContractSettlementDivisionCommand.Description)
+		fmt.Fprintf(color.Output, setContractDivisionCommand.Format)
+		fmt.Fprintf(color.Output, setContractDivisionCommand.Description)
 		return nil
 	}
 
 	if len(textArgs) < 3 {
-		return fmt.Errorf(setContractSettlementDivisionCommand.Format)
+		return fmt.Errorf(setContractDivisionCommand.Format)
 	}
 
-	args := new(litrpc.SetContractSettlementDivisionArgs)
-	reply := new(litrpc.SetContractSettlementDivisionReply)
+	args := new(litrpc.SetContractDivisionArgs)
+	reply := new(litrpc.SetContractDivisionReply)
 
 	cIdx, err := strconv.ParseUint(textArgs[0], 10, 64)
 	if err != nil {
@@ -764,7 +873,7 @@ func (lc *litAfClient) DlcSetContractSettlementDivision(textArgs []string) error
 	args.ValueFullyOurs = fullyOurs
 	args.ValueFullyTheirs = fullyTheirs
 
-	err = lc.rpccon.Call("LitRPC.SetContractSettlementDivision", args, reply)
+	err = lc.rpccon.Call("LitRPC.SetContractDivision", args, reply)
 	if err != nil {
 		return err
 	}
@@ -918,12 +1027,21 @@ func (lc *litAfClient) DlcSettleContract(textArgs []string) error {
 
 func PrintContract(c *lnutil.DlcContract) {
 	fmt.Fprintf(color.Output, "%-30s : %d\n", lnutil.White("Index"), c.Idx)
-	fmt.Fprintf(color.Output, "%-30s : [%x...%x...%x]\n", lnutil.White("Oracle public key"), c.OracleA[:2], c.OracleA[15:16], c.OracleA[31:])
-	fmt.Fprintf(color.Output, "%-30s : [%x...%x...%x]\n", lnutil.White("Oracle R-point"), c.OracleR[:2], c.OracleR[15:16], c.OracleR[31:])
-	fmt.Fprintf(color.Output, "%-30s : %s\n", lnutil.White("Settlement time"), time.Unix(int64(c.OracleTimestamp), 0).UTC().Format(time.UnixDate))
-	fmt.Fprintf(color.Output, "%-30s : %d\n", lnutil.White("Funded by us"), c.OurFundingAmount)
-	fmt.Fprintf(color.Output, "%-30s : %d\n", lnutil.White("Funded by peer"), c.TheirFundingAmount)
-	fmt.Fprintf(color.Output, "%-30s : %d\n", lnutil.White("Coin type"), c.CoinType)
+	fmt.Fprintf(color.Output, "%-30s : [%x...%x...%x]\n",
+		lnutil.White("Oracle public key"),
+		c.OracleA[:2], c.OracleA[15:16], c.OracleA[31:])
+	fmt.Fprintf(color.Output, "%-30s : [%x...%x...%x]\n",
+		lnutil.White("Oracle R-point"), c.OracleR[:2],
+		c.OracleR[15:16], c.OracleR[31:])
+	fmt.Fprintf(color.Output, "%-30s : %s\n",
+		lnutil.White("Settlement time"),
+		time.Unix(int64(c.OracleTimestamp), 0).UTC().Format(time.UnixDate))
+	fmt.Fprintf(color.Output, "%-30s : %d\n",
+		lnutil.White("Funded by us"), c.OurFundingAmount)
+	fmt.Fprintf(color.Output, "%-30s : %d\n",
+		lnutil.White("Funded by peer"), c.TheirFundingAmount)
+	fmt.Fprintf(color.Output, "%-30s : %d\n",
+		lnutil.White("Coin type"), c.CoinType)
 
 	peer := "None"
 	if c.PeerIdx > 0 {
@@ -956,10 +1074,13 @@ func PrintContract(c *lnutil.DlcContract) {
 
 func PrintPayout(c *lnutil.DlcContract, start, end, increment int64) {
 	fmt.Fprintf(color.Output, "Payout division:\n\n")
-	fmt.Fprintf(color.Output, "%-20s | %-20s | %-20s\n", "Oracle value", "Our payout", "Their payout")
+	fmt.Fprintf(color.Output, "%-20s | %-20s | %-20s\n",
+		"Oracle value", "Our payout", "Their payout")
 	fmt.Fprintf(color.Output, "%s\n", strings.Repeat("-", 66))
 
 	for i := start; i < end; i += increment {
-		fmt.Fprintf(color.Output, "%20d | %20d | %20d\n", c.Division[i].OracleValue, c.Division[i].ValueOurs, c.OurFundingAmount+c.TheirFundingAmount-c.Division[i].ValueOurs)
+		fmt.Fprintf(color.Output, "%20d | %20d | %20d\n",
+			c.Division[i].OracleValue, c.Division[i].ValueOurs,
+			c.OurFundingAmount+c.TheirFundingAmount-c.Division[i].ValueOurs)
 	}
 }

--- a/cmd/lit-af/shell.go
+++ b/cmd/lit-af/shell.go
@@ -120,7 +120,7 @@ func (lc *litAfClient) Shellparse(cmdslice []string) error {
 		return nil
 	}
 
-	if cmd == "dlc" { // connect to lnd host
+	if cmd == "dlc" { // the root command for Discreet log contracts
 		err = lc.Dlc(args)
 		if err != nil {
 			fmt.Fprintf(color.Output, "dlc error: %s\n", err)

--- a/cmd/lit-af/shell.go
+++ b/cmd/lit-af/shell.go
@@ -119,6 +119,15 @@ func (lc *litAfClient) Shellparse(cmdslice []string) error {
 		}
 		return nil
 	}
+
+	if cmd == "dlc" { // connect to lnd host
+		err = lc.Dlc(args)
+		if err != nil {
+			fmt.Fprintf(color.Output, "dlc error: %s\n", err)
+		}
+		return nil
+	}
+
 	// fund and create a new channel
 	if cmd == "fund" {
 		err = lc.FundChannel(args)
@@ -364,6 +373,7 @@ func (lc *litAfClient) Help(textArgs []string) error {
 		fmt.Fprintf(color.Output, "%s\t%s", lisCommand.Format, lisCommand.ShortDescription)
 		fmt.Fprintf(color.Output, "%s\t%s", conCommand.Format, conCommand.ShortDescription)
 		fmt.Fprintf(color.Output, "%s\t%s", graphCommand.Format, graphCommand.ShortDescription)
+		fmt.Fprintf(color.Output, "%s\t%s", dlcCommand.Format, dlcCommand.ShortDescription)
 		fmt.Fprintf(color.Output, "%s\t%s", fundCommand.Format, fundCommand.ShortDescription)
 		fmt.Fprintf(color.Output, "%s\t%s", pushCommand.Format, pushCommand.ShortDescription)
 		fmt.Fprintf(color.Output, "%s\t%s", closeCommand.Format, closeCommand.ShortDescription)

--- a/dlc/contract.go
+++ b/dlc/contract.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mit-dci/lit/lnutil"
 )
 
-// Starts a new draft contract
+// AddContract starts a new draft contract
 func (mgr *DlcManager) AddContract() (*lnutil.DlcContract, error) {
 	var err error
 
@@ -23,6 +23,7 @@ func (mgr *DlcManager) AddContract() (*lnutil.DlcContract, error) {
 	return c, nil
 }
 
+// FindContractByKey finds a contract by its generated PubKey
 func (mgr *DlcManager) FindContractByKey(key [33]byte) (*lnutil.DlcContract, error) {
 	contracts, err := mgr.ListContracts()
 	if err != nil {
@@ -38,6 +39,8 @@ func (mgr *DlcManager) FindContractByKey(key [33]byte) (*lnutil.DlcContract, err
 	return nil, fmt.Errorf("Contract not found")
 }
 
+// SetContractOracle assigns a particular oracle to a contract - used for determining which pubkey A to use and can also
+// allow for fetching R-points automatically when the oracle was imported from a REST api
 func (mgr *DlcManager) SetContractOracle(cIdx, oIdx uint64) error {
 	o, err := mgr.LoadOracle(oIdx)
 	if err != nil {
@@ -56,6 +59,8 @@ func (mgr *DlcManager) SetContractOracle(cIdx, oIdx uint64) error {
 	return nil
 }
 
+// SetContractSettlementTime sets the unix epoch at which the oracle will sign a message containing the value the contract
+// pays out on.
 func (mgr *DlcManager) SetContractSettlementTime(cIdx, time uint64) error {
 	c, err := mgr.LoadContract(cIdx)
 	if err != nil {
@@ -69,6 +74,8 @@ func (mgr *DlcManager) SetContractSettlementTime(cIdx, time uint64) error {
 	return nil
 }
 
+// SetContractDatafeed will automatically fetch the R-point from the REST API, if an oracle is imported from a REST API.
+// You need to set the settlement time first, becuase the R point is a key unique for the time and feed
 func (mgr *DlcManager) SetContractDatafeed(cIdx, feed uint64) error {
 	c, err := mgr.LoadContract(cIdx)
 	if err != nil {
@@ -96,6 +103,7 @@ func (mgr *DlcManager) SetContractDatafeed(cIdx, feed uint64) error {
 	return nil
 }
 
+// SetContractRPoint allows you to manually set the R-point key if an oracle is not imported from a REST API
 func (mgr *DlcManager) SetContractRPoint(cIdx uint64, rPoint [33]byte) error {
 	c, err := mgr.LoadContract(cIdx)
 	if err != nil {
@@ -112,6 +120,8 @@ func (mgr *DlcManager) SetContractRPoint(cIdx uint64, rPoint [33]byte) error {
 	return nil
 }
 
+// SetContractFunding sets the funding to the contract. It will specify how much we (the offering party) are
+// funding, as well as
 func (mgr *DlcManager) SetContractFunding(cIdx uint64, ourAmount, theirAmount int64) error {
 	c, err := mgr.LoadContract(cIdx)
 	if err != nil {
@@ -126,6 +136,9 @@ func (mgr *DlcManager) SetContractFunding(cIdx uint64, ourAmount, theirAmount in
 	return nil
 }
 
+// SetContractSettlementDivision sets the division of the contract settlement. If the oraclized value is valueAllOurs, then the entire
+// value of the contract is payable to us. If the oraclized value is valueAllTheirs, then the entire value is paid to
+// our peer. Between those, the value is divided linearly.
 func (mgr *DlcManager) SetContractSettlementDivision(cIdx uint64, valueAllOurs, valueAllTheirs int64) error {
 	c, err := mgr.LoadContract(cIdx)
 	if err != nil {
@@ -173,6 +186,7 @@ func (mgr *DlcManager) SetContractSettlementDivision(cIdx uint64, valueAllOurs, 
 	return nil
 }
 
+// SetContractCoinType sets the cointype for a particular contract
 func (mgr *DlcManager) SetContractCoinType(cIdx uint64, cointype uint32) error {
 	c, err := mgr.LoadContract(cIdx)
 	if err != nil {

--- a/dlc/contract.go
+++ b/dlc/contract.go
@@ -173,3 +173,31 @@ func (mgr *DlcManager) SetContractDatafeed(cIdx, feed uint64) error {
 
 	return nil
 }
+
+func (mgr *DlcManager) SetContractFunding(cIdx, ourAmount, theirAmount uint64) error {
+	c, err := mgr.LoadContract(cIdx)
+	if err != nil {
+		return err
+	}
+
+	c.OurFundingAmount = ourAmount
+	c.TheirFundingAmount = theirAmount
+
+	mgr.SaveContract(c)
+
+	return nil
+}
+
+func (mgr *DlcManager) SetContractSettlementDivision(cIdx, valueAllOurs, valueAllTheirs uint64) error {
+	c, err := mgr.LoadContract(cIdx)
+	if err != nil {
+		return err
+	}
+
+	c.ValueAllOurs = valueAllOurs
+	c.ValueAllTheirs = valueAllTheirs
+
+	mgr.SaveContract(c)
+
+	return nil
+}

--- a/dlc/contract.go
+++ b/dlc/contract.go
@@ -1,126 +1,15 @@
 package dlc
 
 import (
-	"bytes"
-	"encoding/binary"
-
-	"github.com/adiabat/btcd/wire"
 	"github.com/mit-dci/lit/lnutil"
 )
 
-type DlcContractStatus int
-
-const (
-	ContractStatusDraft DlcContractStatus = iota
-	ContractStatusOfferedByMe
-	ContractStatusOfferedToMe
-	ContractStatusActive
-	ContractStatusClosed
-)
-
-type DlcContract struct {
-	Idx                                  uint64                    // Index of the contract for referencing in commands
-	OracleA, OracleB, OracleQ            [33]byte                  // Pub keys of the oracle
-	OracleDataFeed, OracleTimestamp      uint64                    // The data feed and time we use for contract settlement
-	ValueAllOurs, ValueAllTheirs         uint64                    // The value of the datafeed based on which all money in the contract goes to either party
-	OurFundingAmount, TheirFundingAmount uint64                    // The amounts either side are funding
-	OurPayoutPKH, TheirPayoutPKH         [20]byte                  // PKH to which the contracts are supposed to pay out
-	Status                               DlcContractStatus         // Status of the contract
-	OurFundingInputs, TheirFundingInputs []DlcContractFundingInput // Outpoints used to fund the contract
-}
-
-type DlcContractFundingInput struct {
-	Outpoint wire.OutPoint
-	Value    uint64
-}
-
-func DlcContractFromBytes(b []byte) (*DlcContract, error) {
-	buf := bytes.NewBuffer(b)
-	c := new(DlcContract)
-
-	copy(c.OracleA[:], buf.Next(33))
-	copy(c.OracleB[:], buf.Next(33))
-	copy(c.OracleQ[:], buf.Next(33))
-
-	_ = binary.Read(buf, binary.BigEndian, &c.OracleDataFeed)
-	_ = binary.Read(buf, binary.BigEndian, &c.OracleTimestamp)
-	_ = binary.Read(buf, binary.BigEndian, &c.ValueAllOurs)
-	_ = binary.Read(buf, binary.BigEndian, &c.ValueAllTheirs)
-	_ = binary.Read(buf, binary.BigEndian, &c.OurFundingAmount)
-	_ = binary.Read(buf, binary.BigEndian, &c.TheirFundingAmount)
-
-	copy(c.OurPayoutPKH[:], buf.Next(20))
-	copy(c.TheirPayoutPKH[:], buf.Next(20))
-
-	_ = binary.Read(buf, binary.BigEndian, &c.Status)
-
-	var ourInputsLen uint32
-	_ = binary.Read(buf, binary.BigEndian, &ourInputsLen)
-
-	c.OurFundingInputs = make([]DlcContractFundingInput, ourInputsLen)
-	var op [36]byte
-	for i := uint32(0); i < ourInputsLen; i++ {
-		copy(op[:], buf.Next(36))
-		c.OurFundingInputs[i].Outpoint = *lnutil.OutPointFromBytes(op)
-		_ = binary.Read(buf, binary.BigEndian, &c.OurFundingInputs[i].Value)
-	}
-
-	var theirInputsLen uint32
-	_ = binary.Read(buf, binary.BigEndian, &theirInputsLen)
-
-	c.TheirFundingInputs = make([]DlcContractFundingInput, theirInputsLen)
-	for i := uint32(0); i < ourInputsLen; i++ {
-		copy(op[:], buf.Next(36))
-		c.OurFundingInputs[i].Outpoint = *lnutil.OutPointFromBytes(op)
-		_ = binary.Read(buf, binary.BigEndian, &c.OurFundingInputs[i].Value)
-	}
-
-	return c, nil
-}
-
-func (self *DlcContract) Bytes() []byte {
-	var buf bytes.Buffer
-
-	buf.Write(self.OracleA[:])
-	buf.Write(self.OracleB[:])
-	buf.Write(self.OracleQ[:])
-	binary.Write(&buf, binary.BigEndian, self.OracleDataFeed)
-	binary.Write(&buf, binary.BigEndian, self.OracleTimestamp)
-	binary.Write(&buf, binary.BigEndian, self.ValueAllOurs)
-	binary.Write(&buf, binary.BigEndian, self.ValueAllTheirs)
-	binary.Write(&buf, binary.BigEndian, self.OurFundingAmount)
-	binary.Write(&buf, binary.BigEndian, self.TheirFundingAmount)
-	buf.Write(self.OurPayoutPKH[:])
-	buf.Write(self.TheirPayoutPKH[:])
-	binary.Write(&buf, binary.BigEndian, self.Status)
-
-	ourInputsLen := uint32(len(self.OurFundingInputs))
-	binary.Write(&buf, binary.BigEndian, ourInputsLen)
-
-	for i := 0; i < len(self.OurFundingInputs); i++ {
-		opArr := lnutil.OutPointToBytes(self.OurFundingInputs[i].Outpoint)
-		buf.Write(opArr[:])
-		binary.Write(&buf, binary.BigEndian, self.OurFundingInputs[i].Value)
-	}
-
-	theirInputsLen := uint32(len(self.TheirFundingInputs))
-	binary.Write(&buf, binary.BigEndian, theirInputsLen)
-
-	for i := 0; i < len(self.TheirFundingInputs); i++ {
-		opArr := lnutil.OutPointToBytes(self.TheirFundingInputs[i].Outpoint)
-		buf.Write(opArr[:])
-		binary.Write(&buf, binary.BigEndian, self.TheirFundingInputs[i].Value)
-	}
-
-	return buf.Bytes()
-}
-
 // Starts a new draft contract
-func (mgr *DlcManager) AddContract() (*DlcContract, error) {
+func (mgr *DlcManager) AddContract() (*lnutil.DlcContract, error) {
 	var err error
 
-	c := new(DlcContract)
-	c.Status = ContractStatusDraft
+	c := new(lnutil.DlcContract)
+	c.Status = lnutil.ContractStatusDraft
 	err = mgr.SaveContract(c)
 	if err != nil {
 		return nil, err
@@ -197,6 +86,19 @@ func (mgr *DlcManager) SetContractSettlementDivision(cIdx, valueAllOurs, valueAl
 
 	c.ValueAllOurs = valueAllOurs
 	c.ValueAllTheirs = valueAllTheirs
+
+	mgr.SaveContract(c)
+
+	return nil
+}
+
+func (mgr *DlcManager) SetContractCoinType(cIdx uint64, cointype uint32) error {
+	c, err := mgr.LoadContract(cIdx)
+	if err != nil {
+		return err
+	}
+
+	c.CoinType = cointype
 
 	mgr.SaveContract(c)
 

--- a/dlc/contract.go
+++ b/dlc/contract.go
@@ -1,0 +1,175 @@
+package dlc
+
+import (
+	"bytes"
+	"encoding/binary"
+
+	"github.com/adiabat/btcd/wire"
+	"github.com/mit-dci/lit/lnutil"
+)
+
+type DlcContractStatus int
+
+const (
+	ContractStatusDraft DlcContractStatus = iota
+	ContractStatusOffered
+	ContractStatusActive
+	ContractStatusClosed
+)
+
+type DlcContract struct {
+	Idx                                  uint64                    // Index of the contract for referencing in commands
+	OracleA, OracleB, OracleQ            [33]byte                  // Pub keys of the oracle
+	OracleDataFeed, OracleTimestamp      uint64                    // The data feed and time we use for contract settlement
+	ValueAllOurs, ValueAllTheirs         uint64                    // The value of the datafeed based on which all money in the contract goes to either party
+	OurFundingAmount, TheirFundingAmount uint64                    // The amounts either side are funding
+	OurPayoutPKH, TheirPayoutPKH         [20]byte                  // PKH to which the contracts are supposed to pay out
+	Status                               DlcContractStatus         // Status of the contract
+	OurFundingInputs, TheirFundingInputs []DlcContractFundingInput // Outpoints used to fund the contract
+}
+
+type DlcContractFundingInput struct {
+	Outpoint wire.OutPoint
+	Value    uint64
+}
+
+func DlcContractFromBytes(b []byte) (*DlcContract, error) {
+	buf := bytes.NewBuffer(b)
+	c := new(DlcContract)
+
+	copy(c.OracleA[:], buf.Next(33))
+	copy(c.OracleB[:], buf.Next(33))
+	copy(c.OracleQ[:], buf.Next(33))
+
+	_ = binary.Read(buf, binary.BigEndian, &c.OracleDataFeed)
+	_ = binary.Read(buf, binary.BigEndian, &c.OracleTimestamp)
+	_ = binary.Read(buf, binary.BigEndian, &c.ValueAllOurs)
+	_ = binary.Read(buf, binary.BigEndian, &c.ValueAllTheirs)
+	_ = binary.Read(buf, binary.BigEndian, &c.OurFundingAmount)
+	_ = binary.Read(buf, binary.BigEndian, &c.TheirFundingAmount)
+
+	copy(c.OurPayoutPKH[:], buf.Next(20))
+	copy(c.TheirPayoutPKH[:], buf.Next(20))
+
+	_ = binary.Read(buf, binary.BigEndian, &c.Status)
+
+	var ourInputsLen uint32
+	_ = binary.Read(buf, binary.BigEndian, &ourInputsLen)
+
+	c.OurFundingInputs = make([]DlcContractFundingInput, ourInputsLen)
+	var op [36]byte
+	for i := uint32(0); i < ourInputsLen; i++ {
+		copy(op[:], buf.Next(36))
+		c.OurFundingInputs[i].Outpoint = *lnutil.OutPointFromBytes(op)
+		_ = binary.Read(buf, binary.BigEndian, &c.OurFundingInputs[i].Value)
+	}
+
+	var theirInputsLen uint32
+	_ = binary.Read(buf, binary.BigEndian, &theirInputsLen)
+
+	c.TheirFundingInputs = make([]DlcContractFundingInput, theirInputsLen)
+	for i := uint32(0); i < ourInputsLen; i++ {
+		copy(op[:], buf.Next(36))
+		c.OurFundingInputs[i].Outpoint = *lnutil.OutPointFromBytes(op)
+		_ = binary.Read(buf, binary.BigEndian, &c.OurFundingInputs[i].Value)
+	}
+
+	return c, nil
+}
+
+func (self *DlcContract) Bytes() []byte {
+	var buf bytes.Buffer
+
+	buf.Write(self.OracleA[:])
+	buf.Write(self.OracleB[:])
+	buf.Write(self.OracleQ[:])
+	binary.Write(&buf, binary.BigEndian, self.OracleDataFeed)
+	binary.Write(&buf, binary.BigEndian, self.OracleTimestamp)
+	binary.Write(&buf, binary.BigEndian, self.ValueAllOurs)
+	binary.Write(&buf, binary.BigEndian, self.ValueAllTheirs)
+	binary.Write(&buf, binary.BigEndian, self.OurFundingAmount)
+	binary.Write(&buf, binary.BigEndian, self.TheirFundingAmount)
+	buf.Write(self.OurPayoutPKH[:])
+	buf.Write(self.TheirPayoutPKH[:])
+	binary.Write(&buf, binary.BigEndian, self.Status)
+
+	ourInputsLen := uint32(len(self.OurFundingInputs))
+	binary.Write(&buf, binary.BigEndian, ourInputsLen)
+
+	for i := 0; i < len(self.OurFundingInputs); i++ {
+		opArr := lnutil.OutPointToBytes(self.OurFundingInputs[i].Outpoint)
+		buf.Write(opArr[:])
+		binary.Write(&buf, binary.BigEndian, self.OurFundingInputs[i].Value)
+	}
+
+	theirInputsLen := uint32(len(self.TheirFundingInputs))
+	binary.Write(&buf, binary.BigEndian, theirInputsLen)
+
+	for i := 0; i < len(self.TheirFundingInputs); i++ {
+		opArr := lnutil.OutPointToBytes(self.TheirFundingInputs[i].Outpoint)
+		buf.Write(opArr[:])
+		binary.Write(&buf, binary.BigEndian, self.TheirFundingInputs[i].Value)
+	}
+
+	return buf.Bytes()
+}
+
+// Starts a new draft contract
+func (mgr *DlcManager) AddContract() (*DlcContract, error) {
+	var err error
+
+	c := new(DlcContract)
+	c.Status = ContractStatusDraft
+	err = mgr.SaveContract(c)
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+func (mgr *DlcManager) SetContractOracle(cIdx, oIdx uint64) error {
+	o, err := mgr.LoadOracle(oIdx)
+	if err != nil {
+		return err
+	}
+
+	c, err := mgr.LoadContract(cIdx)
+	if err != nil {
+		return err
+	}
+
+	c.OracleA = o.A
+	c.OracleB = o.B
+	c.OracleQ = o.Q
+
+	mgr.SaveContract(c)
+
+	return nil
+}
+
+func (mgr *DlcManager) SetContractSettlementTime(cIdx, time uint64) error {
+	c, err := mgr.LoadContract(cIdx)
+	if err != nil {
+		return err
+	}
+
+	c.OracleTimestamp = time
+
+	mgr.SaveContract(c)
+
+	return nil
+}
+
+func (mgr *DlcManager) SetContractDatafeed(cIdx, feed uint64) error {
+	c, err := mgr.LoadContract(cIdx)
+	if err != nil {
+		return err
+	}
+
+	c.OracleDataFeed = feed
+
+	mgr.SaveContract(c)
+
+	return nil
+}

--- a/dlc/contract.go
+++ b/dlc/contract.go
@@ -23,8 +23,9 @@ func (mgr *DlcManager) AddContract() (*lnutil.DlcContract, error) {
 	return c, nil
 }
 
-// SetContractOracle assigns a particular oracle to a contract - used for determining which pubkey A to use and can also
-// allow for fetching R-points automatically when the oracle was imported from a REST api
+// SetContractOracle assigns a particular oracle to a contract - used for
+// determining which pubkey A to use and can also allow for fetching R-points
+// automatically when the oracle was imported from a REST api
 func (mgr *DlcManager) SetContractOracle(cIdx, oIdx uint64) error {
 
 	c, err := mgr.LoadContract(cIdx)
@@ -33,7 +34,8 @@ func (mgr *DlcManager) SetContractOracle(cIdx, oIdx uint64) error {
 	}
 
 	if c.Status != lnutil.ContractStatusDraft {
-		return fmt.Errorf("You cannot change or set the oracle unless the contract is in Draft state")
+		return fmt.Errorf("You cannot change or set the oracle unless the" +
+			" contract is in Draft state")
 	}
 
 	o, err := mgr.LoadOracle(oIdx)
@@ -51,8 +53,8 @@ func (mgr *DlcManager) SetContractOracle(cIdx, oIdx uint64) error {
 	return nil
 }
 
-// SetContractSettlementTime sets the unix epoch at which the oracle will sign a message containing the value the contract
-// pays out on.
+// SetContractSettlementTime sets the unix epoch at which the oracle will sign a
+// message containing the value the contract pays out on.
 func (mgr *DlcManager) SetContractSettlementTime(cIdx, time uint64) error {
 	c, err := mgr.LoadContract(cIdx)
 	if err != nil {
@@ -60,7 +62,8 @@ func (mgr *DlcManager) SetContractSettlementTime(cIdx, time uint64) error {
 	}
 
 	if c.Status != lnutil.ContractStatusDraft {
-		return fmt.Errorf("You cannot change or set the settlement time unless the contract is in Draft state")
+		return fmt.Errorf("You cannot change or set the settlement time" +
+			" unless the contract is in Draft state")
 	}
 
 	c.OracleTimestamp = time
@@ -73,8 +76,9 @@ func (mgr *DlcManager) SetContractSettlementTime(cIdx, time uint64) error {
 	return nil
 }
 
-// SetContractDatafeed will automatically fetch the R-point from the REST API, if an oracle is imported from a REST API.
-// You need to set the settlement time first, becuase the R point is a key unique for the time and feed
+// SetContractDatafeed will automatically fetch the R-point from the REST API,
+// if an oracle is imported from a REST API. You need to set the settlement time
+// first, becuase the R point is a key unique for the time and feed
 func (mgr *DlcManager) SetContractDatafeed(cIdx, feed uint64) error {
 	c, err := mgr.LoadContract(cIdx)
 	if err != nil {
@@ -82,11 +86,13 @@ func (mgr *DlcManager) SetContractDatafeed(cIdx, feed uint64) error {
 	}
 
 	if c.Status != lnutil.ContractStatusDraft {
-		return fmt.Errorf("You cannot change or set the Datafeed unless the contract is in Draft state")
+		return fmt.Errorf("You cannot change or set the Datafeed unless the" +
+			" contract is in Draft state")
 	}
 
 	if c.OracleTimestamp == 0 {
-		return fmt.Errorf("You need to set the settlement timestamp first, otherwise no R point can be retrieved for the feed")
+		return fmt.Errorf("You need to set the settlement timestamp first," +
+			" otherwise no R point can be retrieved for the feed")
 	}
 
 	o, err := mgr.FindOracleByKey(c.OracleA)
@@ -106,7 +112,8 @@ func (mgr *DlcManager) SetContractDatafeed(cIdx, feed uint64) error {
 	return nil
 }
 
-// SetContractRPoint allows you to manually set the R-point key if an oracle is not imported from a REST API
+// SetContractRPoint allows you to manually set the R-point key if an oracle is
+// not imported from a REST API
 func (mgr *DlcManager) SetContractRPoint(cIdx uint64, rPoint [33]byte) error {
 	c, err := mgr.LoadContract(cIdx)
 	if err != nil {
@@ -114,7 +121,8 @@ func (mgr *DlcManager) SetContractRPoint(cIdx uint64, rPoint [33]byte) error {
 	}
 
 	if c.Status != lnutil.ContractStatusDraft {
-		return fmt.Errorf("You cannot change or set the R-point unless the contract is in Draft state")
+		return fmt.Errorf("You cannot change or set the R-point unless the" +
+			" contract is in Draft state")
 	}
 
 	c.OracleR = rPoint
@@ -127,20 +135,21 @@ func (mgr *DlcManager) SetContractRPoint(cIdx uint64, rPoint [33]byte) error {
 	return nil
 }
 
-// SetContractFunding sets the funding to the contract. It will specify how much we (the offering party) are
-// funding, as well as
-func (mgr *DlcManager) SetContractFunding(cIdx uint64, ourAmount, theirAmount int64) error {
+// SetContractFunding sets the funding to the contract. It will specify how much
+// we (the offering party) are funding, as well as
+func (mgr *DlcManager) SetContractFunding(cIdx uint64, our, their int64) error {
 	c, err := mgr.LoadContract(cIdx)
 	if err != nil {
 		return err
 	}
 
 	if c.Status != lnutil.ContractStatusDraft {
-		return fmt.Errorf("You cannot change or set the funding unless the contract is in Draft state")
+		return fmt.Errorf("You cannot change or set the funding unless the" +
+			" contract is in Draft state")
 	}
 
-	c.OurFundingAmount = ourAmount
-	c.TheirFundingAmount = theirAmount
+	c.OurFundingAmount = our
+	c.TheirFundingAmount = their
 
 	// If the funding changes, the division needs to be re-set.
 	c.Division = nil
@@ -150,17 +159,20 @@ func (mgr *DlcManager) SetContractFunding(cIdx uint64, ourAmount, theirAmount in
 	return nil
 }
 
-// SetContractSettlementDivision sets the division of the contract settlement. If the oraclized value is valueAllOurs, then the entire
-// value of the contract is payable to us. If the oraclized value is valueAllTheirs, then the entire value is paid to
-// our peer. Between those, the value is divided linearly.
-func (mgr *DlcManager) SetContractSettlementDivision(cIdx uint64, valueAllOurs, valueAllTheirs int64) error {
+// SetContractDivision sets the division of the contract settlement. If the
+// oraclized value is valueAllOurs, then the entire value of the contract is
+// payable to us. If the oraclized value is valueAllTheirs, then the entire
+// value is paid to our peer. Between those, the value is divided linearly.
+func (mgr *DlcManager) SetContractDivision(cIdx uint64,
+	valueAllOurs, valueAllTheirs int64) error {
 	c, err := mgr.LoadContract(cIdx)
 	if err != nil {
 		return err
 	}
 
 	if c.Status != lnutil.ContractStatusDraft {
-		return fmt.Errorf("You cannot change or set the division unless the contract is in Draft state")
+		return fmt.Errorf("You cannot change or set the division unless" +
+			" the contract is in Draft state")
 	}
 
 	rangeMin := valueAllTheirs - (valueAllOurs - valueAllTheirs)
@@ -176,26 +188,38 @@ func (mgr *DlcManager) SetContractSettlementDivision(cIdx uint64, valueAllOurs, 
 	}
 
 	totalContractValue := c.OurFundingAmount + c.TheirFundingAmount
-
+	fTotal := float64(totalContractValue)
+	fRange := float64(valueAllOurs - valueAllTheirs)
+	if !oursHighest {
+		fRange = float64(valueAllTheirs - valueAllOurs)
+	}
 	c.Division = make([]lnutil.DlcContractDivision, rangeMax-rangeMin+1)
 	for i := rangeMin; i <= rangeMax; i++ {
 		c.Division[i-rangeMin].OracleValue = i
 
-		if (oursHighest && i >= valueAllOurs) || (!oursHighest && i <= valueAllOurs) {
+		if (oursHighest && i >= valueAllOurs) ||
+			(!oursHighest && i <= valueAllOurs) {
 			c.Division[i-rangeMin].ValueOurs = totalContractValue
 			continue
 		}
 
-		if (oursHighest && i <= valueAllTheirs) || (!oursHighest && i >= valueAllTheirs) {
+		if (oursHighest && i <= valueAllTheirs) ||
+			(!oursHighest && i >= valueAllTheirs) {
 			c.Division[i-rangeMin].ValueOurs = 0
 			continue
 		}
 
+		idx := i - rangeMin
 		if oursHighest {
-			c.Division[i-rangeMin].ValueOurs = int64(float64(totalContractValue) / float64(valueAllOurs-valueAllTheirs) * float64(i-valueAllTheirs))
+			fCurInRange := float64(i - valueAllTheirs)
+			c.Division[idx].ValueOurs = int64(fTotal / fRange * fCurInRange)
 		} else {
-			c.Division[i-rangeMin].ValueOurs = int64(totalContractValue) - int64(float64(totalContractValue)/float64(valueAllTheirs-valueAllOurs)*float64(i-valueAllOurs))
+			fCurInRange := float64(i - valueAllOurs)
+			c.Division[idx].ValueOurs = int64(totalContractValue)
+			c.Division[idx].ValueOurs -= int64(fTotal / fRange * fCurInRange)
+
 		}
+
 	}
 	mgr.SaveContract(c)
 
@@ -210,7 +234,8 @@ func (mgr *DlcManager) SetContractCoinType(cIdx uint64, cointype uint32) error {
 	}
 
 	if c.Status != lnutil.ContractStatusDraft {
-		return fmt.Errorf("You cannot change or set the coin type unless the contract is in Draft state")
+		return fmt.Errorf("You cannot change or set the coin type unless" +
+			" the contract is in Draft state")
 	}
 
 	c.CoinType = cointype

--- a/dlc/contract.go
+++ b/dlc/contract.go
@@ -112,7 +112,7 @@ func (mgr *DlcManager) SetContractRPoint(cIdx uint64, rPoint [33]byte) error {
 	return nil
 }
 
-func (mgr *DlcManager) SetContractFunding(cIdx, ourAmount, theirAmount uint64) error {
+func (mgr *DlcManager) SetContractFunding(cIdx uint64, ourAmount, theirAmount int64) error {
 	c, err := mgr.LoadContract(cIdx)
 	if err != nil {
 		return err
@@ -126,7 +126,7 @@ func (mgr *DlcManager) SetContractFunding(cIdx, ourAmount, theirAmount uint64) e
 	return nil
 }
 
-func (mgr *DlcManager) SetContractSettlementDivision(cIdx, valueAllOurs, valueAllTheirs uint64) error {
+func (mgr *DlcManager) SetContractSettlementDivision(cIdx uint64, valueAllOurs, valueAllTheirs int64) error {
 	c, err := mgr.LoadContract(cIdx)
 	if err != nil {
 		return err

--- a/dlc/contract.go
+++ b/dlc/contract.go
@@ -1,12 +1,12 @@
 package dlc
 
 import (
-	"bytes"
-	"crypto/rand"
 	"fmt"
 
 	"github.com/mit-dci/lit/lnutil"
 )
+
+var COINTYPE_NOT_SET = ^uint32(0) // Max Uint
 
 // AddContract starts a new draft contract
 func (mgr *DlcManager) AddContract() (*lnutil.DlcContract, error) {
@@ -14,29 +14,13 @@ func (mgr *DlcManager) AddContract() (*lnutil.DlcContract, error) {
 
 	c := new(lnutil.DlcContract)
 	c.Status = lnutil.ContractStatusDraft
-	rand.Read(c.PubKey[:])
+	c.CoinType = COINTYPE_NOT_SET
 	err = mgr.SaveContract(c)
 	if err != nil {
 		return nil, err
 	}
 
 	return c, nil
-}
-
-// FindContractByKey finds a contract by its generated PubKey
-func (mgr *DlcManager) FindContractByKey(key [33]byte) (*lnutil.DlcContract, error) {
-	contracts, err := mgr.ListContracts()
-	if err != nil {
-		return nil, err
-	}
-
-	for _, c := range contracts {
-		if bytes.Equal(c.PubKey[:], key[:]) {
-			return c, nil
-		}
-	}
-
-	return nil, fmt.Errorf("Contract not found")
 }
 
 // SetContractOracle assigns a particular oracle to a contract - used for determining which pubkey A to use and can also

--- a/dlc/contract.go
+++ b/dlc/contract.go
@@ -12,7 +12,8 @@ type DlcContractStatus int
 
 const (
 	ContractStatusDraft DlcContractStatus = iota
-	ContractStatusOffered
+	ContractStatusOfferedByMe
+	ContractStatusOfferedToMe
 	ContractStatusActive
 	ContractStatusClosed
 )

--- a/dlc/contract.go
+++ b/dlc/contract.go
@@ -6,7 +6,7 @@ import (
 	"github.com/mit-dci/lit/lnutil"
 )
 
-var COINTYPE_NOT_SET = ^uint32(0) // Max Uint
+const COINTYPE_NOT_SET = ^uint32(0) // Max Uint
 
 // AddContract starts a new draft contract
 func (mgr *DlcManager) AddContract() (*lnutil.DlcContract, error) {

--- a/dlc/dlcdb.go
+++ b/dlc/dlcdb.go
@@ -37,7 +37,8 @@ func (mgr *DlcManager) InitDB(dbPath string) error {
 	return nil
 }
 
-// SaveOracle saves an oracle into the database. Generates a new index if the passed oracle doesn't have one
+// SaveOracle saves an oracle into the database. Generates a new index if the
+// passed oracle doesn't have one
 func (mgr *DlcManager) SaveOracle(o *DlcOracle) error {
 	err := mgr.DLCDB.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket(BKTOracles)
@@ -120,7 +121,8 @@ func (mgr *DlcManager) ListOracles() ([]*DlcOracle, error) {
 	return oracles, nil
 }
 
-// SaveContract saves a contract into the database. Will generate a new index if the passed object doesn't have one.
+// SaveContract saves a contract into the database. Will generate a new index
+// if the passed object doesn't have one.
 func (mgr *DlcManager) SaveContract(c *lnutil.DlcContract) error {
 	err := mgr.DLCDB.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket(BKTContracts)

--- a/dlc/dlcdb.go
+++ b/dlc/dlcdb.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/boltdb/bolt"
+	"github.com/mit-dci/lit/lnutil"
 )
 
 // const strings for db usage
@@ -115,7 +116,7 @@ func (mgr *DlcManager) ListOracles() ([]*DlcOracle, error) {
 	return oracles, nil
 }
 
-func (mgr *DlcManager) SaveContract(c *DlcContract) error {
+func (mgr *DlcManager) SaveContract(c *lnutil.DlcContract) error {
 	err := mgr.DLCDB.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket(BKTContracts)
 
@@ -139,8 +140,8 @@ func (mgr *DlcManager) SaveContract(c *DlcContract) error {
 	return nil
 }
 
-func (mgr *DlcManager) LoadContract(idx uint64) (*DlcContract, error) {
-	c := new(DlcContract)
+func (mgr *DlcManager) LoadContract(idx uint64) (*lnutil.DlcContract, error) {
+	c := new(lnutil.DlcContract)
 
 	err := mgr.DLCDB.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket(BKTContracts)
@@ -154,7 +155,7 @@ func (mgr *DlcManager) LoadContract(idx uint64) (*DlcContract, error) {
 			return fmt.Errorf("Contract %d does not exist", idx)
 		}
 		var err error
-		c, err = DlcContractFromBytes(v)
+		c, err = lnutil.DlcContractFromBytes(v)
 		if err != nil {
 			return err
 		}
@@ -170,15 +171,15 @@ func (mgr *DlcManager) LoadContract(idx uint64) (*DlcContract, error) {
 
 }
 
-func (mgr *DlcManager) ListContracts() ([]*DlcContract, error) {
-	contracts := make([]*DlcContract, 0)
+func (mgr *DlcManager) ListContracts() ([]*lnutil.DlcContract, error) {
+	contracts := make([]*lnutil.DlcContract, 0)
 	err := mgr.DLCDB.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket(BKTContracts)
 		c := b.Cursor()
 
 		for k, v := c.First(); k != nil; k, v = c.Next() {
 			buf := bytes.NewBuffer(k)
-			c, err := DlcContractFromBytes(v)
+			c, err := lnutil.DlcContractFromBytes(v)
 			if err != nil {
 				return err
 			}

--- a/dlc/dlcdb.go
+++ b/dlc/dlcdb.go
@@ -15,6 +15,7 @@ var (
 	BKTContracts = []byte("Contracts")
 )
 
+// InitDB initializes the database for Discreet Log Contract storage
 func (mgr *DlcManager) InitDB(dbPath string) error {
 	var err error
 
@@ -36,6 +37,7 @@ func (mgr *DlcManager) InitDB(dbPath string) error {
 	return nil
 }
 
+// SaveOracle saves an oracle into the database. Generates a new index if the passed oracle doesn't have one
 func (mgr *DlcManager) SaveOracle(o *DlcOracle) error {
 	err := mgr.DLCDB.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket(BKTOracles)
@@ -60,6 +62,7 @@ func (mgr *DlcManager) SaveOracle(o *DlcOracle) error {
 	return nil
 }
 
+// LoadOracle loads an oracle from the database by index.
 func (mgr *DlcManager) LoadOracle(idx uint64) (*DlcOracle, error) {
 	o := new(DlcOracle)
 
@@ -91,6 +94,7 @@ func (mgr *DlcManager) LoadOracle(idx uint64) (*DlcOracle, error) {
 
 }
 
+// ListOracles loads all oracles from the database and returns them as an array
 func (mgr *DlcManager) ListOracles() ([]*DlcOracle, error) {
 	oracles := make([]*DlcOracle, 0)
 	err := mgr.DLCDB.View(func(tx *bolt.Tx) error {
@@ -116,6 +120,7 @@ func (mgr *DlcManager) ListOracles() ([]*DlcOracle, error) {
 	return oracles, nil
 }
 
+// SaveContract saves a contract into the database. Will generate a new index if the passed object doesn't have one.
 func (mgr *DlcManager) SaveContract(c *lnutil.DlcContract) error {
 	err := mgr.DLCDB.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket(BKTContracts)
@@ -140,6 +145,7 @@ func (mgr *DlcManager) SaveContract(c *lnutil.DlcContract) error {
 	return nil
 }
 
+// LoadContract loads a contract from the database by index.
 func (mgr *DlcManager) LoadContract(idx uint64) (*lnutil.DlcContract, error) {
 	c := new(lnutil.DlcContract)
 
@@ -171,6 +177,7 @@ func (mgr *DlcManager) LoadContract(idx uint64) (*lnutil.DlcContract, error) {
 
 }
 
+// ListContracts loads all contracts from the database
 func (mgr *DlcManager) ListContracts() ([]*lnutil.DlcContract, error) {
 	contracts := make([]*lnutil.DlcContract, 0)
 	err := mgr.DLCDB.View(func(tx *bolt.Tx) error {

--- a/dlc/dlcdb.go
+++ b/dlc/dlcdb.go
@@ -1,0 +1,111 @@
+package dlc
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/boltdb/bolt"
+)
+
+// const strings for db usage
+var (
+	BKTOracles = []byte("Oracles")
+)
+
+func (mgr *DlcManager) InitDB(dbPath string) error {
+	var err error
+
+	mgr.DLCDB, err = bolt.Open(dbPath, 0600, nil)
+	if err != nil {
+		return err
+	}
+
+	// Ensure buckets exist that we need
+	err = mgr.DLCDB.Update(func(tx *bolt.Tx) error {
+		_, err = tx.CreateBucketIfNotExists(BKTOracles)
+		return err
+	})
+
+	return nil
+}
+
+func (mgr *DlcManager) SaveOracle(o *Oracle) error {
+	var index uint64
+	err := mgr.DLCDB.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(BKTOracles)
+
+		index, _ = b.NextSequence()
+		var wb bytes.Buffer
+		binary.Write(&wb, binary.BigEndian, index)
+		err := b.Put(wb.Bytes(), o.Bytes())
+
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return err
+	}
+	o.Idx = index
+	return nil
+}
+
+func (mgr *DlcManager) LoadOracle(idx uint64) (*Oracle, error) {
+	o := new(Oracle)
+
+	err := mgr.DLCDB.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(BKTOracles)
+
+		var wb bytes.Buffer
+		binary.Write(&wb, binary.BigEndian, idx)
+
+		v := b.Get(wb.Bytes())
+
+		if v == nil {
+			return fmt.Errorf("Oracle %d does not exist", idx)
+		}
+		var err error
+		o, err = OracleFromBytes(v)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return o, nil
+
+}
+
+func (mgr *DlcManager) LoadAllOracles() ([]*Oracle, error) {
+	oracles := make([]*Oracle, 0)
+	err := mgr.DLCDB.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(BKTOracles)
+		c := b.Cursor()
+
+		for k, v := c.First(); k != nil; k, v = c.Next() {
+			buf := bytes.NewBuffer(k)
+			o, err := OracleFromBytes(v)
+			if err != nil {
+				return err
+			}
+			binary.Read(buf, binary.BigEndian, &o.Idx)
+			oracles = append(oracles, o)
+		}
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return oracles, nil
+}

--- a/dlc/manager.go
+++ b/dlc/manager.go
@@ -11,7 +11,6 @@ type DlcManager struct {
 func NewManager(dbPath string) (*DlcManager, error) {
 
 	var mgr DlcManager
-
 	err := mgr.InitDB(dbPath)
 	if err != nil {
 		return nil, err

--- a/dlc/manager.go
+++ b/dlc/manager.go
@@ -1,0 +1,21 @@
+package dlc
+
+import (
+	"github.com/boltdb/bolt"
+)
+
+type DlcManager struct {
+	DLCDB *bolt.DB
+}
+
+func NewManager(dbPath string) (*DlcManager, error) {
+
+	var mgr DlcManager
+
+	err := mgr.InitDB(dbPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &mgr, nil
+}

--- a/dlc/manager.go
+++ b/dlc/manager.go
@@ -8,6 +8,7 @@ type DlcManager struct {
 	DLCDB *bolt.DB
 }
 
+// NewManager generates a new manager to add to the LitNode
 func NewManager(dbPath string) (*DlcManager, error) {
 
 	var mgr DlcManager

--- a/dlc/oracle.go
+++ b/dlc/oracle.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 )
 
+// DlcOracle contains the identifying data of an Oracle
 type DlcOracle struct {
 	Idx  uint64   // Index of the oracle for refencing in commands
 	A    [33]byte // public key of the oracle
@@ -17,7 +18,7 @@ type DlcOracle struct {
 	Url  string   // Base URL of the oracle, if its REST based (optional)
 }
 
-// This manually imports an oracle using the three keys (A, B, Q) concatenated and a name for reference purposes
+// AddOracle manually imports an oracle using the pubkey (A) and a name for reference purposes
 func (mgr *DlcManager) AddOracle(key [33]byte, name string) (*DlcOracle, error) {
 	var err error
 
@@ -33,6 +34,7 @@ func (mgr *DlcManager) AddOracle(key [33]byte, name string) (*DlcOracle, error) 
 	return o, nil
 }
 
+// FindOracleByKey function looks up an oracle based on its key
 func (mgr *DlcManager) FindOracleByKey(key [33]byte) (*DlcOracle, error) {
 	oracles, err := mgr.ListOracles()
 	if err != nil {
@@ -48,11 +50,12 @@ func (mgr *DlcManager) FindOracleByKey(key [33]byte) (*DlcOracle, error) {
 	return nil, fmt.Errorf("Oracle not found")
 }
 
+// DlcOracleRestPubkeyResponse is the response format for the REST API that returns the pubkey
 type DlcOracleRestPubkeyResponse struct {
 	AHex string `json:"A"`
 }
 
-// This imports an oracle using a REST endpoint
+// ImportOracle imports an oracle using a REST endpoint. It will save the oracle in the database and give it the passed name.
 func (mgr *DlcManager) ImportOracle(url string, name string) (*DlcOracle, error) {
 	req, err := http.NewRequest("GET", url+"/api/pubkey", nil)
 	if err != nil {
@@ -88,10 +91,12 @@ func (mgr *DlcManager) ImportOracle(url string, name string) (*DlcOracle, error)
 	return o, nil
 }
 
+// DlcOracleRPointResponse is the response format for the REST API that returns the R-point
 type DlcOracleRPointResponse struct {
 	RHex string `json:"R"`
 }
 
+// FetchRPoint retrieves the R-point based on datafeedID and timestamp (unix epoch) from the REST API of the oracle.
 func (o *DlcOracle) FetchRPoint(datafeedId, timestamp uint64) ([33]byte, error) {
 	var rPoint [33]byte
 	if len(o.Url) == 0 {
@@ -125,6 +130,7 @@ func (o *DlcOracle) FetchRPoint(datafeedId, timestamp uint64) ([33]byte, error) 
 
 }
 
+// DlcOracleFromBytes parses a byte array that was serialized using DlcOracle.Bytes() back into a DlcOracle struct
 func DlcOracleFromBytes(b []byte) (*DlcOracle, error) {
 	buf := bytes.NewBuffer(b)
 	o := new(DlcOracle)
@@ -148,6 +154,7 @@ func DlcOracleFromBytes(b []byte) (*DlcOracle, error) {
 	return o, nil
 }
 
+// Bytes serializes a DlcOracle struct into a byte array
 func (self *DlcOracle) Bytes() []byte {
 	var buf bytes.Buffer
 

--- a/dlc/oracle.go
+++ b/dlc/oracle.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strconv"
 )
 
 // DlcOracle contains the identifying data of an Oracle
@@ -18,7 +17,8 @@ type DlcOracle struct {
 	Url  string   // Base URL of the oracle, if its REST based (optional)
 }
 
-// AddOracle manually imports an oracle using the pubkey (A) and a name for reference purposes
+// AddOracle manually imports an oracle using the pubkey (A) and a name for
+// reference purposes
 func (mgr *DlcManager) AddOracle(key [33]byte, name string) (*DlcOracle, error) {
 	var err error
 
@@ -50,12 +50,14 @@ func (mgr *DlcManager) FindOracleByKey(key [33]byte) (*DlcOracle, error) {
 	return nil, fmt.Errorf("Oracle not found")
 }
 
-// DlcOracleRestPubkeyResponse is the response format for the REST API that returns the pubkey
+// DlcOracleRestPubkeyResponse is the response format for the REST API that
+// returns the pubkey
 type DlcOracleRestPubkeyResponse struct {
 	AHex string `json:"A"`
 }
 
-// ImportOracle imports an oracle using a REST endpoint. It will save the oracle in the database and give it the passed name.
+// ImportOracle imports an oracle using a REST endpoint. It will save the oracle
+// in the database and give it the passed name.
 func (mgr *DlcManager) ImportOracle(url string, name string) (*DlcOracle, error) {
 	req, err := http.NewRequest("GET", url+"/api/pubkey", nil)
 	if err != nil {
@@ -91,19 +93,25 @@ func (mgr *DlcManager) ImportOracle(url string, name string) (*DlcOracle, error)
 	return o, nil
 }
 
-// DlcOracleRPointResponse is the response format for the REST API that returns the R-point
+// DlcOracleRPointResponse is the response format for the REST API that returns
+// the R-point
 type DlcOracleRPointResponse struct {
 	RHex string `json:"R"`
 }
 
-// FetchRPoint retrieves the R-point based on datafeedID and timestamp (unix epoch) from the REST API of the oracle.
+// FetchRPoint retrieves the R-point based on datafeedID and timestamp
+// (unix epoch) from the REST API of the oracle.
 func (o *DlcOracle) FetchRPoint(datafeedId, timestamp uint64) ([33]byte, error) {
 	var rPoint [33]byte
 	if len(o.Url) == 0 {
-		return rPoint, fmt.Errorf("Oracle was not imported from the web - cannot fetch R point. Enter manually using the [dlc contract setrpoint] command")
+		return rPoint, fmt.Errorf("Oracle was not imported from the web -" +
+			" cannot fetch R point. Enter manually using the" +
+			" [dlc contract setrpoint] command")
 	}
 
-	req, err := http.NewRequest("GET", o.Url+"/api/rpoint/"+strconv.FormatUint(datafeedId, 10)+"/"+strconv.FormatUint(timestamp, 10), nil)
+	url := fmt.Sprintf("%s/api/rpoint/%d/%d", o.Url, datafeedId, timestamp)
+
+	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return rPoint, err
 	}
@@ -130,7 +138,8 @@ func (o *DlcOracle) FetchRPoint(datafeedId, timestamp uint64) ([33]byte, error) 
 
 }
 
-// DlcOracleFromBytes parses a byte array that was serialized using DlcOracle.Bytes() back into a DlcOracle struct
+// DlcOracleFromBytes parses a byte array that was serialized using
+// DlcOracle.Bytes() back into a DlcOracle struct
 func DlcOracleFromBytes(b []byte) (*DlcOracle, error) {
 	buf := bytes.NewBuffer(b)
 	o := new(DlcOracle)

--- a/dlc/oracle.go
+++ b/dlc/oracle.go
@@ -1,0 +1,137 @@
+package dlc
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+)
+
+type Oracle struct {
+	Idx     uint64   // Index of the oracle for refencing in commands
+	A, B, Q [33]byte // public keys of the oracle
+	Name    string   // Name of the oracle for display purposes
+	Url     string   // Base URL of the oracle, if its REST based (optional)
+}
+
+// This manually imports an oracle using the three keys (A, B, Q) concatenated and a name for reference purposes
+func (mgr *DlcManager) AddOracle(keys [99]byte, name string) (*Oracle, error) {
+	var err error
+
+	o := new(Oracle)
+	copy(o.A[:], keys[:33])
+	copy(o.B[:], keys[34:66])
+	copy(o.Q[:], keys[67:])
+	o.Url = ""
+	o.Name = name
+	err = mgr.SaveOracle(o)
+	if err != nil {
+		return nil, err
+	}
+
+	return o, nil
+}
+
+type OracleRestPubkeyResponse struct {
+	AHex string `json:"A"`
+	BHex string `json:"B"`
+	QHex string `json:"Q"`
+}
+
+// This imports an oracle using a REST endpoint
+func (mgr *DlcManager) ImportOracle(url string, name string) (*Oracle, error) {
+	req, err := http.NewRequest("GET", url+"/api/pubkey", nil)
+	if err != nil {
+		return nil, err
+	}
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var response OracleRestPubkeyResponse
+
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return nil, err
+	}
+
+	o := new(Oracle)
+	A, err := hex.DecodeString(response.AHex)
+	if err != nil {
+		return nil, err
+	}
+
+	B, err := hex.DecodeString(response.BHex)
+	if err != nil {
+		return nil, err
+	}
+
+	Q, err := hex.DecodeString(response.QHex)
+	if err != nil {
+		return nil, err
+	}
+
+	copy(o.A[:], A[:])
+	copy(o.B[:], B[:])
+	copy(o.Q[:], Q[:])
+	o.Url = url
+	o.Name = name
+	err = mgr.SaveOracle(o)
+	if err != nil {
+		return nil, err
+	}
+
+	return o, nil
+}
+
+func OracleFromBuffer(buf *bytes.Buffer) (*Oracle, error) {
+	o := new(Oracle)
+
+	copy(o.A[:], buf.Next(33))
+	copy(o.B[:], buf.Next(33))
+	copy(o.Q[:], buf.Next(33))
+
+	var nameLen uint32
+	err := binary.Read(buf, binary.BigEndian, &nameLen)
+	if err != nil {
+		return nil, err
+	}
+	o.Name = string(buf.Next(int(nameLen)))
+
+	var urlLen uint32
+	err = binary.Read(buf, binary.BigEndian, &urlLen)
+	if err != nil {
+		return nil, err
+	}
+	o.Url = string(buf.Next(int(urlLen)))
+
+	return o, nil
+}
+
+func OracleFromBytes(b []byte) (*Oracle, error) {
+	buf := bytes.NewBuffer(b)
+	return OracleFromBuffer(buf)
+}
+
+func (self *Oracle) Bytes() []byte {
+	var buf bytes.Buffer
+
+	buf.Write(self.A[:])
+	buf.Write(self.B[:])
+	buf.Write(self.Q[:])
+
+	nameBytes := []byte(self.Name)
+	nameLen := uint32(len(nameBytes))
+	binary.Write(&buf, binary.BigEndian, nameLen)
+	buf.Write(nameBytes)
+
+	urlBytes := []byte(self.Url)
+	urlLen := uint32(len(urlBytes))
+	binary.Write(&buf, binary.BigEndian, urlLen)
+	buf.Write(urlBytes)
+
+	return buf.Bytes()
+}

--- a/litrpc/dlccmds.go
+++ b/litrpc/dlccmds.go
@@ -340,3 +340,25 @@ func (r *LitRPC) AcceptContract(args AcceptContractArgs, reply *AcceptContractRe
 	reply.Success = true
 	return nil
 }
+
+type SettleContractArgs struct {
+	CIdx        uint64
+	OracleValue int64
+	OracleSig   [32]byte
+}
+
+type SettleContractReply struct {
+	Success bool
+}
+
+func (r *LitRPC) SettleContract(args SettleContractArgs, reply *SettleContractReply) error {
+	var err error
+
+	err = r.Node.SettleContract(args.CIdx, args.OracleValue, args.OracleSig)
+	if err != nil {
+		return err
+	}
+
+	reply.Success = true
+	return nil
+}

--- a/litrpc/dlccmds.go
+++ b/litrpc/dlccmds.go
@@ -47,7 +47,7 @@ func (r *LitRPC) ImportOracle(args ImportOracleArgs, reply *ImportOracleReply) e
 }
 
 type AddOracleArgs struct {
-	Keys string
+	Key  string
 	Name string
 }
 
@@ -57,15 +57,15 @@ type AddOracleReply struct {
 
 func (r *LitRPC) AddOracle(args AddOracleArgs, reply *AddOracleReply) error {
 	var err error
-	parsedKeys, err := hex.DecodeString(args.Keys)
+	parsedKey, err := hex.DecodeString(args.Key)
 	if err != nil {
 		return err
 	}
 
-	var keys [99]byte
-	copy(keys[:], parsedKeys)
+	var key [33]byte
+	copy(key[:], parsedKey)
 
-	reply.Oracle, err = r.Node.DlcManager.AddOracle(keys, args.Name)
+	reply.Oracle, err = r.Node.DlcManager.AddOracle(key, args.Name)
 	if err != nil {
 		return err
 	}
@@ -84,7 +84,7 @@ type NewContractReply struct {
 func (r *LitRPC) NewContract(args NewContractArgs, reply *NewContractReply) error {
 	var err error
 
-	reply.Contract, err = r.Node.DlcManager.AddContract()
+	reply.Contract, err = r.Node.AddContract()
 	if err != nil {
 		return err
 	}
@@ -165,6 +165,27 @@ func (r *LitRPC) SetContractDatafeed(args SetContractDatafeedArgs, reply *SetCon
 	var err error
 
 	err = r.Node.DlcManager.SetContractDatafeed(args.CIdx, args.Feed)
+	if err != nil {
+		return err
+	}
+
+	reply.Success = true
+	return nil
+}
+
+type SetContractRPointArgs struct {
+	CIdx   uint64
+	RPoint [33]byte
+}
+
+type SetContractRPointReply struct {
+	Success bool
+}
+
+func (r *LitRPC) SetContractRPoint(args SetContractRPointArgs, reply *SetContractRPointReply) error {
+	var err error
+
+	err = r.Node.DlcManager.SetContractRPoint(args.CIdx, args.RPoint)
 	if err != nil {
 		return err
 	}
@@ -292,6 +313,26 @@ func (r *LitRPC) DeclineContract(args DeclineContractArgs, reply *DeclineContrac
 	var err error
 
 	err = r.Node.DeclineDlc(args.CIdx)
+	if err != nil {
+		return err
+	}
+
+	reply.Success = true
+	return nil
+}
+
+type AcceptContractArgs struct {
+	CIdx uint64
+}
+
+type AcceptContractReply struct {
+	Success bool
+}
+
+func (r *LitRPC) AcceptContract(args AcceptContractArgs, reply *AcceptContractReply) error {
+	var err error
+
+	err = r.Node.AcceptDlc(args.CIdx)
 	if err != nil {
 		return err
 	}

--- a/litrpc/dlccmds.go
+++ b/litrpc/dlccmds.go
@@ -16,7 +16,8 @@ type ListOraclesReply struct {
 }
 
 // ListOracles returns all oracles know to LIT
-func (r *LitRPC) ListOracles(args ListOraclesArgs, reply *ListOraclesReply) error {
+func (r *LitRPC) ListOracles(args ListOraclesArgs,
+	reply *ListOraclesReply) error {
 	var err error
 
 	reply.Oracles, err = r.Node.DlcManager.ListOracles()
@@ -37,7 +38,8 @@ type ImportOracleReply struct {
 }
 
 // ImportOracle imports an oracle from a REST API
-func (r *LitRPC) ImportOracle(args ImportOracleArgs, reply *ImportOracleReply) error {
+func (r *LitRPC) ImportOracle(args ImportOracleArgs,
+	reply *ImportOracleReply) error {
 	var err error
 	reply.Oracle, err = r.Node.DlcManager.ImportOracle(args.Url, args.Name)
 	if err != nil {
@@ -84,7 +86,8 @@ type NewContractReply struct {
 }
 
 // NewContract creates a new draft contract
-func (r *LitRPC) NewContract(args NewContractArgs, reply *NewContractReply) error {
+func (r *LitRPC) NewContract(args NewContractArgs,
+	reply *NewContractReply) error {
 	var err error
 
 	reply.Contract, err = r.Node.AddContract()
@@ -104,7 +107,8 @@ type ListContractsReply struct {
 }
 
 // ListContracts returns all contracts know to LIT
-func (r *LitRPC) ListContracts(args ListContractsArgs, reply *ListContractsReply) error {
+func (r *LitRPC) ListContracts(args ListContractsArgs,
+	reply *ListContractsReply) error {
 	var err error
 
 	reply.Contracts, err = r.Node.DlcManager.ListContracts()
@@ -124,7 +128,8 @@ type GetContractReply struct {
 }
 
 // GetContract returns a single contract based on its index
-func (r *LitRPC) GetContract(args GetContractArgs, reply *GetContractReply) error {
+func (r *LitRPC) GetContract(args GetContractArgs,
+	reply *GetContractReply) error {
 	var err error
 
 	reply.Contract, err = r.Node.DlcManager.LoadContract(args.Idx)
@@ -145,7 +150,8 @@ type SetContractOracleReply struct {
 }
 
 // SetContractOracle assigns a known oracle to a (new) contract
-func (r *LitRPC) SetContractOracle(args SetContractOracleArgs, reply *SetContractOracleReply) error {
+func (r *LitRPC) SetContractOracle(args SetContractOracleArgs,
+	reply *SetContractOracleReply) error {
 	var err error
 
 	err = r.Node.DlcManager.SetContractOracle(args.CIdx, args.OIdx)
@@ -166,8 +172,10 @@ type SetContractDatafeedReply struct {
 	Success bool
 }
 
-// SetContractDatafeed sets a data feed by index to a contract, which is then used to fetch the R-point from the oracle's REST API
-func (r *LitRPC) SetContractDatafeed(args SetContractDatafeedArgs, reply *SetContractDatafeedReply) error {
+// SetContractDatafeed sets a data feed by index to a contract, which is then
+// used to fetch the R-point from the oracle's REST API
+func (r *LitRPC) SetContractDatafeed(args SetContractDatafeedArgs,
+	reply *SetContractDatafeedReply) error {
 	var err error
 
 	err = r.Node.DlcManager.SetContractDatafeed(args.CIdx, args.Feed)
@@ -189,7 +197,8 @@ type SetContractRPointReply struct {
 }
 
 // SetContractRPoint manually sets the R-point for the contract using a pubkey
-func (r *LitRPC) SetContractRPoint(args SetContractRPointArgs, reply *SetContractRPointReply) error {
+func (r *LitRPC) SetContractRPoint(args SetContractRPointArgs,
+	reply *SetContractRPointReply) error {
 	var err error
 
 	err = r.Node.DlcManager.SetContractRPoint(args.CIdx, args.RPoint)
@@ -210,8 +219,10 @@ type SetContractSettlementTimeReply struct {
 	Success bool
 }
 
-// SetContractSettlementTime sets the time this contract will settle (the unix epoch)
-func (r *LitRPC) SetContractSettlementTime(args SetContractSettlementTimeArgs, reply *SetContractSettlementTimeReply) error {
+// SetContractSettlementTime sets the time this contract will settle (the
+// unix epoch)
+func (r *LitRPC) SetContractSettlementTime(args SetContractSettlementTimeArgs,
+	reply *SetContractSettlementTimeReply) error {
 	var err error
 
 	err = r.Node.DlcManager.SetContractSettlementTime(args.CIdx, args.Time)
@@ -233,12 +244,15 @@ type SetContractFundingReply struct {
 	Success bool
 }
 
-// SetContractFunding sets the division in funding the channel. The arguments decide how much we're funding and how much we expect
-// the peer we offer the contract to to fund
-func (r *LitRPC) SetContractFunding(args SetContractFundingArgs, reply *SetContractFundingReply) error {
+// SetContractFunding sets the division in funding the channel. The arguments
+// decide how much we're funding and how much we expect the peer we offer the
+// contract to to fund
+func (r *LitRPC) SetContractFunding(args SetContractFundingArgs,
+	reply *SetContractFundingReply) error {
 	var err error
 
-	err = r.Node.DlcManager.SetContractFunding(args.CIdx, args.OurAmount, args.TheirAmount)
+	err = r.Node.DlcManager.SetContractFunding(args.CIdx,
+		args.OurAmount, args.TheirAmount)
 	if err != nil {
 		return err
 	}
@@ -247,22 +261,26 @@ func (r *LitRPC) SetContractFunding(args SetContractFundingArgs, reply *SetContr
 	return nil
 }
 
-type SetContractSettlementDivisionArgs struct {
+type SetContractDivisionArgs struct {
 	CIdx             uint64
 	ValueFullyOurs   int64
 	ValueFullyTheirs int64
 }
 
-type SetContractSettlementDivisionReply struct {
+type SetContractDivisionReply struct {
 	Success bool
 }
 
-// SetContractSettlementDivision sets how the contract is settled. The parameters indicate at what value the full contract funds are ours,
-// and at what value they are full funds are for our peer. Between those values, the contract will divide the contract funds linearly
-func (r *LitRPC) SetContractSettlementDivision(args SetContractSettlementDivisionArgs, reply *SetContractSettlementDivisionReply) error {
+// SetContractDivision sets how the contract is settled. The parameters indicate
+// at what value the full contract funds are ours, and at what value they are
+// full funds are for our peer. Between those values, the contract will divide
+// the contract funds linearly
+func (r *LitRPC) SetContractDivision(args SetContractDivisionArgs,
+	reply *SetContractDivisionReply) error {
 	var err error
 
-	err = r.Node.DlcManager.SetContractSettlementDivision(args.CIdx, args.ValueFullyOurs, args.ValueFullyTheirs)
+	err = r.Node.DlcManager.SetContractDivision(args.CIdx,
+		args.ValueFullyOurs, args.ValueFullyTheirs)
 	if err != nil {
 		return err
 	}
@@ -280,9 +298,11 @@ type SetContractCoinTypeReply struct {
 	Success bool
 }
 
-// SetContractCoinType sets the coin type the contract will be in. Note that a peer that doesn't have a wallet of that type will automatically
-// decline the contract.
-func (r *LitRPC) SetContractCoinType(args SetContractCoinTypeArgs, reply *SetContractCoinTypeReply) error {
+// SetContractCoinType sets the coin type the contract will be in. Note that a
+// peer that doesn't have a wallet of that type will automatically decline the
+// contract.
+func (r *LitRPC) SetContractCoinType(args SetContractCoinTypeArgs,
+	reply *SetContractCoinTypeReply) error {
 	var err error
 
 	err = r.Node.DlcManager.SetContractCoinType(args.CIdx, args.CoinType)
@@ -304,7 +324,8 @@ type OfferContractReply struct {
 }
 
 // OfferContract offers a contract to a (connected) peer
-func (r *LitRPC) OfferContract(args OfferContractArgs, reply *OfferContractReply) error {
+func (r *LitRPC) OfferContract(args OfferContractArgs,
+	reply *OfferContractReply) error {
 	var err error
 
 	err = r.Node.OfferDlc(args.PeerIdx, args.CIdx)
@@ -325,7 +346,8 @@ type DeclineContractReply struct {
 }
 
 // DeclineContract declines an offered contract
-func (r *LitRPC) DeclineContract(args DeclineContractArgs, reply *DeclineContractReply) error {
+func (r *LitRPC) DeclineContract(args DeclineContractArgs,
+	reply *DeclineContractReply) error {
 	var err error
 
 	err = r.Node.DeclineDlc(args.CIdx, 0x01)
@@ -345,8 +367,10 @@ type AcceptContractReply struct {
 	Success bool
 }
 
-// AcceptContract accepts an offered contract and will initiate a signature-exchange for settlement and then for funding
-func (r *LitRPC) AcceptContract(args AcceptContractArgs, reply *AcceptContractReply) error {
+// AcceptContract accepts an offered contract and will initiate a
+// signature-exchange for settlement and then for funding
+func (r *LitRPC) AcceptContract(args AcceptContractArgs,
+	reply *AcceptContractReply) error {
 	var err error
 
 	err = r.Node.AcceptDlc(args.CIdx)
@@ -370,12 +394,15 @@ type SettleContractReply struct {
 	ClaimTxHash  [32]byte
 }
 
-// SettleContract uses the value and signature from the oracle to settle the contract and send the equivalent settlement
-// transaction to the blockchain. It will subsequently claim the contract output back to our wallet
-func (r *LitRPC) SettleContract(args SettleContractArgs, reply *SettleContractReply) error {
+// SettleContract uses the value and signature from the oracle to settle the
+// contract and send the equivalent settlement transaction to the blockchain.
+// It will subsequently claim the contract output back to our wallet
+func (r *LitRPC) SettleContract(args SettleContractArgs,
+	reply *SettleContractReply) error {
 	var err error
 
-	reply.SettleTxHash, reply.ClaimTxHash, err = r.Node.SettleContract(args.CIdx, args.OracleValue, args.OracleSig)
+	reply.SettleTxHash, reply.ClaimTxHash, err = r.Node.SettleContract(
+		args.CIdx, args.OracleValue, args.OracleSig)
 	if err != nil {
 		return err
 	}

--- a/litrpc/dlccmds.go
+++ b/litrpc/dlccmds.go
@@ -217,8 +217,8 @@ func (r *LitRPC) SetContractSettlementTime(args SetContractSettlementTimeArgs, r
 
 type SetContractFundingArgs struct {
 	CIdx        uint64
-	OurAmount   uint64
-	TheirAmount uint64
+	OurAmount   int64
+	TheirAmount int64
 }
 
 type SetContractFundingReply struct {
@@ -239,8 +239,8 @@ func (r *LitRPC) SetContractFunding(args SetContractFundingArgs, reply *SetContr
 
 type SetContractSettlementDivisionArgs struct {
 	CIdx             uint64
-	ValueFullyOurs   uint64
-	ValueFullyTheirs uint64
+	ValueFullyOurs   int64
+	ValueFullyTheirs int64
 }
 
 type SetContractSettlementDivisionReply struct {

--- a/litrpc/dlccmds.go
+++ b/litrpc/dlccmds.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 
 	"github.com/mit-dci/lit/dlc"
+	"github.com/mit-dci/lit/lnutil"
 )
 
 type ListOraclesArgs struct {
@@ -77,7 +78,7 @@ type NewContractArgs struct {
 }
 
 type NewContractReply struct {
-	Contract *dlc.DlcContract
+	Contract *lnutil.DlcContract
 }
 
 func (r *LitRPC) NewContract(args NewContractArgs, reply *NewContractReply) error {
@@ -96,7 +97,7 @@ type ListContractsArgs struct {
 }
 
 type ListContractsReply struct {
-	Contracts []*dlc.DlcContract
+	Contracts []*lnutil.DlcContract
 }
 
 // ListOracles will return all contracts know to LIT
@@ -116,7 +117,7 @@ type GetContractArgs struct {
 }
 
 type GetContractReply struct {
-	Contract *dlc.DlcContract
+	Contract *lnutil.DlcContract
 }
 
 func (r *LitRPC) GetContract(args GetContractArgs, reply *GetContractReply) error {
@@ -229,6 +230,68 @@ func (r *LitRPC) SetContractSettlementDivision(args SetContractSettlementDivisio
 	var err error
 
 	err = r.Node.DlcManager.SetContractSettlementDivision(args.CIdx, args.ValueFullyOurs, args.ValueFullyTheirs)
+	if err != nil {
+		return err
+	}
+
+	reply.Success = true
+	return nil
+}
+
+type SetContractCoinTypeArgs struct {
+	CIdx     uint64
+	CoinType uint32
+}
+
+type SetContractCoinTypeReply struct {
+	Success bool
+}
+
+func (r *LitRPC) SetContractCoinType(args SetContractCoinTypeArgs, reply *SetContractCoinTypeReply) error {
+	var err error
+
+	err = r.Node.DlcManager.SetContractCoinType(args.CIdx, args.CoinType)
+	if err != nil {
+		return err
+	}
+
+	reply.Success = true
+	return nil
+}
+
+type OfferContractArgs struct {
+	CIdx    uint64
+	PeerIdx uint32
+}
+
+type OfferContractReply struct {
+	Success bool
+}
+
+func (r *LitRPC) OfferContract(args OfferContractArgs, reply *OfferContractReply) error {
+	var err error
+
+	err = r.Node.OfferDlc(args.PeerIdx, args.CIdx)
+	if err != nil {
+		return err
+	}
+
+	reply.Success = true
+	return nil
+}
+
+type DeclineContractArgs struct {
+	CIdx uint64
+}
+
+type DeclineContractReply struct {
+	Success bool
+}
+
+func (r *LitRPC) DeclineContract(args DeclineContractArgs, reply *DeclineContractReply) error {
+	var err error
+
+	err = r.Node.DeclineDlc(args.CIdx)
 	if err != nil {
 		return err
 	}

--- a/litrpc/dlccmds.go
+++ b/litrpc/dlccmds.go
@@ -192,3 +192,47 @@ func (r *LitRPC) SetContractSettlementTime(args SetContractSettlementTimeArgs, r
 	reply.Success = true
 	return nil
 }
+
+type SetContractFundingArgs struct {
+	CIdx        uint64
+	OurAmount   uint64
+	TheirAmount uint64
+}
+
+type SetContractFundingReply struct {
+	Success bool
+}
+
+func (r *LitRPC) SetContractFunding(args SetContractFundingArgs, reply *SetContractFundingReply) error {
+	var err error
+
+	err = r.Node.DlcManager.SetContractFunding(args.CIdx, args.OurAmount, args.TheirAmount)
+	if err != nil {
+		return err
+	}
+
+	reply.Success = true
+	return nil
+}
+
+type SetContractSettlementDivisionArgs struct {
+	CIdx             uint64
+	ValueFullyOurs   uint64
+	ValueFullyTheirs uint64
+}
+
+type SetContractSettlementDivisionReply struct {
+	Success bool
+}
+
+func (r *LitRPC) SetContractSettlementDivision(args SetContractSettlementDivisionArgs, reply *SetContractSettlementDivisionReply) error {
+	var err error
+
+	err = r.Node.DlcManager.SetContractSettlementDivision(args.CIdx, args.ValueFullyOurs, args.ValueFullyTheirs)
+	if err != nil {
+		return err
+	}
+
+	reply.Success = true
+	return nil
+}

--- a/litrpc/dlccmds.go
+++ b/litrpc/dlccmds.go
@@ -328,7 +328,7 @@ type DeclineContractReply struct {
 func (r *LitRPC) DeclineContract(args DeclineContractArgs, reply *DeclineContractReply) error {
 	var err error
 
-	err = r.Node.DeclineDlc(args.CIdx)
+	err = r.Node.DeclineDlc(args.CIdx, 0x01)
 	if err != nil {
 		return err
 	}

--- a/litrpc/dlccmds.go
+++ b/litrpc/dlccmds.go
@@ -1,0 +1,73 @@
+package litrpc
+
+import (
+	"encoding/hex"
+
+	"github.com/mit-dci/lit/dlc"
+)
+
+// ------------------------- statedump
+type ListOraclesArgs struct {
+	// none
+}
+
+type ListOraclesReply struct {
+	Oracles []*dlc.Oracle
+}
+
+// ListOracles will return all oracles know to LIT
+func (r *LitRPC) ListOracles(args ListOraclesArgs, reply *ListOraclesReply) error {
+	var err error
+	reply.Oracles, err = r.Node.DlcManager.LoadAllOracles()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type ImportOracleArgs struct {
+	Url  string
+	Name string
+}
+
+type ImportOracleReply struct {
+	Oracle *dlc.Oracle
+}
+
+func (r *LitRPC) ImportOracle(args ImportOracleArgs, reply *ImportOracleReply) error {
+	var err error
+	reply.Oracle, err = r.Node.DlcManager.ImportOracle(args.Url, args.Name)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type AddOracleArgs struct {
+	Keys string
+	Name string
+}
+
+type AddOracleReply struct {
+	Oracle *dlc.Oracle
+}
+
+func (r *LitRPC) AddOracle(args AddOracleArgs, reply *AddOracleReply) error {
+	var err error
+	parsedKeys, err := hex.DecodeString(args.Keys)
+	if err != nil {
+		return err
+	}
+
+	var keys [99]byte
+	copy(keys[:], parsedKeys)
+
+	reply.Oracle, err = r.Node.DlcManager.AddOracle(keys, args.Name)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/litrpc/dlccmds.go
+++ b/litrpc/dlccmds.go
@@ -348,13 +348,15 @@ type SettleContractArgs struct {
 }
 
 type SettleContractReply struct {
-	Success bool
+	Success      bool
+	SettleTxHash [32]byte
+	ClaimTxHash  [32]byte
 }
 
 func (r *LitRPC) SettleContract(args SettleContractArgs, reply *SettleContractReply) error {
 	var err error
 
-	err = r.Node.SettleContract(args.CIdx, args.OracleValue, args.OracleSig)
+	reply.SettleTxHash, reply.ClaimTxHash, err = r.Node.SettleContract(args.CIdx, args.OracleValue, args.OracleSig)
 	if err != nil {
 		return err
 	}

--- a/litrpc/dlccmds.go
+++ b/litrpc/dlccmds.go
@@ -6,19 +6,19 @@ import (
 	"github.com/mit-dci/lit/dlc"
 )
 
-// ------------------------- statedump
 type ListOraclesArgs struct {
 	// none
 }
 
 type ListOraclesReply struct {
-	Oracles []*dlc.Oracle
+	Oracles []*dlc.DlcOracle
 }
 
 // ListOracles will return all oracles know to LIT
 func (r *LitRPC) ListOracles(args ListOraclesArgs, reply *ListOraclesReply) error {
 	var err error
-	reply.Oracles, err = r.Node.DlcManager.LoadAllOracles()
+
+	reply.Oracles, err = r.Node.DlcManager.ListOracles()
 	if err != nil {
 		return err
 	}
@@ -32,7 +32,7 @@ type ImportOracleArgs struct {
 }
 
 type ImportOracleReply struct {
-	Oracle *dlc.Oracle
+	Oracle *dlc.DlcOracle
 }
 
 func (r *LitRPC) ImportOracle(args ImportOracleArgs, reply *ImportOracleReply) error {
@@ -51,7 +51,7 @@ type AddOracleArgs struct {
 }
 
 type AddOracleReply struct {
-	Oracle *dlc.Oracle
+	Oracle *dlc.DlcOracle
 }
 
 func (r *LitRPC) AddOracle(args AddOracleArgs, reply *AddOracleReply) error {
@@ -69,5 +69,126 @@ func (r *LitRPC) AddOracle(args AddOracleArgs, reply *AddOracleReply) error {
 		return err
 	}
 
+	return nil
+}
+
+type NewContractArgs struct {
+	// empty
+}
+
+type NewContractReply struct {
+	Contract *dlc.DlcContract
+}
+
+func (r *LitRPC) NewContract(args NewContractArgs, reply *NewContractReply) error {
+	var err error
+
+	reply.Contract, err = r.Node.DlcManager.AddContract()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type ListContractsArgs struct {
+	// none
+}
+
+type ListContractsReply struct {
+	Contracts []*dlc.DlcContract
+}
+
+// ListOracles will return all contracts know to LIT
+func (r *LitRPC) ListContracts(args ListContractsArgs, reply *ListContractsReply) error {
+	var err error
+
+	reply.Contracts, err = r.Node.DlcManager.ListContracts()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type GetContractArgs struct {
+	Idx uint64
+}
+
+type GetContractReply struct {
+	Contract *dlc.DlcContract
+}
+
+func (r *LitRPC) GetContract(args GetContractArgs, reply *GetContractReply) error {
+	var err error
+
+	reply.Contract, err = r.Node.DlcManager.LoadContract(args.Idx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type SetContractOracleArgs struct {
+	CIdx uint64
+	OIdx uint64
+}
+
+type SetContractOracleReply struct {
+	Success bool
+}
+
+func (r *LitRPC) SetContractOracle(args SetContractOracleArgs, reply *SetContractOracleReply) error {
+	var err error
+
+	err = r.Node.DlcManager.SetContractOracle(args.CIdx, args.OIdx)
+	if err != nil {
+		return err
+	}
+
+	reply.Success = true
+	return nil
+}
+
+type SetContractDatafeedArgs struct {
+	CIdx uint64
+	Feed uint64
+}
+
+type SetContractDatafeedReply struct {
+	Success bool
+}
+
+func (r *LitRPC) SetContractDatafeed(args SetContractDatafeedArgs, reply *SetContractDatafeedReply) error {
+	var err error
+
+	err = r.Node.DlcManager.SetContractDatafeed(args.CIdx, args.Feed)
+	if err != nil {
+		return err
+	}
+
+	reply.Success = true
+	return nil
+}
+
+type SetContractSettlementTimeArgs struct {
+	CIdx uint64
+	Time uint64
+}
+
+type SetContractSettlementTimeReply struct {
+	Success bool
+}
+
+func (r *LitRPC) SetContractSettlementTime(args SetContractSettlementTimeArgs, reply *SetContractSettlementTimeReply) error {
+	var err error
+
+	err = r.Node.DlcManager.SetContractSettlementTime(args.CIdx, args.Time)
+	if err != nil {
+		return err
+	}
+
+	reply.Success = true
 	return nil
 }

--- a/litrpc/dlccmds.go
+++ b/litrpc/dlccmds.go
@@ -15,7 +15,7 @@ type ListOraclesReply struct {
 	Oracles []*dlc.DlcOracle
 }
 
-// ListOracles will return all oracles know to LIT
+// ListOracles returns all oracles know to LIT
 func (r *LitRPC) ListOracles(args ListOraclesArgs, reply *ListOraclesReply) error {
 	var err error
 
@@ -36,6 +36,7 @@ type ImportOracleReply struct {
 	Oracle *dlc.DlcOracle
 }
 
+// ImportOracle imports an oracle from a REST API
 func (r *LitRPC) ImportOracle(args ImportOracleArgs, reply *ImportOracleReply) error {
 	var err error
 	reply.Oracle, err = r.Node.DlcManager.ImportOracle(args.Url, args.Name)
@@ -55,6 +56,7 @@ type AddOracleReply struct {
 	Oracle *dlc.DlcOracle
 }
 
+// AddOracle manually adds an oracle from its PubKey A
 func (r *LitRPC) AddOracle(args AddOracleArgs, reply *AddOracleReply) error {
 	var err error
 	parsedKey, err := hex.DecodeString(args.Key)
@@ -81,6 +83,7 @@ type NewContractReply struct {
 	Contract *lnutil.DlcContract
 }
 
+// NewContract creates a new draft contract
 func (r *LitRPC) NewContract(args NewContractArgs, reply *NewContractReply) error {
 	var err error
 
@@ -100,7 +103,7 @@ type ListContractsReply struct {
 	Contracts []*lnutil.DlcContract
 }
 
-// ListOracles will return all contracts know to LIT
+// ListContracts returns all contracts know to LIT
 func (r *LitRPC) ListContracts(args ListContractsArgs, reply *ListContractsReply) error {
 	var err error
 
@@ -120,6 +123,7 @@ type GetContractReply struct {
 	Contract *lnutil.DlcContract
 }
 
+// GetContract returns a single contract based on its index
 func (r *LitRPC) GetContract(args GetContractArgs, reply *GetContractReply) error {
 	var err error
 
@@ -140,6 +144,7 @@ type SetContractOracleReply struct {
 	Success bool
 }
 
+// SetContractOracle assigns a known oracle to a (new) contract
 func (r *LitRPC) SetContractOracle(args SetContractOracleArgs, reply *SetContractOracleReply) error {
 	var err error
 
@@ -161,6 +166,7 @@ type SetContractDatafeedReply struct {
 	Success bool
 }
 
+// SetContractDatafeed sets a data feed by index to a contract, which is then used to fetch the R-point from the oracle's REST API
 func (r *LitRPC) SetContractDatafeed(args SetContractDatafeedArgs, reply *SetContractDatafeedReply) error {
 	var err error
 
@@ -182,6 +188,7 @@ type SetContractRPointReply struct {
 	Success bool
 }
 
+// SetContractRPoint manually sets the R-point for the contract using a pubkey
 func (r *LitRPC) SetContractRPoint(args SetContractRPointArgs, reply *SetContractRPointReply) error {
 	var err error
 
@@ -203,6 +210,7 @@ type SetContractSettlementTimeReply struct {
 	Success bool
 }
 
+// SetContractSettlementTime sets the time this contract will settle (the unix epoch)
 func (r *LitRPC) SetContractSettlementTime(args SetContractSettlementTimeArgs, reply *SetContractSettlementTimeReply) error {
 	var err error
 
@@ -225,6 +233,8 @@ type SetContractFundingReply struct {
 	Success bool
 }
 
+// SetContractFunding sets the division in funding the channel. The arguments decide how much we're funding and how much we expect
+// the peer we offer the contract to to fund
 func (r *LitRPC) SetContractFunding(args SetContractFundingArgs, reply *SetContractFundingReply) error {
 	var err error
 
@@ -247,6 +257,8 @@ type SetContractSettlementDivisionReply struct {
 	Success bool
 }
 
+// SetContractSettlementDivision sets how the contract is settled. The parameters indicate at what value the full contract funds are ours,
+// and at what value they are full funds are for our peer. Between those values, the contract will divide the contract funds linearly
 func (r *LitRPC) SetContractSettlementDivision(args SetContractSettlementDivisionArgs, reply *SetContractSettlementDivisionReply) error {
 	var err error
 
@@ -268,6 +280,8 @@ type SetContractCoinTypeReply struct {
 	Success bool
 }
 
+// SetContractCoinType sets the coin type the contract will be in. Note that a peer that doesn't have a wallet of that type will automatically
+// decline the contract.
 func (r *LitRPC) SetContractCoinType(args SetContractCoinTypeArgs, reply *SetContractCoinTypeReply) error {
 	var err error
 
@@ -289,6 +303,7 @@ type OfferContractReply struct {
 	Success bool
 }
 
+// OfferContract offers a contract to a (connected) peer
 func (r *LitRPC) OfferContract(args OfferContractArgs, reply *OfferContractReply) error {
 	var err error
 
@@ -309,6 +324,7 @@ type DeclineContractReply struct {
 	Success bool
 }
 
+// DeclineContract declines an offered contract
 func (r *LitRPC) DeclineContract(args DeclineContractArgs, reply *DeclineContractReply) error {
 	var err error
 
@@ -329,6 +345,7 @@ type AcceptContractReply struct {
 	Success bool
 }
 
+// AcceptContract accepts an offered contract and will initiate a signature-exchange for settlement and then for funding
 func (r *LitRPC) AcceptContract(args AcceptContractArgs, reply *AcceptContractReply) error {
 	var err error
 
@@ -353,6 +370,8 @@ type SettleContractReply struct {
 	ClaimTxHash  [32]byte
 }
 
+// SettleContract uses the value and signature from the oracle to settle the contract and send the equivalent settlement
+// transaction to the blockchain. It will subsequently claim the contract output back to our wallet
 func (r *LitRPC) SettleContract(args SettleContractArgs, reply *SettleContractReply) error {
 	var err error
 

--- a/litrpc/listener.go
+++ b/litrpc/listener.go
@@ -42,11 +42,11 @@ func serveWS(ws *websocket.Conn) {
 	jsonrpc.ServeConn(ws)
 }
 
-func RPCListen(rpcl *LitRPC, host string, port uint16) {
+func RPCListen(rpcl *LitRPC, port uint16) {
 
 	rpc.Register(rpcl)
 
-	listenString := fmt.Sprintf("%s:%d", host, port)
+	listenString := fmt.Sprintf("localhost:%d", port)
 
 	http.Handle("/ws", websocket.Handler(serveWS))
 	log.Fatal(http.ListenAndServe(listenString, nil))

--- a/litrpc/listener.go
+++ b/litrpc/listener.go
@@ -42,11 +42,11 @@ func serveWS(ws *websocket.Conn) {
 	jsonrpc.ServeConn(ws)
 }
 
-func RPCListen(rpcl *LitRPC, port uint16) {
+func RPCListen(rpcl *LitRPC, host string, port uint16) {
 
 	rpc.Register(rpcl)
 
-	listenString := fmt.Sprintf("localhost:%d", port)
+	listenString := fmt.Sprintf("%s:%d", host, port)
 
 	http.Handle("/ws", websocket.Handler(serveWS))
 	log.Fatal(http.ListenAndServe(listenString, nil))

--- a/lnutil/dlclib.go
+++ b/lnutil/dlclib.go
@@ -1,37 +1,48 @@
 package lnutil
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/binary"
+	"fmt"
 
+	"github.com/adiabat/btcd/txscript"
 	"github.com/adiabat/btcd/wire"
 )
 
 type DlcContractStatus int
 
 const (
-	ContractStatusDraft       DlcContractStatus = 0
-	ContractStatusOfferedByMe DlcContractStatus = 1
-	ContractStatusOfferedToMe DlcContractStatus = 2
-	ContractStatusDeclined    DlcContractStatus = 3
-	ContractStatusAccepted    DlcContractStatus = 4
-	ContractStatusActive      DlcContractStatus = 5
-	ContractStatusClosed      DlcContractStatus = 6
+	ContractStatusDraft        DlcContractStatus = 0
+	ContractStatusOfferedByMe  DlcContractStatus = 1
+	ContractStatusOfferedToMe  DlcContractStatus = 2
+	ContractStatusDeclined     DlcContractStatus = 3
+	ContractStatusAccepted     DlcContractStatus = 4
+	ContractStatusAcknowledged DlcContractStatus = 5
+	ContractStatusActive       DlcContractStatus = 6
+	ContractStatusClosed       DlcContractStatus = 7
 )
 
 type DlcContract struct {
-	Idx                                  uint64                    // Index of the contract for referencing in commands
-	PeerIdx                              uint32                    // Index of the peer we've offered the contract to or received the contract from
-	PubKey                               [33]byte                  // Key of the contract
-	CoinType                             uint32                    // Coin type
-	OracleA, OracleR                     [33]byte                  // Pub keys of the oracle
-	OracleTimestamp                      uint64                    // The time we expect the oracle to publish
-	ValueAllOurs, ValueAllTheirs         int64                     // The value of the datafeed based on which all money in the contract goes to either party
-	OurFundingAmount, TheirFundingAmount int64                     // The amounts either side are funding
-	OurChangePKH, TheirChangePKH         [20]byte                  // PKH to which the contracts funding change should go
-	OurPayoutPub, TheirPayoutPub         [33]byte                  // Pubkey to which the contracts are supposed to pay out
-	Status                               DlcContractStatus         // Status of the contract
-	OurFundingInputs, TheirFundingInputs []DlcContractFundingInput // Outpoints used to fund the contract
+	Idx                                      uint64                           // Index of the contract for referencing in commands
+	PeerIdx                                  uint32                           // Index of the peer we've offered the contract to or received the contract from
+	PubKey                                   [33]byte                         // Key of the contract
+	CoinType                                 uint32                           // Coin type
+	OracleA, OracleR                         [33]byte                         // Pub keys of the oracle
+	OracleTimestamp                          uint64                           // The time we expect the oracle to publish
+	Division                                 []DlcContractDivision            // The payout specification
+	OurFundingAmount, TheirFundingAmount     int64                            // The amounts either side are funding
+	OurChangePKH, TheirChangePKH             [20]byte                         // PKH to which the contracts funding change should go
+	OurFundMultisigPub, TheirFundMultisigPub [33]byte                         // Pubkey used in the funding multisig output
+	OurPayoutPub, TheirPayoutPub             [33]byte                         // Pubkey to which the contracts are supposed to pay out
+	Status                                   DlcContractStatus                // Status of the contract
+	OurFundingInputs, TheirFundingInputs     []DlcContractFundingInput        // Outpoints used to fund the contract
+	TheirSettlementSignatures                []DlcContractSettlementSignature // Signatures for the settlement transactions
+}
+
+type DlcContractDivision struct {
+	OracleValue int64
+	ValueOurs   int64
 }
 
 type DlcContractFundingInput struct {
@@ -48,11 +59,16 @@ func DlcContractFromBytes(b []byte) (*DlcContract, error) {
 	copy(c.OracleR[:], buf.Next(33))
 
 	_ = binary.Read(buf, binary.BigEndian, &c.PeerIdx)
+	_ = binary.Read(buf, binary.BigEndian, &c.CoinType)
 	_ = binary.Read(buf, binary.BigEndian, &c.OracleTimestamp)
-	_ = binary.Read(buf, binary.BigEndian, &c.ValueAllOurs)
-	_ = binary.Read(buf, binary.BigEndian, &c.ValueAllTheirs)
 	_ = binary.Read(buf, binary.BigEndian, &c.OurFundingAmount)
 	_ = binary.Read(buf, binary.BigEndian, &c.TheirFundingAmount)
+
+	copy(c.OurChangePKH[:], buf.Next(20))
+	copy(c.TheirChangePKH[:], buf.Next(20))
+
+	copy(c.OurFundMultisigPub[:], buf.Next(33))
+	copy(c.TheirFundMultisigPub[:], buf.Next(33))
 
 	copy(c.OurPayoutPub[:], buf.Next(33))
 	copy(c.TheirPayoutPub[:], buf.Next(33))
@@ -64,6 +80,7 @@ func DlcContractFromBytes(b []byte) (*DlcContract, error) {
 
 	var ourInputsLen uint32
 	_ = binary.Read(buf, binary.BigEndian, &ourInputsLen)
+	fmt.Printf("[R] Our input len: [%d]\n", ourInputsLen)
 
 	c.OurFundingInputs = make([]DlcContractFundingInput, ourInputsLen)
 	var op [36]byte
@@ -75,6 +92,7 @@ func DlcContractFromBytes(b []byte) (*DlcContract, error) {
 
 	var theirInputsLen uint32
 	_ = binary.Read(buf, binary.BigEndian, &theirInputsLen)
+	fmt.Printf("[R] Their input len: [%d]\n", theirInputsLen)
 
 	c.TheirFundingInputs = make([]DlcContractFundingInput, theirInputsLen)
 	for i := uint32(0); i < theirInputsLen; i++ {
@@ -83,10 +101,25 @@ func DlcContractFromBytes(b []byte) (*DlcContract, error) {
 		_ = binary.Read(buf, binary.BigEndian, &c.TheirFundingInputs[i].Value)
 	}
 
-	_ = binary.Read(buf, binary.BigEndian, &c.CoinType)
+	var divisionLen uint32
+	_ = binary.Read(buf, binary.BigEndian, &divisionLen)
+	c.Division = make([]DlcContractDivision, divisionLen)
+	for i := uint32(0); i < divisionLen; i++ {
+		_ = binary.Read(buf, binary.BigEndian, &c.Division[i].OracleValue)
+		_ = binary.Read(buf, binary.BigEndian, &c.Division[i].ValueOurs)
+	}
 
-	copy(c.OurChangePKH[:], buf.Next(20))
-	copy(c.TheirChangePKH[:], buf.Next(20))
+	var theirSigCount uint32
+	_ = binary.Read(buf, binary.BigEndian, &theirSigCount)
+	c.TheirSettlementSignatures = make([]DlcContractSettlementSignature, theirSigCount)
+
+	var sigLen uint32
+	for i := uint32(0); i < theirSigCount; i++ {
+		_ = binary.Read(buf, binary.BigEndian, &c.TheirSettlementSignatures[i].Outcome)
+		_ = binary.Read(buf, binary.BigEndian, &sigLen)
+		c.TheirSettlementSignatures[i].Signature = make([]byte, sigLen)
+		copy(c.TheirSettlementSignatures[i].Signature, buf.Next(int(sigLen)))
+	}
 
 	return c, nil
 }
@@ -98,17 +131,23 @@ func (self *DlcContract) Bytes() []byte {
 	buf.Write(self.OracleA[:])
 	buf.Write(self.OracleR[:])
 	binary.Write(&buf, binary.BigEndian, self.PeerIdx)
+	binary.Write(&buf, binary.BigEndian, self.CoinType)
 	binary.Write(&buf, binary.BigEndian, self.OracleTimestamp)
-	binary.Write(&buf, binary.BigEndian, self.ValueAllOurs)
-	binary.Write(&buf, binary.BigEndian, self.ValueAllTheirs)
 	binary.Write(&buf, binary.BigEndian, self.OurFundingAmount)
 	binary.Write(&buf, binary.BigEndian, self.TheirFundingAmount)
+
+	buf.Write(self.OurChangePKH[:])
+	buf.Write(self.TheirChangePKH[:])
+	buf.Write(self.OurFundMultisigPub[:])
+	buf.Write(self.TheirFundMultisigPub[:])
 	buf.Write(self.OurPayoutPub[:])
 	buf.Write(self.TheirPayoutPub[:])
+
 	var status = int32(self.Status)
 	binary.Write(&buf, binary.BigEndian, status)
 
 	ourInputsLen := uint32(len(self.OurFundingInputs))
+	fmt.Printf("[W] Our input len: [%d]\n", ourInputsLen)
 	binary.Write(&buf, binary.BigEndian, ourInputsLen)
 
 	for i := 0; i < len(self.OurFundingInputs); i++ {
@@ -118,6 +157,7 @@ func (self *DlcContract) Bytes() []byte {
 	}
 
 	theirInputsLen := uint32(len(self.TheirFundingInputs))
+	fmt.Printf("[W] Their input len: [%d]\n", theirInputsLen)
 	binary.Write(&buf, binary.BigEndian, theirInputsLen)
 
 	for i := 0; i < len(self.TheirFundingInputs); i++ {
@@ -126,10 +166,77 @@ func (self *DlcContract) Bytes() []byte {
 		binary.Write(&buf, binary.BigEndian, self.TheirFundingInputs[i].Value)
 	}
 
-	binary.Write(&buf, binary.BigEndian, self.CoinType)
+	divisionLen := uint32(len(self.Division))
+	binary.Write(&buf, binary.BigEndian, divisionLen)
 
-	buf.Write(self.OurChangePKH[:])
-	buf.Write(self.TheirChangePKH[:])
+	for i := 0; i < len(self.Division); i++ {
+		binary.Write(&buf, binary.BigEndian, self.Division[i].OracleValue)
+		binary.Write(&buf, binary.BigEndian, self.Division[i].ValueOurs)
+	}
+
+	theirSigLen := uint32(len(self.TheirSettlementSignatures))
+	binary.Write(&buf, binary.BigEndian, theirSigLen)
+
+	for i := 0; i < len(self.TheirSettlementSignatures); i++ {
+		binary.Write(&buf, binary.BigEndian, self.TheirSettlementSignatures[i].Outcome)
+		binary.Write(&buf, binary.BigEndian, uint32(len(self.TheirSettlementSignatures[i].Signature)))
+		buf.Write(self.TheirSettlementSignatures[i].Signature)
+	}
+
+	fmt.Printf("Serialized contract: %x\n", buf.Bytes())
 
 	return buf.Bytes()
+}
+
+func PrintTx(tx *wire.MsgTx) {
+	var buf bytes.Buffer
+	w := bufio.NewWriter(&buf)
+	tx.Serialize(w)
+	w.Flush()
+	fmt.Printf("%x\n", buf.Bytes())
+}
+
+func DlcOutput(pubKeyPeer, pubKeyOracleSig, ourPubKey [33]byte, value int64) *wire.TxOut {
+	scriptBytes := DlcCommitScript(pubKeyPeer, pubKeyOracleSig, ourPubKey, 5)
+	scriptBytes = P2WSHify(scriptBytes)
+
+	return wire.NewTxOut(value, scriptBytes)
+}
+
+// DLC Commit script makes a script that pays to (PubKeyPeer+PubKeyOracleSig or (OurPubKey and TimeDelay))
+// We send this over (signed) to the other side. If they publish the TX with the correct script they can use
+// The oracle's signature and their own private key to claim the funds from the output. However,
+// If they send the wrong one, they won't be able to claim the funds - and we can claim them once the
+// Time delay has passed.
+func DlcCommitScript(pubKeyPeer, pubKeyOracleSig, ourPubKey [33]byte, delay uint16) []byte {
+	builder := txscript.NewScriptBuilder()
+
+	// 1 for penalty / revoked, 0 for timeout
+	// 1, so timeout
+	builder.AddOp(txscript.OP_IF)
+
+	// Combine pubKey and Oracle Sig
+	combinedPubKey := CombinePubs(pubKeyPeer, pubKeyOracleSig)
+	builder.AddData(combinedPubKey[:])
+
+	// 0, so revoked
+	builder.AddOp(txscript.OP_ELSE)
+
+	// CSV delay
+	builder.AddInt64(int64(delay))
+	// CSV check, fails here if too early
+	builder.AddOp(txscript.OP_NOP3) // really OP_CHECKSEQUENCEVERIFY
+	// Drop delay value
+	builder.AddOp(txscript.OP_DROP)
+	// push timeout key
+	builder.AddData(ourPubKey[:])
+
+	builder.AddOp(txscript.OP_ENDIF)
+
+	// check whatever pubkey is left on the stack
+	builder.AddOp(txscript.OP_CHECKSIG)
+
+	// never any errors we care about here.
+	s, _ := builder.Script()
+	return s
 }

--- a/lnutil/dlclib.go
+++ b/lnutil/dlclib.go
@@ -25,7 +25,8 @@ const (
 	ContractStatusAccepted     DlcContractStatus = 4
 	ContractStatusAcknowledged DlcContractStatus = 5
 	ContractStatusActive       DlcContractStatus = 6
-	ContractStatusClosed       DlcContractStatus = 7
+	ContractStatusSettling     DlcContractStatus = 7
+	ContractStatusClosed       DlcContractStatus = 8
 )
 
 // scalarSize is the size of an encoded big endian scalar.

--- a/lnutil/dlclib.go
+++ b/lnutil/dlclib.go
@@ -1,0 +1,131 @@
+package lnutil
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/adiabat/btcd/wire"
+)
+
+type DlcContractStatus int
+
+const (
+	ContractStatusDraft       DlcContractStatus = 0
+	ContractStatusOfferedByMe DlcContractStatus = 1
+	ContractStatusOfferedToMe DlcContractStatus = 2
+	ContractStatusDeclined    DlcContractStatus = 3
+	ContractStatusActive      DlcContractStatus = 4
+	ContractStatusClosed      DlcContractStatus = 5
+)
+
+type DlcContract struct {
+	Idx                                  uint64                    // Index of the contract for referencing in commands
+	CoinType                             uint32                    // Coin type
+	OracleA, OracleB, OracleQ            [33]byte                  // Pub keys of the oracle
+	OracleDataFeed, OracleTimestamp      uint64                    // The data feed and time we use for contract settlement
+	ValueAllOurs, ValueAllTheirs         uint64                    // The value of the datafeed based on which all money in the contract goes to either party
+	OurFundingAmount, TheirFundingAmount uint64                    // The amounts either side are funding
+	OurPayoutPKH, TheirPayoutPKH         [20]byte                  // PKH to which the contracts are supposed to pay out
+	RemoteNodePub                        [33]byte                  // Pubkey of the peer we've offered the contract to or received the contract from
+	Status                               DlcContractStatus         // Status of the contract
+	OurFundingInputs, TheirFundingInputs []DlcContractFundingInput // Outpoints used to fund the contract
+}
+
+type DlcContractFundingInput struct {
+	Outpoint wire.OutPoint
+	Value    uint64
+}
+
+func DlcContractFromBytes(b []byte) (*DlcContract, error) {
+	buf := bytes.NewBuffer(b)
+	c := new(DlcContract)
+
+	copy(c.OracleA[:], buf.Next(33))
+	copy(c.OracleB[:], buf.Next(33))
+	copy(c.OracleQ[:], buf.Next(33))
+
+	_ = binary.Read(buf, binary.BigEndian, &c.OracleDataFeed)
+	_ = binary.Read(buf, binary.BigEndian, &c.OracleTimestamp)
+	_ = binary.Read(buf, binary.BigEndian, &c.ValueAllOurs)
+	_ = binary.Read(buf, binary.BigEndian, &c.ValueAllTheirs)
+	_ = binary.Read(buf, binary.BigEndian, &c.OurFundingAmount)
+	_ = binary.Read(buf, binary.BigEndian, &c.TheirFundingAmount)
+
+	copy(c.OurPayoutPKH[:], buf.Next(20))
+	copy(c.TheirPayoutPKH[:], buf.Next(20))
+
+	var status int32
+	_ = binary.Read(buf, binary.BigEndian, &status)
+	fmt.Printf("Read byte for status: %d\n", status)
+
+	c.Status = DlcContractStatus(status)
+
+	var ourInputsLen uint32
+	_ = binary.Read(buf, binary.BigEndian, &ourInputsLen)
+
+	c.OurFundingInputs = make([]DlcContractFundingInput, ourInputsLen)
+	var op [36]byte
+	for i := uint32(0); i < ourInputsLen; i++ {
+		copy(op[:], buf.Next(36))
+		c.OurFundingInputs[i].Outpoint = *OutPointFromBytes(op)
+		_ = binary.Read(buf, binary.BigEndian, &c.OurFundingInputs[i].Value)
+	}
+
+	var theirInputsLen uint32
+	_ = binary.Read(buf, binary.BigEndian, &theirInputsLen)
+
+	c.TheirFundingInputs = make([]DlcContractFundingInput, theirInputsLen)
+	for i := uint32(0); i < ourInputsLen; i++ {
+		copy(op[:], buf.Next(36))
+		c.OurFundingInputs[i].Outpoint = *OutPointFromBytes(op)
+		_ = binary.Read(buf, binary.BigEndian, &c.OurFundingInputs[i].Value)
+	}
+
+	_ = binary.Read(buf, binary.BigEndian, &c.CoinType)
+	copy(c.RemoteNodePub[:], buf.Next(33))
+	return c, nil
+}
+
+func (self *DlcContract) Bytes() []byte {
+	var buf bytes.Buffer
+
+	buf.Write(self.OracleA[:])
+	buf.Write(self.OracleB[:])
+	buf.Write(self.OracleQ[:])
+	binary.Write(&buf, binary.BigEndian, self.OracleDataFeed)
+	binary.Write(&buf, binary.BigEndian, self.OracleTimestamp)
+	binary.Write(&buf, binary.BigEndian, self.ValueAllOurs)
+	binary.Write(&buf, binary.BigEndian, self.ValueAllTheirs)
+	binary.Write(&buf, binary.BigEndian, self.OurFundingAmount)
+	binary.Write(&buf, binary.BigEndian, self.TheirFundingAmount)
+	buf.Write(self.OurPayoutPKH[:])
+	buf.Write(self.TheirPayoutPKH[:])
+	var status = int32(self.Status)
+	fmt.Printf("Writing byte for status: %d\n", status)
+	binary.Write(&buf, binary.BigEndian, status)
+
+	ourInputsLen := uint32(len(self.OurFundingInputs))
+	binary.Write(&buf, binary.BigEndian, ourInputsLen)
+
+	for i := 0; i < len(self.OurFundingInputs); i++ {
+		opArr := OutPointToBytes(self.OurFundingInputs[i].Outpoint)
+		buf.Write(opArr[:])
+		binary.Write(&buf, binary.BigEndian, self.OurFundingInputs[i].Value)
+	}
+
+	theirInputsLen := uint32(len(self.TheirFundingInputs))
+	binary.Write(&buf, binary.BigEndian, theirInputsLen)
+
+	for i := 0; i < len(self.TheirFundingInputs); i++ {
+		opArr := OutPointToBytes(self.TheirFundingInputs[i].Outpoint)
+		buf.Write(opArr[:])
+		binary.Write(&buf, binary.BigEndian, self.TheirFundingInputs[i].Value)
+	}
+
+	binary.Write(&buf, binary.BigEndian, self.CoinType)
+
+	buf.Write(self.RemoteNodePub[:])
+
+	return buf.Bytes()
+}

--- a/lnutil/dlclib.go
+++ b/lnutil/dlclib.go
@@ -383,7 +383,7 @@ func DlcCalcOracleSignaturePubKey(msg []byte, oracleA, oracleR [33]byte) ([33]by
 }
 
 // Ours = the one we generate & sign. Theirs (ours = false) = the one they generated, so we can use their sigs
-func SettlementTx(c *DlcContract, d DlcContractDivision, contractInput wire.OutPoint, ours bool, debug bool) (*wire.MsgTx, error) {
+func SettlementTx(c *DlcContract, d DlcContractDivision, contractInput wire.OutPoint, ours bool) (*wire.MsgTx, error) {
 
 	tx := wire.NewMsgTx()
 	// set version 2, for op_csv
@@ -424,18 +424,6 @@ func SettlementTx(c *DlcContract, d DlcContractDivision, contractInput wire.OutP
 	if err != nil {
 		return nil, err
 	}
-
-	if debug {
-		fmt.Printf("== Building settlement TX ==\n")
-		fmt.Printf("Ours: %t\n", ours)
-		fmt.Printf("TheirPayoutPub: %x\n", c.TheirPayoutPub)
-		fmt.Printf("OurPayoutPub: %x\n", c.OurPayoutPub)
-		fmt.Printf("oracleSigPub: %x\n", oracleSigPub)
-		fmt.Printf("valueTheirs: %d\n", valueTheirs)
-		fmt.Printf("valueOurs: %d\n", valueOurs)
-		fmt.Printf("feeTheirs: %d\n", feeTheirs)
-		fmt.Printf("feeOurs: %d\n", feeOurs)
-	}
 	// Ours = the one we generate & sign. Theirs (ours = false) = the one they generated, so we can use their sigs
 	if ours {
 		if valueTheirs > 0 {
@@ -459,10 +447,6 @@ func SettlementTx(c *DlcContract, d DlcContractDivision, contractInput wire.OutP
 			tx.AddTxOut(wire.NewTxOut(valueTheirs, DirectWPKHScriptFromPKH(theirPayoutPKH)))
 		}
 	}
-	if debug {
-		fmt.Printf("Tx hash: %s", tx.TxHash().String())
-		fmt.Printf("Tx raw:\n")
-		PrintTx(tx)
-	}
+
 	return tx, nil
 }

--- a/lnutil/msglib.go
+++ b/lnutil/msglib.go
@@ -1049,6 +1049,7 @@ type DlcOfferAcceptMsg struct {
 	ContractPubKey       [33]byte
 	OurChangePKH         [20]byte
 	OurFundMultisigPub   [33]byte
+	OurPayoutPub         [33]byte
 	FundingInputs        []DlcContractFundingInput
 	SettlementSignatures []DlcContractSettlementSignature
 }
@@ -1060,6 +1061,7 @@ func NewDlcOfferAcceptMsg(contract *DlcContract, signatures []DlcContractSettlem
 	msg.FundingInputs = contract.OurFundingInputs
 	msg.OurChangePKH = contract.OurChangePKH
 	msg.OurFundMultisigPub = contract.OurFundMultisigPub
+	msg.OurPayoutPub = contract.OurPayoutPub
 	msg.SettlementSignatures = signatures
 	return *msg
 }
@@ -1076,6 +1078,7 @@ func NewDlcOfferAcceptMsgFromBytes(b []byte, peerIdx uint32) (DlcOfferAcceptMsg,
 	copy(msg.ContractPubKey[:], buf.Next(33))
 	copy(msg.OurChangePKH[:], buf.Next(20))
 	copy(msg.OurFundMultisigPub[:], buf.Next(33))
+	copy(msg.OurPayoutPub[:], buf.Next(33))
 
 	inputCount, _ := wire.ReadVarInt(buf, 0)
 
@@ -1109,6 +1112,7 @@ func (self DlcOfferAcceptMsg) Bytes() []byte {
 	buf.Write(self.ContractPubKey[:])
 	buf.Write(self.OurChangePKH[:])
 	buf.Write(self.OurFundMultisigPub[:])
+	buf.Write(self.OurPayoutPub[:])
 
 	inputCount := uint64(len(self.FundingInputs))
 	wire.WriteVarInt(&buf, 0, inputCount)

--- a/lnutil/msglib.go
+++ b/lnutil/msglib.go
@@ -958,7 +958,8 @@ func (self LinkMsg) Bytes() []byte {
 func (self LinkMsg) Peer() uint32   { return self.PeerIdx }
 func (self LinkMsg) MsgType() uint8 { return MSGID_LINK_DESC }
 
-// DlcOfferMsg is the message we send to a peer to offer that peer a particular contract
+// DlcOfferMsg is the message we send to a peer to offer that peer a
+// particular contract
 type DlcOfferMsg struct {
 	PeerIdx  uint32
 	Contract *DlcContract
@@ -1002,14 +1003,15 @@ func (msg DlcOfferMsg) MsgType() uint8 { return MSGID_DLC_OFFER }
 
 type DlcOfferDeclineMsg struct {
 	PeerIdx uint32
-	Idx     uint64 // The contract we are declining (indexing on the peer receiving this message)
+	Idx     uint64 // The contract we are declining
 	Reason  uint8  // Reason for declining the funding request
 
 }
 
-// NewDlcOfferDeclineMsg creates a new DlcOfferDeclineMsg based on a peer, a reason for declining and the key of the
-// contract we're declining
-func NewDlcOfferDeclineMsg(peerIdx uint32, reason uint8, theirIdx uint64) DlcOfferDeclineMsg {
+// NewDlcOfferDeclineMsg creates a new DlcOfferDeclineMsg based on a peer, a
+// reason for declining and the index of the contract we're declining
+func NewDlcOfferDeclineMsg(peerIdx uint32, reason uint8,
+	theirIdx uint64) DlcOfferDeclineMsg {
 	msg := new(DlcOfferDeclineMsg)
 	msg.PeerIdx = peerIdx
 	msg.Reason = reason
@@ -1017,13 +1019,17 @@ func NewDlcOfferDeclineMsg(peerIdx uint32, reason uint8, theirIdx uint64) DlcOff
 	return *msg
 }
 
-// NewDlcOfferDeclineMsgFromBytes deserializes a byte array into a DlcOfferDeclineMsg
-func NewDlcOfferDeclineMsgFromBytes(b []byte, peerIdx uint32) (DlcOfferDeclineMsg, error) {
+// NewDlcOfferDeclineMsgFromBytes deserializes a byte array into a
+// DlcOfferDeclineMsg
+func NewDlcOfferDeclineMsgFromBytes(b []byte,
+	peerIdx uint32) (DlcOfferDeclineMsg, error) {
+
 	msg := new(DlcOfferDeclineMsg)
 	msg.PeerIdx = peerIdx
 
 	if len(b) < 2 {
-		return *msg, fmt.Errorf("DlcOfferDeclineMsg %d bytes, expect at least 2", len(b))
+		return *msg, fmt.Errorf("DlcOfferDeclineMsg %d bytes, expect at"+
+			" least 2", len(b))
 	}
 
 	buf := bytes.NewBuffer(b[1:]) // get rid of messageType
@@ -1051,27 +1057,42 @@ func (msg DlcOfferDeclineMsg) Peer() uint32 { return msg.PeerIdx }
 // MsgType returns the type of this message
 func (msg DlcOfferDeclineMsg) MsgType() uint8 { return MSGID_DLC_DECLINEOFFER }
 
-// DlcContractSettlementSignature contains the signature for a particular settlement transaction
+// DlcContractSettlementSignature contains the signature for a particular
+// settlement transaction
 type DlcContractSettlementSignature struct {
-	Outcome   int64    // The oracle value for which transaction these are the signatures
-	Signature [64]byte // The signature for the transaction
+	// The oracle value for which transaction these are the signatures
+	Outcome int64
+	// The signature for the transaction
+	Signature [64]byte
 }
 
 // DlcOfferAcceptMsg is a message indicating we are accepting the contract
 type DlcOfferAcceptMsg struct {
-	PeerIdx              uint32                           // Index of the peer we are forming the contract with
-	Idx                  uint64                           // The index of the contract on the peer we're receiving this message on
-	OurIdx               uint64                           // The index of the contract on our side, so they know how to reference it
-	OurChangePKH         [20]byte                         // The PKH we want the change from funding to be paid back to
-	OurFundMultisigPub   [33]byte                         // The Pubkey that is part of the multisig for spending the contract funds
-	OurPayoutBase        [33]byte                         // The Pubkey to be used to in the contract settlement
-	OurPayoutPKH         [20]byte                         // The PKH to be paid to in the contract settlement
-	FundingInputs        []DlcContractFundingInput        // The UTXOs we are using to fund the contract
-	SettlementSignatures []DlcContractSettlementSignature // The signatures for settling the contract at various values
+	// Index of the peer we are forming the contract with
+	PeerIdx uint32
+	// The index of the contract on the peer we're receiving this message on
+	Idx uint64
+	// The index of the contract on our side, so they know how to reference it
+	OurIdx uint64
+	// The PKH we want the change from funding to be paid back to
+	OurChangePKH [20]byte
+	// The Pubkey that is part of the multisig for spending the contract funds
+	OurFundMultisigPub [33]byte
+	// The Pubkey to be used to in the contract settlement
+	OurPayoutBase [33]byte
+	// The PKH to be paid to in the contract settlement
+	OurPayoutPKH [20]byte
+	// The UTXOs we are using to fund the contract
+	FundingInputs []DlcContractFundingInput
+	// The signatures for settling the contract at various values
+	SettlementSignatures []DlcContractSettlementSignature
 }
 
-// NewDlcOfferAcceptMsg generates a new DlcOfferAcceptMsg struct based on the passed contract and signatures
-func NewDlcOfferAcceptMsg(contract *DlcContract, signatures []DlcContractSettlementSignature) DlcOfferAcceptMsg {
+// NewDlcOfferAcceptMsg generates a new DlcOfferAcceptMsg struct based on the
+// passed contract and signatures
+func NewDlcOfferAcceptMsg(contract *DlcContract,
+	signatures []DlcContractSettlementSignature) DlcOfferAcceptMsg {
+
 	msg := new(DlcOfferAcceptMsg)
 	msg.PeerIdx = contract.PeerIdx
 	msg.Idx = contract.TheirIdx
@@ -1085,13 +1106,17 @@ func NewDlcOfferAcceptMsg(contract *DlcContract, signatures []DlcContractSettlem
 	return *msg
 }
 
-// NewDlcOfferAcceptMsgFromBytes parses a byte array back into a DlcOfferAcceptMsg struct
-func NewDlcOfferAcceptMsgFromBytes(b []byte, peerIdx uint32) (DlcOfferAcceptMsg, error) {
+// NewDlcOfferAcceptMsgFromBytes parses a byte array back into a
+// DlcOfferAcceptMsg struct
+func NewDlcOfferAcceptMsgFromBytes(b []byte,
+	peerIdx uint32) (DlcOfferAcceptMsg, error) {
+
 	msg := new(DlcOfferAcceptMsg)
 	msg.PeerIdx = peerIdx
 
 	if len(b) < 34 {
-		return *msg, fmt.Errorf("DlcOfferAcceptMsg %d bytes, expect at least 34", len(b))
+		return *msg, fmt.Errorf("DlcOfferAcceptMsg %d bytes, expect at"+
+			" least 34", len(b))
 	}
 
 	buf := bytes.NewBuffer(b[1:]) // get rid of messageType
@@ -1115,10 +1140,10 @@ func NewDlcOfferAcceptMsgFromBytes(b []byte, peerIdx uint32) (DlcOfferAcceptMsg,
 
 	}
 
-	signatureCount, _ := wire.ReadVarInt(buf, 0)
-	msg.SettlementSignatures = make([]DlcContractSettlementSignature, signatureCount)
+	sigCount, _ := wire.ReadVarInt(buf, 0)
+	msg.SettlementSignatures = make([]DlcContractSettlementSignature, sigCount)
 
-	for i := uint64(0); i < signatureCount; i++ {
+	for i := uint64(0); i < sigCount; i++ {
 		val, _ := wire.ReadVarInt(buf, 0)
 		msg.SettlementSignatures[i].Outcome = int64(val)
 		copy(msg.SettlementSignatures[i].Signature[:], buf.Next(64))
@@ -1161,21 +1186,32 @@ func (msg DlcOfferAcceptMsg) Bytes() []byte {
 }
 
 // Peer returns the peer index this message was received from/sent to
-func (msg DlcOfferAcceptMsg) Peer() uint32 { return msg.PeerIdx }
-
-// MsgType returns the type of this message
-func (msg DlcOfferAcceptMsg) MsgType() uint8 { return MSGID_DLC_ACCEPTOFFER }
-
-// DlcContractAckMsg is sent from the offering party back to the peer when the contract acceptance
-// is acknowledged. Includes the signatures from this peer for the settlement TXes.
-type DlcContractAckMsg struct {
-	PeerIdx              uint32                           // Peer we're sending the Ack to (or received it from)
-	Idx                  uint64                           // The index of the contract we're acknowledging
-	SettlementSignatures []DlcContractSettlementSignature // The settlement signatures of the party acknowledging
+func (msg DlcOfferAcceptMsg) Peer() uint32 {
+	return msg.PeerIdx
 }
 
-// NewDlcContractAckMsg generates a new DlcContractAckMsg struct based on the passed contract and signatures
-func NewDlcContractAckMsg(contract *DlcContract, signatures []DlcContractSettlementSignature) DlcContractAckMsg {
+// MsgType returns the type of this message
+func (msg DlcOfferAcceptMsg) MsgType() uint8 {
+	return MSGID_DLC_ACCEPTOFFER
+}
+
+// DlcContractAckMsg is sent from the offering party back to the peer when the
+// contract acceptance is acknowledged. Includes the signatures from this peer
+// for the settlement TXes.
+type DlcContractAckMsg struct {
+	// Peer we're sending the Ack to (or received it from)
+	PeerIdx uint32
+	// The index of the contract we're acknowledging
+	Idx uint64
+	// The settlement signatures of the party acknowledging
+	SettlementSignatures []DlcContractSettlementSignature
+}
+
+// NewDlcContractAckMsg generates a new DlcContractAckMsg struct based on the
+// passed contract and signatures
+func NewDlcContractAckMsg(contract *DlcContract,
+	signatures []DlcContractSettlementSignature) DlcContractAckMsg {
+
 	msg := new(DlcContractAckMsg)
 	msg.PeerIdx = contract.PeerIdx
 	msg.Idx = contract.TheirIdx
@@ -1183,24 +1219,28 @@ func NewDlcContractAckMsg(contract *DlcContract, signatures []DlcContractSettlem
 	return *msg
 }
 
-// NewDlcContractAckMsgFromBytes deserializes a byte array into a DlcContractAckMsg
-func NewDlcContractAckMsgFromBytes(b []byte, peerIdx uint32) (DlcContractAckMsg, error) {
+// NewDlcContractAckMsgFromBytes deserializes a byte array into a
+// DlcContractAckMsg
+func NewDlcContractAckMsgFromBytes(b []byte,
+	peerIdx uint32) (DlcContractAckMsg, error) {
+
 	msg := new(DlcContractAckMsg)
 	msg.PeerIdx = peerIdx
 
 	// TODO
 	if len(b) < 34 {
-		return *msg, fmt.Errorf("DlcContractAckMsg %d bytes, expect at least 34", len(b))
+		return *msg, fmt.Errorf("DlcContractAckMsg %d bytes, expect at"+
+			" least 34", len(b))
 	}
 
 	buf := bytes.NewBuffer(b[1:]) // get rid of messageType
 	msg.Idx, _ = wire.ReadVarInt(buf, 0)
 
-	var signatureCount uint32
-	binary.Read(buf, binary.BigEndian, &signatureCount)
-	msg.SettlementSignatures = make([]DlcContractSettlementSignature, signatureCount)
+	var sigCount uint32
+	binary.Read(buf, binary.BigEndian, &sigCount)
+	msg.SettlementSignatures = make([]DlcContractSettlementSignature, sigCount)
 
-	for i := uint32(0); i < signatureCount; i++ {
+	for i := uint32(0); i < sigCount; i++ {
 		binary.Read(buf, binary.BigEndian, &msg.SettlementSignatures[i].Outcome)
 		copy(msg.SettlementSignatures[i].Signature[:], buf.Next(64))
 	}
@@ -1219,29 +1259,38 @@ func (msg DlcContractAckMsg) Bytes() []byte {
 	binary.Write(&buf, binary.BigEndian, signatureCount)
 
 	for i := uint32(0); i < signatureCount; i++ {
-		binary.Write(&buf, binary.BigEndian, msg.SettlementSignatures[i].Outcome)
+		outcome := msg.SettlementSignatures[i].Outcome
+		binary.Write(&buf, binary.BigEndian, outcome)
 		buf.Write(msg.SettlementSignatures[i].Signature[:])
 	}
 	return buf.Bytes()
 }
 
 // Peer returns the peer index this message was received from/sent to
-func (msg DlcContractAckMsg) Peer() uint32 { return msg.PeerIdx }
+func (msg DlcContractAckMsg) Peer() uint32 {
+	return msg.PeerIdx
+}
 
 // MsgType returns the type of this message
-func (msg DlcContractAckMsg) MsgType() uint8 { return MSGID_DLC_CONTRACTACK }
+func (msg DlcContractAckMsg) MsgType() uint8 {
+	return MSGID_DLC_CONTRACTACK
+}
 
-// DlcContractFundingSigsMsg is sent by the counter party once the signatures for the settlement are
-// verified and accepted. These signatures can be used to spend the peer's UTXOs for funding the
-// contract into the actual contract output.
+// DlcContractFundingSigsMsg is sent by the counter party once the signatures
+// for the settlement are verified and accepted. These signatures can be used
+// to spend the peer's UTXOs for funding the contract into the actual contract
+// output.
 type DlcContractFundingSigsMsg struct {
 	PeerIdx         uint32      // Peer we're exchanging the message with
 	Idx             uint64      // The index of the concerning contract
 	SignedFundingTx *wire.MsgTx // The funding TX containing the signatures
 }
 
-// NewDlcContractFundingSigsMsg creates a new DlcContractFundingSigsMsg based on the passed contract and signed funding TX
-func NewDlcContractFundingSigsMsg(contract *DlcContract, signedTx *wire.MsgTx) DlcContractFundingSigsMsg {
+// NewDlcContractFundingSigsMsg creates a new DlcContractFundingSigsMsg based
+// on the passed contract and signed funding TX
+func NewDlcContractFundingSigsMsg(contract *DlcContract,
+	signedTx *wire.MsgTx) DlcContractFundingSigsMsg {
+
 	msg := new(DlcContractFundingSigsMsg)
 	msg.PeerIdx = contract.PeerIdx
 	msg.Idx = contract.TheirIdx
@@ -1249,14 +1298,18 @@ func NewDlcContractFundingSigsMsg(contract *DlcContract, signedTx *wire.MsgTx) D
 	return *msg
 }
 
-// NewDlcContractFundingSigsMsgFromBytes deserializes a byte array into a DlcContractFundingSigsMsg
-func NewDlcContractFundingSigsMsgFromBytes(b []byte, peerIdx uint32) (DlcContractFundingSigsMsg, error) {
+// NewDlcContractFundingSigsMsgFromBytes deserializes a byte array into a
+// DlcContractFundingSigsMsg
+func NewDlcContractFundingSigsMsgFromBytes(b []byte,
+	peerIdx uint32) (DlcContractFundingSigsMsg, error) {
+
 	msg := new(DlcContractFundingSigsMsg)
 	msg.PeerIdx = peerIdx
 
 	// TODO
 	if len(b) < 34 {
-		return *msg, fmt.Errorf("DlcContractFundingSigsMsg %d bytes, expect at least 34", len(b))
+		return *msg, fmt.Errorf("DlcContractFundingSigsMsg %d bytes, expect"+
+			"at least 34", len(b))
 	}
 
 	buf := bytes.NewBuffer(b[1:]) // get rid of messageType
@@ -1282,21 +1335,32 @@ func (msg DlcContractFundingSigsMsg) Bytes() []byte {
 }
 
 // Peer returns the peer index this message was received from/sent to
-func (msg DlcContractFundingSigsMsg) Peer() uint32 { return msg.PeerIdx }
-
-// MsgType returns the type of this message
-func (msg DlcContractFundingSigsMsg) MsgType() uint8 { return MSGID_DLC_CONTRACTFUNDINGSIGS }
-
-// DlcContractSigProofMsg acknowledges the funding of the contract to a peer. It contains the fully signed
-// funding transaction that has already been published to the blockchain
-type DlcContractSigProofMsg struct {
-	PeerIdx         uint32      // The index of the peer we're communicating with
-	Idx             uint64      // The contract we're communicating about
-	SignedFundingTx *wire.MsgTx // The fully signed funding transaction
+func (msg DlcContractFundingSigsMsg) Peer() uint32 {
+	return msg.PeerIdx
 }
 
-// NewDlcContractSigProofMsg creates a new DlcContractSigProofMsg based on the passed contract and signed funding TX
-func NewDlcContractSigProofMsg(contract *DlcContract, signedTx *wire.MsgTx) DlcContractSigProofMsg {
+// MsgType returns the type of this message
+func (msg DlcContractFundingSigsMsg) MsgType() uint8 {
+	return MSGID_DLC_CONTRACTFUNDINGSIGS
+}
+
+// DlcContractSigProofMsg acknowledges the funding of the contract to a peer.
+// It contains the fully signed funding transaction that has already been
+// published to the blockchain
+type DlcContractSigProofMsg struct {
+	// The index of the peer we're communicating with
+	PeerIdx uint32
+	// The contract we're communicating about
+	Idx uint64
+	// The fully signed funding transaction
+	SignedFundingTx *wire.MsgTx
+}
+
+// NewDlcContractSigProofMsg creates a new DlcContractSigProofMsg based on the
+// passed contract and signed funding TX
+func NewDlcContractSigProofMsg(contract *DlcContract,
+	signedTx *wire.MsgTx) DlcContractSigProofMsg {
+
 	msg := new(DlcContractSigProofMsg)
 	msg.PeerIdx = contract.PeerIdx
 	msg.Idx = contract.TheirIdx
@@ -1304,14 +1368,18 @@ func NewDlcContractSigProofMsg(contract *DlcContract, signedTx *wire.MsgTx) DlcC
 	return *msg
 }
 
-// NewDlcContractSigProofMsgFromBytes deserializes a byte array into a DlcContractSigProofMsg
-func NewDlcContractSigProofMsgFromBytes(b []byte, peerIdx uint32) (DlcContractSigProofMsg, error) {
+// NewDlcContractSigProofMsgFromBytes deserializes a byte array into a
+// DlcContractSigProofMsg
+func NewDlcContractSigProofMsgFromBytes(b []byte,
+	peerIdx uint32) (DlcContractSigProofMsg, error) {
+
 	msg := new(DlcContractSigProofMsg)
 	msg.PeerIdx = peerIdx
 
 	// TODO
 	if len(b) < 34 {
-		return *msg, fmt.Errorf("DlcContractSigProofMsg %d bytes, expect at least 34", len(b))
+		return *msg, fmt.Errorf("DlcContractSigProofMsg %d bytes, expect"+
+			" at least 34", len(b))
 	}
 
 	buf := bytes.NewBuffer(b[1:]) // get rid of messageType
@@ -1337,7 +1405,11 @@ func (msg DlcContractSigProofMsg) Bytes() []byte {
 }
 
 // Peer returns the peer index this message was received from/sent to
-func (msg DlcContractSigProofMsg) Peer() uint32 { return msg.PeerIdx }
+func (msg DlcContractSigProofMsg) Peer() uint32 {
+	return msg.PeerIdx
+}
 
 // MsgType returns the type of this message
-func (msg DlcContractSigProofMsg) MsgType() uint8 { return MSGID_DLC_SIGPROOF }
+func (msg DlcContractSigProofMsg) MsgType() uint8 {
+	return MSGID_DLC_SIGPROOF
+}

--- a/qln/basewallet.go
+++ b/qln/basewallet.go
@@ -93,6 +93,12 @@ type UWallet interface {
 	// ===== TESTING / SPAMMING ONLY, these funcs will not be in the real interface
 	// Sweep sends lots of txs (uint32 of them) to the specified address.
 	Sweep([]byte, uint32) ([]*chainhash.Hash, error)
+
+	PickUtxos(amtWanted, outputByteSize, feePerByte int64, ow bool) (portxo.TxoSliceByBip69, int64, error)
+
+	SignMyInputs(tx *wire.MsgTx) error
+
+	DirectSendTx(tx *wire.MsgTx) error
 }
 
 // GetUsePub gets a pubkey from the base wallet, but first modifies

--- a/qln/basewallet.go
+++ b/qln/basewallet.go
@@ -94,7 +94,8 @@ type UWallet interface {
 	// Sweep sends lots of txs (uint32 of them) to the specified address.
 	Sweep([]byte, uint32) ([]*chainhash.Hash, error)
 
-	PickUtxos(amtWanted, outputByteSize, feePerByte int64, ow bool) (portxo.TxoSliceByBip69, int64, error)
+	PickUtxos(amtWanted, outputByteSize,
+		feePerByte int64, ow bool) (portxo.TxoSliceByBip69, int64, error)
 
 	SignMyInputs(tx *wire.MsgTx) error
 

--- a/qln/dlc.go
+++ b/qln/dlc.go
@@ -1,11 +1,12 @@
 package qln
 
 import (
-	"bufio"
-	"bytes"
 	"fmt"
 
-	"github.com/adiabat/btcd/chaincfg/chainhash"
+	"github.com/adiabat/btcutil"
+
+	"github.com/adiabat/btcd/btcec"
+	"github.com/adiabat/btcd/txscript"
 	"github.com/adiabat/btcd/wire"
 	"github.com/adiabat/btcutil/txsort"
 	"github.com/mit-dci/lit/lnutil"
@@ -28,19 +29,22 @@ func (nd *LitNode) OfferDlc(peerIdx uint32, cIdx uint64) error {
 		return err
 	}
 
-	msg := lnutil.NewDlcOfferMsg(peerIdx, c)
-	c.Status = lnutil.ContractStatusOfferedByMe
 	c.PeerIdx = peerIdx
 
 	var kg portxo.KeyGen
 	kg.Depth = 5
 	kg.Step[0] = 44 | 1<<31
 	kg.Step[1] = c.CoinType | 1<<31
-	kg.Step[2] = UseContractPayout
+	kg.Step[2] = UseContractFundMultisig
 	kg.Step[3] = c.PeerIdx | 1<<31
 	kg.Step[4] = uint32(c.Idx) | 1<<31
 
-	c.OurPayoutPub, err = nd.GetUsePub(kg, UseContractPayout)
+	c.OurFundMultisigPub, err = nd.GetUsePub(kg, UseContractFundMultisig)
+	if err != nil {
+		return err
+	}
+
+	c.OurPayoutPub, err = nd.GetUsePub(kg, UseContractFundMultisig)
 	if err != nil {
 		return err
 	}
@@ -51,6 +55,9 @@ func (nd *LitNode) OfferDlc(peerIdx uint32, cIdx uint64) error {
 		return err
 	}
 
+	msg := lnutil.NewDlcOfferMsg(peerIdx, c)
+
+	c.Status = lnutil.ContractStatusOfferedByMe
 	err = nd.DlcManager.SaveContract(c)
 	if err != nil {
 		return err
@@ -96,32 +103,27 @@ func (nd *LitNode) AcceptDlc(cIdx uint64) error {
 	kg.Depth = 5
 	kg.Step[0] = 44 | 1<<31
 	kg.Step[1] = c.CoinType | 1<<31
-	kg.Step[2] = UseContractPayout
+	kg.Step[2] = UseContractFundMultisig
 	kg.Step[3] = c.PeerIdx | 1<<31
 	kg.Step[4] = uint32(c.Idx) | 1<<31
+
+	c.OurFundMultisigPub, err = nd.GetUsePub(kg, UseContractFundMultisig)
+	if err != nil {
+		return err
+	}
 
 	c.OurPayoutPub, err = nd.GetUsePub(kg, UseContractPayout)
 	if err != nil {
 		return err
 	}
 
-	// Now we can calculate the funding TX, all inputs are known
-	tx, err := nd.BuildDlcFundingTransaction(c)
-	if err != nil {
-		return err
-	}
-
-	var buf bytes.Buffer
-	w := bufio.NewWriter(&buf)
-	tx.Serialize(w)
-	w.Flush()
-	fmt.Printf("Funding TX created:\n%x", buf.Bytes())
-
 	// Now we can sign the division
-	sigs, err := nd.SignSettlementDivisions(tx.TxHash(), c)
+	sigs, err := nd.SignSettlementDivisions(c)
 	if err != nil {
 		return err
 	}
+
+	fmt.Printf("Sending acceptance. Our funding input length: [%d] - Their funding input length: [%d]", len(c.OurFundingInputs), len(c.TheirFundingInputs))
 
 	msg := lnutil.NewDlcOfferAcceptMsg(c, sigs)
 	c.Status = lnutil.ContractStatusAccepted
@@ -146,12 +148,18 @@ func (nd *LitNode) DlcOfferHandler(msg lnutil.DlcOfferMsg, peer *RemotePeer) {
 	c.TheirFundingAmount = msg.Contract.OurFundingAmount
 	c.OurFundingInputs = msg.Contract.TheirFundingInputs
 	c.TheirFundingInputs = msg.Contract.OurFundingInputs
+	c.OurFundMultisigPub = msg.Contract.TheirFundMultisigPub
+	c.TheirFundMultisigPub = msg.Contract.OurFundMultisigPub
 	c.OurPayoutPub = msg.Contract.TheirPayoutPub
 	c.TheirPayoutPub = msg.Contract.OurPayoutPub
-	c.ValueAllOurs = msg.Contract.ValueAllTheirs
-	c.ValueAllTheirs = msg.Contract.ValueAllOurs
 	c.OurChangePKH = msg.Contract.TheirChangePKH
 	c.TheirChangePKH = msg.Contract.OurChangePKH
+
+	c.Division = make([]lnutil.DlcContractDivision, len(msg.Contract.Division))
+	for i := 0; i < len(msg.Contract.Division); i++ {
+		c.Division[i].OracleValue = msg.Contract.Division[i].OracleValue
+		c.Division[i].ValueOurs = (c.TheirFundingAmount + c.OurFundingAmount) - msg.Contract.Division[i].ValueOurs
+	}
 
 	// Copy
 	c.CoinType = msg.Contract.CoinType
@@ -160,11 +168,21 @@ func (nd *LitNode) DlcOfferHandler(msg lnutil.DlcOfferMsg, peer *RemotePeer) {
 	c.OracleTimestamp = msg.Contract.OracleTimestamp
 	c.PubKey = msg.Contract.PubKey
 
+	fmt.Printf("Received contract offer. Funding input length: [%d]\n", len(c.TheirFundingInputs))
+
 	err := nd.DlcManager.SaveContract(c)
 	if err != nil {
 		fmt.Printf("DlcOfferHandler SaveContract err %s\n", err.Error())
 		return
 	}
+
+	c, err = nd.DlcManager.FindContractByKey(msg.Contract.PubKey)
+	if err != nil {
+		fmt.Printf("DlcOfferHandler FindContract err %s\n", err.Error())
+		return
+	}
+	fmt.Printf("DlcOfferHandler after reloading - Their inputs [%d]\n", len(c.TheirFundingInputs))
+
 }
 
 func (nd *LitNode) DlcDeclineHandler(msg lnutil.DlcOfferDeclineMsg, peer *RemotePeer) {
@@ -182,24 +200,237 @@ func (nd *LitNode) DlcDeclineHandler(msg lnutil.DlcOfferDeclineMsg, peer *Remote
 	}
 }
 
-func (nd *LitNode) DlcAcceptHandler(msg lnutil.DlcOfferAcceptMsg, peer *RemotePeer) {
+func (nd *LitNode) DlcAcceptHandler(msg lnutil.DlcOfferAcceptMsg, peer *RemotePeer) error {
 	c, err := nd.DlcManager.FindContractByKey(msg.ContractPubKey)
 	if err != nil {
 		fmt.Printf("DlcAcceptHandler FindContract err %s\n", err.Error())
-		return
+		return err
 	}
+
+	// TODO: Check signatures
+
+	c.TheirChangePKH = msg.MyChangePKH
+	c.TheirFundingInputs = msg.FundingInputs
+	c.TheirSettlementSignatures = msg.SettlementSignatures
+
+	fmt.Printf("DlcAcceptHandler - Our inputs [%d] - Their inputs [%d]\n", len(c.OurFundingInputs), len(c.TheirFundingInputs))
 
 	c.Status = lnutil.ContractStatusAccepted
 	err = nd.DlcManager.SaveContract(c)
 	if err != nil {
 		fmt.Printf("DlcAcceptHandler SaveContract err %s\n", err.Error())
-		return
+		return err
 	}
+
+	// create our settlement signatures and ack
+	sigs, err := nd.SignSettlementDivisions(c)
+	if err != nil {
+		return err
+	}
+
+	outMsg := lnutil.NewDlcContractAckMsg(c, sigs)
+	c.Status = lnutil.ContractStatusAcknowledged
+
+	err = nd.DlcManager.SaveContract(c)
+	if err != nil {
+		return err
+	}
+
+	nd.OmniOut <- outMsg
+
+	return nil
 
 }
 
-func (nd *LitNode) SignSettlementDivisions(txId chainhash.Hash, c *lnutil.DlcContract) ([]lnutil.DlcContractSettlementSignature, error) {
-	return []lnutil.DlcContractSettlementSignature{}, nil
+func (nd *LitNode) DlcContractAckHandler(msg lnutil.DlcContractAckMsg, peer *RemotePeer) {
+	c, err := nd.DlcManager.FindContractByKey(msg.ContractPubKey)
+	if err != nil {
+		fmt.Printf("DlcContractAckHandler FindContract err %s\n", err.Error())
+		return
+	}
+
+	// TODO: Check signatures
+
+	c.Status = lnutil.ContractStatusAcknowledged
+
+	err = nd.DlcManager.SaveContract(c)
+	if err != nil {
+		fmt.Printf("DlcContractAckHandler SaveContract err %s\n", err.Error())
+		return
+	}
+
+	// We have everything now, send our signatures to the funding TX
+	wal, ok := nd.SubWallet[c.CoinType]
+	if !ok {
+		fmt.Printf("DlcContractAckHandler No wallet for cointype %d\n", c.CoinType)
+		return
+	}
+
+	tx, err := nd.BuildDlcFundingTransaction(c)
+	if err != nil {
+		fmt.Printf("DlcContractAckHandler BuildDlcFundingTransaction err %s\n", err.Error())
+		return
+	}
+
+	err = wal.SignMyInputs(&tx)
+	if err != nil {
+		fmt.Printf("DlcContractAckHandler SignMyInputs err %s\n", err.Error())
+		return
+	}
+
+	fmt.Printf("My funding TX:\n")
+	lnutil.PrintTx(&tx)
+
+	outMsg := lnutil.NewDlcContractFundingSigsMsg(c, &tx)
+
+	nd.OmniOut <- outMsg
+}
+
+func (nd *LitNode) DlcFundingSigsHandler(msg lnutil.DlcContractFundingSigsMsg, peer *RemotePeer) {
+	c, err := nd.DlcManager.FindContractByKey(msg.ContractPubKey)
+	if err != nil {
+		fmt.Printf("DlcFundingSigsHandler FindContract err %s\n", err.Error())
+		return
+	}
+
+	// TODO: Check signatures
+
+	// We have everything now. Sign our inputs to the funding TX and send it to the blockchain.
+	wal, ok := nd.SubWallet[c.CoinType]
+	if !ok {
+		fmt.Printf("DlcFundingSigsHandler No wallet for cointype %d\n", c.CoinType)
+		return
+	}
+
+	fmt.Printf("Received funding TX:\n")
+	lnutil.PrintTx(msg.SignedFundingTx)
+
+	wal.SignMyInputs(msg.SignedFundingTx)
+
+	fmt.Printf("Signed funding TX:\n")
+	lnutil.PrintTx(msg.SignedFundingTx)
+
+	wal.DirectSendTx(msg.SignedFundingTx)
+
+	c.Status = lnutil.ContractStatusActive
+	err = nd.DlcManager.SaveContract(c)
+	if err != nil {
+		fmt.Printf("DlcFundingSigsHandler SaveContract err %s\n", err.Error())
+		return
+	}
+
+	outMsg := lnutil.NewDlcContractSigProofMsg(c, msg.SignedFundingTx)
+
+	nd.OmniOut <- outMsg
+}
+
+func (nd *LitNode) DlcSigProofHandler(msg lnutil.DlcContractSigProofMsg, peer *RemotePeer) {
+	c, err := nd.DlcManager.FindContractByKey(msg.ContractPubKey)
+	if err != nil {
+		fmt.Printf("DlcSigProofHandler FindContract err %s\n", err.Error())
+		return
+	}
+
+	// TODO: Check signatures
+
+	c.Status = lnutil.ContractStatusActive
+	err = nd.DlcManager.SaveContract(c)
+	if err != nil {
+		fmt.Printf("DlcSigProofHandler SaveContract err %s\n", err.Error())
+		return
+	}
+}
+
+func (nd *LitNode) SignSettlementDivisions(c *lnutil.DlcContract) ([]lnutil.DlcContractSettlementSignature, error) {
+	wal, ok := nd.SubWallet[c.CoinType]
+	if !ok {
+		return nil, fmt.Errorf("Wallet of type %d not found", c.CoinType)
+	}
+
+	var kg portxo.KeyGen
+	kg.Depth = 5
+	kg.Step[0] = 44 | 1<<31
+	kg.Step[1] = c.CoinType | 1<<31
+	kg.Step[2] = UseContractFundMultisig
+	kg.Step[3] = c.PeerIdx | 1<<31
+	kg.Step[4] = uint32(c.Idx) | 1<<31
+
+	priv := wal.GetPriv(kg)
+	if priv == nil {
+		return nil, fmt.Errorf("Could not get private key for contract %d", c.Idx)
+	}
+
+	totalContractValue := c.OurFundingAmount + c.TheirFundingAmount
+	var ourPayoutPKH [20]byte
+	copy(ourPayoutPKH[:], btcutil.Hash160(c.OurPayoutPub[:]))
+
+	fundingTx, err := nd.BuildDlcFundingTransaction(c)
+	if err != nil {
+		return nil, err
+	}
+
+	contractInput := wire.OutPoint{fundingTx.TxHash(), 0}
+
+	returnValue := make([]lnutil.DlcContractSettlementSignature, len(c.Division))
+	for i, d := range c.Division {
+		tx := wire.NewMsgTx()
+		// set version 2, for op_csv
+		tx.Version = 2
+
+		tx.AddTxIn(wire.NewTxIn(&contractInput, nil, nil))
+		totalFee := int64(1000) // TODO: Calculate
+		feeEach := int64(float64(totalFee) / float64(2))
+		feeOurs := feeEach
+		feeTheirs := feeEach
+		valueOurs := d.ValueOurs
+		// We don't have enough to pay for a fee. We get 0, our contract partner pays the rest of the fee
+		if valueOurs < feeEach {
+			feeOurs = valueOurs
+			valueOurs = 0
+		} else {
+			valueOurs = d.ValueOurs - feeOurs
+		}
+
+		valueTheirs := totalContractValue - d.ValueOurs
+
+		if valueTheirs < feeEach {
+			feeTheirs = valueTheirs
+			valueTheirs = 0
+			feeOurs = totalFee - feeTheirs
+			valueOurs = d.ValueOurs - feeOurs
+		} else {
+			valueTheirs -= feeTheirs
+		}
+
+		if valueTheirs > 0 {
+			tx.AddTxOut(lnutil.DlcOutput(c.TheirPayoutPub, c.TheirPayoutPub, c.OurPayoutPub, valueTheirs-(totalFee-feeOurs)))
+		}
+
+		if valueOurs > 0 {
+			tx.AddTxOut(wire.NewTxOut(valueOurs, lnutil.DirectWPKHScriptFromPKH(ourPayoutPKH)))
+		}
+
+		sig, err := nd.SignSettlementTx(tx, &fundingTx, priv)
+		if err != nil {
+			return nil, err
+		}
+		returnValue[i].Outcome = d.OracleValue
+		returnValue[i].Signature = sig
+	}
+
+	return returnValue, nil
+}
+
+func (nd *LitNode) SignSettlementTx(txSettle, txFund *wire.MsgTx, priv *btcec.PrivateKey) ([]byte, error) {
+
+	hCache := txscript.NewTxSigHashes(txSettle)
+	sig, err := txscript.RawTxInWitnessSignature(txSettle, hCache, 0,
+		txFund.TxOut[0].Value, txFund.TxOut[0].PkScript, txscript.SigHashAll, priv)
+	if err != nil {
+		return []byte{}, err
+	}
+	return sig, nil
+
 }
 
 func (nd *LitNode) BuildDlcFundingTransaction(c *lnutil.DlcContract) (wire.MsgTx, error) {
@@ -222,17 +453,21 @@ func (nd *LitNode) BuildDlcFundingTransaction(c *lnutil.DlcContract) (wire.MsgTx
 	var ourInputTotal int64
 	var theirInputTotal int64
 
+	fmt.Printf("Building funding TX. Our input len: [%d]. Their input len: [%d]\n", len(c.OurFundingInputs), len(c.TheirFundingInputs))
+
 	for _, u := range c.OurFundingInputs {
+		fmt.Printf("Adding our outpoint %s\n", u.Outpoint.String())
 		tx.AddTxIn(wire.NewTxIn(&u.Outpoint, nil, nil))
 		ourInputTotal += u.Value
 	}
 	for _, u := range c.TheirFundingInputs {
+		fmt.Printf("Adding their outpoint %s\n", u.Outpoint.String())
 		tx.AddTxIn(wire.NewTxIn(&u.Outpoint, nil, nil))
 		theirInputTotal += u.Value
 	}
 
 	// get txo for channel
-	txo, err := lnutil.FundTxOut(c.TheirPayoutPub, c.OurPayoutPub, c.OurFundingAmount+c.TheirFundingAmount)
+	txo, err := lnutil.FundTxOut(c.TheirFundMultisigPub, c.OurFundMultisigPub, c.OurFundingAmount+c.TheirFundingAmount)
 	if err != nil {
 		return *tx, err
 	}

--- a/qln/dlc.go
+++ b/qln/dlc.go
@@ -521,6 +521,13 @@ func (nd *LitNode) SettleContract(cIdx uint64, oracleValue int64, oracleSig [32]
 		return [32]byte{}, [32]byte{}, err
 	}
 
+	c.Status = lnutil.ContractStatusSettling
+	err = nd.DlcManager.SaveContract(c)
+	if err != nil {
+		fmt.Printf("SettleContract SaveContract err %s\n", err.Error())
+		return [32]byte{}, [32]byte{}, err
+	}
+
 	d, err := c.GetDivision(oracleValue)
 	if err != nil {
 		fmt.Printf("SettleContract GetDivision err %s\n", err.Error())
@@ -618,6 +625,12 @@ func (nd *LitNode) SettleContract(cIdx uint64, oracleValue int64, oracleSig [32]
 	err = wal.DirectSendTx(txClaim)
 	if err != nil {
 		log.Printf("SettleContract DirectSendTx (claim) err %s", err.Error())
+		return [32]byte{}, [32]byte{}, err
+	}
+
+	c.Status = lnutil.ContractStatusClosed
+	err = nd.DlcManager.SaveContract(c)
+	if err != nil {
 		return [32]byte{}, [32]byte{}, err
 	}
 	return settleTx.TxHash(), txClaim.TxHash(), nil

--- a/qln/dlc.go
+++ b/qln/dlc.go
@@ -1,47 +1,113 @@
 package qln
 
-func (nd *LitNode) OfferDlc(
-	peerIdx, cointype uint32, outAmount, theirAmount, valueAllOurs, valueAllTheirs uint64, oraclePub, oracleOts [33]byte) (uint32, error) {
-	/*
-		_, ok := nd.SubWallet[cointype]
-		if !ok {
-			return 0, fmt.Errorf("No wallet of type %d connected", cointype)
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/mit-dci/lit/lnutil"
+)
+
+func (nd *LitNode) OfferDlc(peerIdx uint32, cIdx uint64) error {
+	c, err := nd.DlcManager.LoadContract(cIdx)
+	if err != nil {
+		return err
+	}
+
+	msg := lnutil.NewDlcOfferMsg(peerIdx, c)
+	for _, peer := range nd.RemoteCons {
+		if peer.Idx == peerIdx {
+			copy(c.RemoteNodePub[:], peer.Con.RemotePub.SerializeCompressed())
 		}
+	}
+	c.Status = lnutil.ContractStatusOfferedByMe
 
-		nd.InProg.mtx.Lock()
-		//	defer nd.InProg.mtx.Lock()
-		if nd.InProg.PeerIdx != 0 {
-			nd.InProg.mtx.Unlock()
-			return 0, fmt.Errorf("fund with peer %d not done yet", nd.InProg.PeerIdx)
+	err = nd.DlcManager.SaveContract(c)
+	if err != nil {
+		return err
+	}
+
+	nd.OmniOut <- msg
+
+	return nil
+}
+
+func (nd *LitNode) DeclineDlc(cIdx uint64) error {
+	c, err := nd.DlcManager.LoadContract(cIdx)
+	if err != nil {
+		return err
+	}
+
+	peerIdx := uint32(0)
+	for _, peer := range nd.RemoteCons {
+		if bytes.Equal(c.RemoteNodePub[:], peer.Con.RemotePub.SerializeCompressed()) {
+			peerIdx = peer.Idx
+			break
 		}
+	}
+	msg := lnutil.NewDlcOfferDeclMsg(peerIdx, 0x01)
+	c.Status = lnutil.ContractStatusDeclined
 
-		// TODO - would be convenient if it auto connected to the peer huh
-		if !nd.ConnectedToPeer(peerIdx) {
-			nd.InProg.mtx.Unlock()
-			return 0, fmt.Errorf("Not connected to peer %d. Do that yourself.", peerIdx)
+	err = nd.DlcManager.SaveContract(c)
+	if err != nil {
+		return err
+	}
+
+	nd.OmniOut <- msg
+
+	return nil
+}
+
+func (nd *LitNode) DlcOfferHandler(msg lnutil.DlcOfferMsg, peer *RemotePeer) {
+	fmt.Println("DlcOfferHandler")
+
+	c := new(lnutil.DlcContract)
+
+	copy(c.RemoteNodePub[:], peer.Con.RemotePub.SerializeCompressed())
+	c.Status = lnutil.ContractStatusOfferedToMe
+
+	// Reverse copy from the contract we received
+	c.OurFundingAmount = msg.Contract.TheirFundingAmount
+	c.TheirFundingAmount = msg.Contract.OurFundingAmount
+	c.OurFundingInputs = msg.Contract.TheirFundingInputs
+	c.TheirFundingInputs = msg.Contract.OurFundingInputs
+	c.OurPayoutPKH = msg.Contract.TheirPayoutPKH
+	c.TheirPayoutPKH = msg.Contract.OurPayoutPKH
+	c.ValueAllOurs = msg.Contract.ValueAllTheirs
+	c.ValueAllTheirs = msg.Contract.ValueAllOurs
+
+	// Copy
+	c.CoinType = msg.Contract.CoinType
+	c.OracleA = msg.Contract.OracleA
+	c.OracleB = msg.Contract.OracleB
+	c.OracleQ = msg.Contract.OracleQ
+	c.OracleDataFeed = msg.Contract.OracleDataFeed
+	c.OracleTimestamp = msg.Contract.OracleTimestamp
+
+	err := nd.DlcManager.SaveContract(c)
+	if err != nil {
+		fmt.Printf("DlcOfferHandler SaveContract err %s\n", err.Error())
+		return
+	}
+}
+
+func (nd *LitNode) DlcDeclineHandler(msg lnutil.DlcOfferDeclMsg, peer *RemotePeer) {
+	fmt.Println("DlcDeclineHandler")
+
+	contracts, err := nd.DlcManager.ListContracts()
+	if err != nil {
+		fmt.Printf("DlcDeclineHandler ListContracts err %s\n", err.Error())
+		return
+	}
+
+	for _, c := range contracts {
+		if bytes.Equal(c.RemoteNodePub[:], peer.Con.RemotePub.SerializeCompressed()) {
+			c.Status = lnutil.ContractStatusDeclined
+			err = nd.DlcManager.SaveContract(c)
+			if err != nil {
+				fmt.Printf("DlcDeclineHandler SaveContract err %s\n", err.Error())
+				return
+			}
 		}
+	}
 
-		cIdx, err := nd.NextChannelIdx()
-		if err != nil {
-			nd.InProg.mtx.Unlock()
-			return 0, err
-		}
-
-		nd.InProg.ChanIdx = cIdx
-		nd.InProg.PeerIdx = peerIdx
-		nd.InProg.Amt = ccap
-		nd.InProg.InitSend = initSend
-		nd.InProg.Data = data
-
-		nd.InProg.Coin = cointype
-		nd.InProg.mtx.Unlock() // switch to defer
-
-		outMsg := lnutil.NewDlcOfferMsg(peerIdx, cointype, ourAmount, theirAmount, valueAllOurs, valueAlltheirs,)
-
-		nd.OmniOut <- outMsg
-
-		// wait until it's done!
-		idx := <-nd.InProg.done
-		return idx, nil*/
-	return 0, nil
 }

--- a/qln/dlc.go
+++ b/qln/dlc.go
@@ -1,0 +1,47 @@
+package qln
+
+func (nd *LitNode) OfferDlc(
+	peerIdx, cointype uint32, outAmount, theirAmount, valueAllOurs, valueAllTheirs uint64, oraclePub, oracleOts [33]byte) (uint32, error) {
+	/*
+		_, ok := nd.SubWallet[cointype]
+		if !ok {
+			return 0, fmt.Errorf("No wallet of type %d connected", cointype)
+		}
+
+		nd.InProg.mtx.Lock()
+		//	defer nd.InProg.mtx.Lock()
+		if nd.InProg.PeerIdx != 0 {
+			nd.InProg.mtx.Unlock()
+			return 0, fmt.Errorf("fund with peer %d not done yet", nd.InProg.PeerIdx)
+		}
+
+		// TODO - would be convenient if it auto connected to the peer huh
+		if !nd.ConnectedToPeer(peerIdx) {
+			nd.InProg.mtx.Unlock()
+			return 0, fmt.Errorf("Not connected to peer %d. Do that yourself.", peerIdx)
+		}
+
+		cIdx, err := nd.NextChannelIdx()
+		if err != nil {
+			nd.InProg.mtx.Unlock()
+			return 0, err
+		}
+
+		nd.InProg.ChanIdx = cIdx
+		nd.InProg.PeerIdx = peerIdx
+		nd.InProg.Amt = ccap
+		nd.InProg.InitSend = initSend
+		nd.InProg.Data = data
+
+		nd.InProg.Coin = cointype
+		nd.InProg.mtx.Unlock() // switch to defer
+
+		outMsg := lnutil.NewDlcOfferMsg(peerIdx, cointype, ourAmount, theirAmount, valueAllOurs, valueAlltheirs,)
+
+		nd.OmniOut <- outMsg
+
+		// wait until it's done!
+		idx := <-nd.InProg.done
+		return idx, nil*/
+	return 0, nil
+}

--- a/qln/dlc.go
+++ b/qln/dlc.go
@@ -2,15 +2,14 @@ package qln
 
 import (
 	"fmt"
+	"log"
 
-	"github.com/adiabat/btcutil"
-
-	"github.com/adiabat/btcd/btcec"
 	"github.com/adiabat/btcd/txscript"
 	"github.com/adiabat/btcd/wire"
 	"github.com/adiabat/btcutil/txsort"
 	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/portxo"
+	"github.com/mit-dci/lit/sig64"
 )
 
 func (nd *LitNode) AddContract() (*lnutil.DlcContract, error) {
@@ -168,8 +167,6 @@ func (nd *LitNode) DlcOfferHandler(msg lnutil.DlcOfferMsg, peer *RemotePeer) {
 	c.OracleTimestamp = msg.Contract.OracleTimestamp
 	c.PubKey = msg.Contract.PubKey
 
-	fmt.Printf("Received contract offer. Funding input length: [%d]\n", len(c.TheirFundingInputs))
-
 	err := nd.DlcManager.SaveContract(c)
 	if err != nil {
 		fmt.Printf("DlcOfferHandler SaveContract err %s\n", err.Error())
@@ -181,7 +178,6 @@ func (nd *LitNode) DlcOfferHandler(msg lnutil.DlcOfferMsg, peer *RemotePeer) {
 		fmt.Printf("DlcOfferHandler FindContract err %s\n", err.Error())
 		return
 	}
-	fmt.Printf("DlcOfferHandler after reloading - Their inputs [%d]\n", len(c.TheirFundingInputs))
 
 }
 
@@ -209,12 +205,10 @@ func (nd *LitNode) DlcAcceptHandler(msg lnutil.DlcOfferAcceptMsg, peer *RemotePe
 
 	// TODO: Check signatures
 
-	c.TheirChangePKH = msg.MyChangePKH
+	c.TheirChangePKH = msg.OurChangePKH
 	c.TheirFundingInputs = msg.FundingInputs
 	c.TheirSettlementSignatures = msg.SettlementSignatures
-
-	fmt.Printf("DlcAcceptHandler - Our inputs [%d] - Their inputs [%d]\n", len(c.OurFundingInputs), len(c.TheirFundingInputs))
-
+	c.TheirFundMultisigPub = msg.OurFundMultisigPub
 	c.Status = lnutil.ContractStatusAccepted
 	err = nd.DlcManager.SaveContract(c)
 	if err != nil {
@@ -278,9 +272,6 @@ func (nd *LitNode) DlcContractAckHandler(msg lnutil.DlcContractAckMsg, peer *Rem
 		return
 	}
 
-	fmt.Printf("My funding TX:\n")
-	lnutil.PrintTx(&tx)
-
 	outMsg := lnutil.NewDlcContractFundingSigsMsg(c, &tx)
 
 	nd.OmniOut <- outMsg
@@ -304,11 +295,18 @@ func (nd *LitNode) DlcFundingSigsHandler(msg lnutil.DlcContractFundingSigsMsg, p
 
 	fmt.Printf("Received funding TX:\n")
 	lnutil.PrintTx(msg.SignedFundingTx)
+	fmt.Printf("Received hash: %s\n", msg.SignedFundingTx.TxHash().String())
+
+	ftx, err := nd.BuildDlcFundingTransaction(c)
+	if err != nil {
+		fmt.Printf("DlcFundingSigsHandler BuildDlcFundingTransaction err %s\n", err.Error())
+		return
+	}
+	fmt.Printf("Self-generated funding TX:\n")
+	lnutil.PrintTx(&ftx)
+	fmt.Printf("Self-generated hash: %s\n", ftx.TxHash().String())
 
 	wal.SignMyInputs(msg.SignedFundingTx)
-
-	fmt.Printf("Signed funding TX:\n")
-	lnutil.PrintTx(msg.SignedFundingTx)
 
 	wal.DirectSendTx(msg.SignedFundingTx)
 
@@ -360,10 +358,6 @@ func (nd *LitNode) SignSettlementDivisions(c *lnutil.DlcContract) ([]lnutil.DlcC
 		return nil, fmt.Errorf("Could not get private key for contract %d", c.Idx)
 	}
 
-	totalContractValue := c.OurFundingAmount + c.TheirFundingAmount
-	var ourPayoutPKH [20]byte
-	copy(ourPayoutPKH[:], btcutil.Hash160(c.OurPayoutPub[:]))
-
 	fundingTx, err := nd.BuildDlcFundingTransaction(c)
 	if err != nil {
 		return nil, err
@@ -373,44 +367,8 @@ func (nd *LitNode) SignSettlementDivisions(c *lnutil.DlcContract) ([]lnutil.DlcC
 
 	returnValue := make([]lnutil.DlcContractSettlementSignature, len(c.Division))
 	for i, d := range c.Division {
-		tx := wire.NewMsgTx()
-		// set version 2, for op_csv
-		tx.Version = 2
-
-		tx.AddTxIn(wire.NewTxIn(&contractInput, nil, nil))
-		totalFee := int64(1000) // TODO: Calculate
-		feeEach := int64(float64(totalFee) / float64(2))
-		feeOurs := feeEach
-		feeTheirs := feeEach
-		valueOurs := d.ValueOurs
-		// We don't have enough to pay for a fee. We get 0, our contract partner pays the rest of the fee
-		if valueOurs < feeEach {
-			feeOurs = valueOurs
-			valueOurs = 0
-		} else {
-			valueOurs = d.ValueOurs - feeOurs
-		}
-
-		valueTheirs := totalContractValue - d.ValueOurs
-
-		if valueTheirs < feeEach {
-			feeTheirs = valueTheirs
-			valueTheirs = 0
-			feeOurs = totalFee - feeTheirs
-			valueOurs = d.ValueOurs - feeOurs
-		} else {
-			valueTheirs -= feeTheirs
-		}
-
-		if valueTheirs > 0 {
-			tx.AddTxOut(lnutil.DlcOutput(c.TheirPayoutPub, c.TheirPayoutPub, c.OurPayoutPub, valueTheirs-(totalFee-feeOurs)))
-		}
-
-		if valueOurs > 0 {
-			tx.AddTxOut(wire.NewTxOut(valueOurs, lnutil.DirectWPKHScriptFromPKH(ourPayoutPKH)))
-		}
-
-		sig, err := nd.SignSettlementTx(tx, &fundingTx, priv)
+		tx, err := lnutil.SettlementTx(c, d, contractInput, true)
+		sig, err := nd.SignSettlementTx(c, tx, priv)
 		if err != nil {
 			return nil, err
 		}
@@ -419,18 +377,6 @@ func (nd *LitNode) SignSettlementDivisions(c *lnutil.DlcContract) ([]lnutil.DlcC
 	}
 
 	return returnValue, nil
-}
-
-func (nd *LitNode) SignSettlementTx(txSettle, txFund *wire.MsgTx, priv *btcec.PrivateKey) ([]byte, error) {
-
-	hCache := txscript.NewTxSigHashes(txSettle)
-	sig, err := txscript.RawTxInWitnessSignature(txSettle, hCache, 0,
-		txFund.TxOut[0].Value, txFund.TxOut[0].PkScript, txscript.SigHashAll, priv)
-	if err != nil {
-		return []byte{}, err
-	}
-	return sig, nil
-
 }
 
 func (nd *LitNode) BuildDlcFundingTransaction(c *lnutil.DlcContract) (wire.MsgTx, error) {
@@ -453,30 +399,35 @@ func (nd *LitNode) BuildDlcFundingTransaction(c *lnutil.DlcContract) (wire.MsgTx
 	var ourInputTotal int64
 	var theirInputTotal int64
 
-	fmt.Printf("Building funding TX. Our input len: [%d]. Their input len: [%d]\n", len(c.OurFundingInputs), len(c.TheirFundingInputs))
-
 	for _, u := range c.OurFundingInputs {
-		fmt.Printf("Adding our outpoint %s\n", u.Outpoint.String())
 		tx.AddTxIn(wire.NewTxIn(&u.Outpoint, nil, nil))
 		ourInputTotal += u.Value
 	}
 	for _, u := range c.TheirFundingInputs {
-		fmt.Printf("Adding their outpoint %s\n", u.Outpoint.String())
 		tx.AddTxIn(wire.NewTxIn(&u.Outpoint, nil, nil))
 		theirInputTotal += u.Value
 	}
+
+	// add change and sort
+	tx.AddTxOut(wire.NewTxOut(theirInputTotal-c.TheirFundingAmount-500, lnutil.DirectWPKHScriptFromPKH(c.TheirChangePKH)))
+	tx.AddTxOut(wire.NewTxOut(ourInputTotal-c.OurFundingAmount-500, lnutil.DirectWPKHScriptFromPKH(c.OurChangePKH)))
+
+	txsort.InPlaceSort(tx)
 
 	// get txo for channel
 	txo, err := lnutil.FundTxOut(c.TheirFundMultisigPub, c.OurFundMultisigPub, c.OurFundingAmount+c.TheirFundingAmount)
 	if err != nil {
 		return *tx, err
 	}
-	tx.AddTxOut(txo)
-	tx.AddTxOut(wire.NewTxOut(theirInputTotal-c.TheirFundingAmount-500, lnutil.DirectWPKHScriptFromPKH(c.TheirChangePKH)))
-	tx.AddTxOut(wire.NewTxOut(ourInputTotal-c.OurFundingAmount-500, lnutil.DirectWPKHScriptFromPKH(c.OurChangePKH)))
 
-	txsort.InPlaceSort(tx)
+	// Ensure contract funding output is always at position 0
+	txos := make([]*wire.TxOut, len(tx.TxOut)+1)
+	txos[0] = txo
+	copy(txos[1:], tx.TxOut)
+	tx.TxOut = txos
 
+	fmt.Printf("Returning funding TX: %s\n", tx.TxHash().String())
+	lnutil.PrintTx(tx)
 	return *tx, nil
 
 }
@@ -501,6 +452,103 @@ func (nd *LitNode) FundContract(c *lnutil.DlcContract) error {
 	if err != nil {
 		return err
 	}
+
+	return nil
+}
+
+func (nd *LitNode) SettleContract(cIdx uint64, oracleValue int64, oracleSig [32]byte) error {
+	fmt.Printf("Settling contract %d on value %d (sig: %x)\n", cIdx, oracleValue, oracleSig)
+
+	c, err := nd.DlcManager.LoadContract(cIdx)
+	if err != nil {
+		fmt.Printf("SettleContract FindContract err %s\n", err.Error())
+		return err
+	}
+
+	d, err := c.GetDivision(oracleValue)
+	if err != nil {
+		fmt.Printf("SettleContract GetDivision err %s\n", err.Error())
+		return err
+	}
+
+	fundingTx, err := nd.BuildDlcFundingTransaction(c)
+	if err != nil {
+		fmt.Printf("SettleContract BuildDlcFundingTransaction err %s\n", err.Error())
+		return err
+	}
+
+	wal, ok := nd.SubWallet[c.CoinType]
+	if !ok {
+		return fmt.Errorf("SettleContract Wallet of type %d not found", c.CoinType)
+	}
+
+	var kg portxo.KeyGen
+	kg.Depth = 5
+	kg.Step[0] = 44 | 1<<31
+	kg.Step[1] = c.CoinType | 1<<31
+	kg.Step[2] = UseContractFundMultisig
+	kg.Step[3] = c.PeerIdx | 1<<31
+	kg.Step[4] = uint32(c.Idx) | 1<<31
+
+	priv := wal.GetPriv(kg)
+	if priv == nil {
+		return fmt.Errorf("SettleContract Could not get private key for contract %d", c.Idx)
+	}
+
+	fmt.Printf("Funding TX hash: %s\n", fundingTx.TxHash().String())
+
+	contractInput := wire.OutPoint{fundingTx.TxHash(), 0}
+
+	settleTx, err := lnutil.SettlementTx(c, *d, contractInput, false)
+	if err != nil {
+		fmt.Printf("SettleContract SettlementTx err %s\n", err.Error())
+		return err
+	}
+
+	mySig, err := nd.SignSettlementTx(c, settleTx, priv)
+	if err != nil {
+		log.Printf("SettleContract SignSettlementTx err %s", err.Error())
+		return err
+	}
+
+	myBigSig := sig64.SigDecompress(mySig)
+
+	theirSig, err := c.GetTheirSettlementSignature(oracleValue)
+	theirBigSig := sig64.SigDecompress(theirSig)
+
+	// put the sighash all byte on the end of both signatures
+	myBigSig = append(myBigSig, byte(txscript.SigHashAll))
+	theirBigSig = append(theirBigSig, byte(txscript.SigHashAll))
+
+	pre, swap, err := lnutil.FundTxScript(c.OurFundMultisigPub, c.TheirFundMultisigPub)
+	if err != nil {
+		log.Printf("SettleContract FundTxScript err %s", err.Error())
+		return err
+	}
+
+	fmt.Printf("FundTXScript: %x\n", pre)
+	fmt.Printf("mySig: %x\n", myBigSig)
+	fmt.Printf("theirSig: %x\n", theirBigSig)
+
+	// swap if needed
+	if swap {
+		settleTx.TxIn[0].Witness = SpendMultiSigWitStack(pre, theirBigSig, myBigSig)
+	} else {
+		settleTx.TxIn[0].Witness = SpendMultiSigWitStack(pre, myBigSig, theirBigSig)
+	}
+
+	fmt.Printf("Settlement TX has witness: %t\n", settleTx.HasWitness())
+	fmt.Printf("Settlement TX that i am about to publish:\n")
+	lnutil.PrintTx(settleTx)
+
+	// Settlement TX should be valid here, so publish it.
+	err = wal.DirectSendTx(settleTx)
+	if err != nil {
+		log.Printf("SettleContract DirectSendTx err %s", err.Error())
+		return err
+	}
+
+	// TODO: Claim the contract settlement output back to our wallet - otherwise the peer can claim it after locktime.
 
 	return nil
 }

--- a/qln/dlc.go
+++ b/qln/dlc.go
@@ -368,7 +368,7 @@ func (nd *LitNode) SignSettlementDivisions(c *lnutil.DlcContract) ([]lnutil.DlcC
 
 	returnValue := make([]lnutil.DlcContractSettlementSignature, len(c.Division))
 	for i, d := range c.Division {
-		tx, err := lnutil.SettlementTx(c, d, contractInput, true, (d.OracleValue == 12080))
+		tx, err := lnutil.SettlementTx(c, d, contractInput, true)
 
 		sig, err := nd.SignSettlementTx(c, tx, priv)
 		if err != nil {
@@ -497,27 +497,19 @@ func (nd *LitNode) SettleContract(cIdx uint64, oracleValue int64, oracleSig [32]
 		return fmt.Errorf("SettleContract Could not get private key for contract %d", c.Idx)
 	}
 
-	fmt.Printf("Funding TX hash: %s\n", fundingTx.TxHash().String())
-
 	contractInput := wire.OutPoint{fundingTx.TxHash(), 0}
 
-	settleTx, err := lnutil.SettlementTx(c, *d, contractInput, false, true)
+	settleTx, err := lnutil.SettlementTx(c, *d, contractInput, false)
 	if err != nil {
 		fmt.Printf("SettleContract SettlementTx err %s\n", err.Error())
 		return err
 	}
-
-	fmt.Printf("SettleTX Before signing: %s\n", settleTx.TxHash().String())
-	lnutil.PrintTx(settleTx)
 
 	mySig, err := nd.SignSettlementTx(c, settleTx, priv)
 	if err != nil {
 		log.Printf("SettleContract SignSettlementTx err %s", err.Error())
 		return err
 	}
-
-	fmt.Printf("SettleTX After getting my signature: %s\n", settleTx.TxHash().String())
-	lnutil.PrintTx(settleTx)
 
 	myBigSig := sig64.SigDecompress(mySig)
 

--- a/qln/dlc.go
+++ b/qln/dlc.go
@@ -1,9 +1,15 @@
 package qln
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
 
+	"github.com/adiabat/btcd/chaincfg/chainhash"
+	"github.com/adiabat/btcd/wire"
+	"github.com/adiabat/btcutil/txsort"
 	"github.com/mit-dci/lit/lnutil"
+	"github.com/mit-dci/lit/portxo"
 )
 
 func (nd *LitNode) AddContract() (*lnutil.DlcContract, error) {
@@ -25,6 +31,25 @@ func (nd *LitNode) OfferDlc(peerIdx uint32, cIdx uint64) error {
 	msg := lnutil.NewDlcOfferMsg(peerIdx, c)
 	c.Status = lnutil.ContractStatusOfferedByMe
 	c.PeerIdx = peerIdx
+
+	var kg portxo.KeyGen
+	kg.Depth = 5
+	kg.Step[0] = 44 | 1<<31
+	kg.Step[1] = c.CoinType | 1<<31
+	kg.Step[2] = UseContractPayout
+	kg.Step[3] = c.PeerIdx | 1<<31
+	kg.Step[4] = uint32(c.Idx) | 1<<31
+
+	c.OurPayoutPub, err = nd.GetUsePub(kg, UseContractPayout)
+	if err != nil {
+		return err
+	}
+
+	// Fund the contract
+	err = nd.FundContract(c)
+	if err != nil {
+		return err
+	}
 
 	err = nd.DlcManager.SaveContract(c)
 	if err != nil {
@@ -61,7 +86,44 @@ func (nd *LitNode) AcceptDlc(cIdx uint64) error {
 		return err
 	}
 
-	msg := lnutil.NewDlcOfferAcceptMsg(c.PeerIdx, c.PubKey)
+	// Fund the contract
+	err = nd.FundContract(c)
+	if err != nil {
+		return err
+	}
+
+	var kg portxo.KeyGen
+	kg.Depth = 5
+	kg.Step[0] = 44 | 1<<31
+	kg.Step[1] = c.CoinType | 1<<31
+	kg.Step[2] = UseContractPayout
+	kg.Step[3] = c.PeerIdx | 1<<31
+	kg.Step[4] = uint32(c.Idx) | 1<<31
+
+	c.OurPayoutPub, err = nd.GetUsePub(kg, UseContractPayout)
+	if err != nil {
+		return err
+	}
+
+	// Now we can calculate the funding TX, all inputs are known
+	tx, err := nd.BuildDlcFundingTransaction(c)
+	if err != nil {
+		return err
+	}
+
+	var buf bytes.Buffer
+	w := bufio.NewWriter(&buf)
+	tx.Serialize(w)
+	w.Flush()
+	fmt.Printf("Funding TX created:\n%x", buf.Bytes())
+
+	// Now we can sign the division
+	sigs, err := nd.SignSettlementDivisions(tx.TxHash(), c)
+	if err != nil {
+		return err
+	}
+
+	msg := lnutil.NewDlcOfferAcceptMsg(c, sigs)
 	c.Status = lnutil.ContractStatusAccepted
 
 	err = nd.DlcManager.SaveContract(c)
@@ -84,10 +146,12 @@ func (nd *LitNode) DlcOfferHandler(msg lnutil.DlcOfferMsg, peer *RemotePeer) {
 	c.TheirFundingAmount = msg.Contract.OurFundingAmount
 	c.OurFundingInputs = msg.Contract.TheirFundingInputs
 	c.TheirFundingInputs = msg.Contract.OurFundingInputs
-	c.OurPayoutPKH = msg.Contract.TheirPayoutPKH
-	c.TheirPayoutPKH = msg.Contract.OurPayoutPKH
+	c.OurPayoutPub = msg.Contract.TheirPayoutPub
+	c.TheirPayoutPub = msg.Contract.OurPayoutPub
 	c.ValueAllOurs = msg.Contract.ValueAllTheirs
 	c.ValueAllTheirs = msg.Contract.ValueAllOurs
+	c.OurChangePKH = msg.Contract.TheirChangePKH
+	c.TheirChangePKH = msg.Contract.OurChangePKH
 
 	// Copy
 	c.CoinType = msg.Contract.CoinType
@@ -132,4 +196,76 @@ func (nd *LitNode) DlcAcceptHandler(msg lnutil.DlcOfferAcceptMsg, peer *RemotePe
 		return
 	}
 
+}
+
+func (nd *LitNode) SignSettlementDivisions(txId chainhash.Hash, c *lnutil.DlcContract) ([]lnutil.DlcContractSettlementSignature, error) {
+	return []lnutil.DlcContractSettlementSignature{}, nil
+}
+
+func (nd *LitNode) BuildDlcFundingTransaction(c *lnutil.DlcContract) (wire.MsgTx, error) {
+
+	// make the tx
+	tx := wire.NewMsgTx()
+
+	w, ok := nd.SubWallet[c.CoinType]
+	if !ok {
+		err := fmt.Errorf("BuildDlcFundingTransaction err no wallet for type %d", c.CoinType)
+		return *tx, err
+	}
+
+	// set version 2, for op_csv
+	tx.Version = 2
+	// set the time, the way core does.
+	tx.LockTime = uint32(w.CurrentHeight())
+
+	// add all the txins
+	var ourInputTotal int64
+	var theirInputTotal int64
+
+	for _, u := range c.OurFundingInputs {
+		tx.AddTxIn(wire.NewTxIn(&u.Outpoint, nil, nil))
+		ourInputTotal += u.Value
+	}
+	for _, u := range c.TheirFundingInputs {
+		tx.AddTxIn(wire.NewTxIn(&u.Outpoint, nil, nil))
+		theirInputTotal += u.Value
+	}
+
+	// get txo for channel
+	txo, err := lnutil.FundTxOut(c.TheirPayoutPub, c.OurPayoutPub, c.OurFundingAmount+c.TheirFundingAmount)
+	if err != nil {
+		return *tx, err
+	}
+	tx.AddTxOut(txo)
+	tx.AddTxOut(wire.NewTxOut(theirInputTotal-c.TheirFundingAmount-500, lnutil.DirectWPKHScriptFromPKH(c.TheirChangePKH)))
+	tx.AddTxOut(wire.NewTxOut(ourInputTotal-c.OurFundingAmount-500, lnutil.DirectWPKHScriptFromPKH(c.OurChangePKH)))
+
+	txsort.InPlaceSort(tx)
+
+	return *tx, nil
+
+}
+
+func (nd *LitNode) FundContract(c *lnutil.DlcContract) error {
+	wal, ok := nd.SubWallet[c.CoinType]
+	if !ok {
+		return fmt.Errorf("No wallet of type %d connected", c.CoinType)
+	}
+
+	utxos, _, err := wal.PickUtxos(int64(c.OurFundingAmount), 500, wal.Fee(), true)
+	if err != nil {
+		return err
+	}
+
+	c.OurFundingInputs = make([]lnutil.DlcContractFundingInput, len(utxos))
+	for i := 0; i < len(utxos); i++ {
+		c.OurFundingInputs[i] = lnutil.DlcContractFundingInput{utxos[i].Op, utxos[i].Value}
+	}
+
+	c.OurChangePKH, err = wal.NewAdr()
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/qln/init.go
+++ b/qln/init.go
@@ -7,6 +7,7 @@ import (
 	"github.com/adiabat/btcutil/hdkeychain"
 	"github.com/boltdb/bolt"
 	"github.com/mit-dci/lit/coinparam"
+	"github.com/mit-dci/lit/dlc"
 	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/portxo"
 	"github.com/mit-dci/lit/wallit"
@@ -52,6 +53,11 @@ func NewLitNode(privKey *[32]byte, path string, trackerURL string) (*LitNode, er
 	// optional tower activation
 
 	nd.Tower = new(watchtower.WatchTower)
+
+	nd.DlcManager, err = dlc.NewManager(filepath.Join(nd.LitFolder, "dlc.db"))
+	if err != nil {
+		return nil, err
+	}
 
 	// make maps and channels
 	nd.UserMessageBox = make(chan string, 32)

--- a/qln/init.go
+++ b/qln/init.go
@@ -54,6 +54,7 @@ func NewLitNode(privKey *[32]byte, path string, trackerURL string) (*LitNode, er
 
 	nd.Tower = new(watchtower.WatchTower)
 
+	// Create a new manager for the discreet log contracts
 	nd.DlcManager, err = dlc.NewManager(filepath.Join(nd.LitFolder, "dlc.db"))
 	if err != nil {
 		return nil, err

--- a/qln/lndb.go
+++ b/qln/lndb.go
@@ -9,6 +9,7 @@ import (
 	"github.com/adiabat/btcd/wire"
 	"github.com/adiabat/btcutil"
 	"github.com/boltdb/bolt"
+	"github.com/mit-dci/lit/dlc"
 	"github.com/mit-dci/lit/elkrem"
 	"github.com/mit-dci/lit/lndc"
 	"github.com/mit-dci/lit/lnutil"
@@ -90,6 +91,9 @@ type LitNode struct {
 
 	// all nodes have a watchtower.  but could have a tower without a node
 	Tower watchtower.Watcher
+
+	// discreet log contract manager
+	DlcManager *dlc.DlcManager
 
 	// BaseWallet is the underlying wallet which keeps track of utxos, secrets,
 	// and network i/o

--- a/qln/magicnums.go
+++ b/qln/magicnums.go
@@ -10,8 +10,9 @@ const (
 	UseChannelHAKDBase    = 40 | hdkeychain.HardenedKeyStart
 	UseChannelElkrem      = 8888 | hdkeychain.HardenedKeyStart
 
-	UseContractPayout       = 50 | hdkeychain.HardenedKeyStart // key derivation path for contract payout keys (the keys the contract pays TO)
+	UseContractPayoutBase   = 50 | hdkeychain.HardenedKeyStart // key derivation path for contract payout keys (the keys the contract pays TO combined with the oracle's signature)
 	UseContractFundMultisig = 51 | hdkeychain.HardenedKeyStart // key derivation path for contract spending keys (the keys the contract pays FROM, and the funding TX pays TO)
+	UseContractPayoutPKH    = 52 | hdkeychain.HardenedKeyStart // key derivation path for contract payout PKH (the hash the contract pays TO)
 	// links Id and channel. replaces UseChannelFund
 
 	UseIdKey = 111 | hdkeychain.HardenedKeyStart

--- a/qln/magicnums.go
+++ b/qln/magicnums.go
@@ -10,7 +10,8 @@ const (
 	UseChannelHAKDBase    = 40 | hdkeychain.HardenedKeyStart
 	UseChannelElkrem      = 8888 | hdkeychain.HardenedKeyStart
 
-	UseContractPayout = 50 | hdkeychain.HardenedKeyStart
+	UseContractPayout       = 50 | hdkeychain.HardenedKeyStart
+	UseContractFundMultisig = 51 | hdkeychain.HardenedKeyStart
 	// links Id and channel. replaces UseChannelFund
 
 	UseIdKey = 111 | hdkeychain.HardenedKeyStart

--- a/qln/magicnums.go
+++ b/qln/magicnums.go
@@ -10,11 +10,19 @@ const (
 	UseChannelHAKDBase    = 40 | hdkeychain.HardenedKeyStart
 	UseChannelElkrem      = 8888 | hdkeychain.HardenedKeyStart
 
-	UseContractPayoutBase   = 50 | hdkeychain.HardenedKeyStart // key derivation path for contract payout keys (the keys the contract pays TO combined with the oracle's signature)
-	UseContractFundMultisig = 51 | hdkeychain.HardenedKeyStart // key derivation path for contract spending keys (the keys the contract pays FROM, and the funding TX pays TO)
-	UseContractPayoutPKH    = 52 | hdkeychain.HardenedKeyStart // key derivation path for contract payout PKH (the hash the contract pays TO)
-	// links Id and channel. replaces UseChannelFund
+	// key derivation path for contract payout keys (the keys the contract pays
+	// TO combined with the oracle's signature)
+	UseContractPayoutBase = 50 | hdkeychain.HardenedKeyStart
 
+	// key derivation path for contract spending keys (the keys the contract
+	// pays FROM, and the funding TX pays TO)
+	UseContractFundMultisig = 51 | hdkeychain.HardenedKeyStart
+
+	// key derivation path for contract payout PKH (the hash the contract
+	// pays TO)
+	UseContractPayoutPKH = 52 | hdkeychain.HardenedKeyStart
+
+	// links Id and channel. replaces UseChannelFund
 	UseIdKey = 111 | hdkeychain.HardenedKeyStart
 
 	// high 3 bytes are in sequence, low 3 bytes are in time

--- a/qln/magicnums.go
+++ b/qln/magicnums.go
@@ -9,6 +9,8 @@ const (
 	UseChannelWatchRefund = 31 | hdkeychain.HardenedKeyStart
 	UseChannelHAKDBase    = 40 | hdkeychain.HardenedKeyStart
 	UseChannelElkrem      = 8888 | hdkeychain.HardenedKeyStart
+
+	UseContractPayout = 50 | hdkeychain.HardenedKeyStart
 	// links Id and channel. replaces UseChannelFund
 
 	UseIdKey = 111 | hdkeychain.HardenedKeyStart

--- a/qln/magicnums.go
+++ b/qln/magicnums.go
@@ -10,8 +10,8 @@ const (
 	UseChannelHAKDBase    = 40 | hdkeychain.HardenedKeyStart
 	UseChannelElkrem      = 8888 | hdkeychain.HardenedKeyStart
 
-	UseContractPayout       = 50 | hdkeychain.HardenedKeyStart
-	UseContractFundMultisig = 51 | hdkeychain.HardenedKeyStart
+	UseContractPayout       = 50 | hdkeychain.HardenedKeyStart // key derivation path for contract payout keys (the keys the contract pays TO)
+	UseContractFundMultisig = 51 | hdkeychain.HardenedKeyStart // key derivation path for contract spending keys (the keys the contract pays FROM, and the funding TX pays TO)
 	// links Id and channel. replaces UseChannelFund
 
 	UseIdKey = 111 | hdkeychain.HardenedKeyStart

--- a/qln/msghandler.go
+++ b/qln/msghandler.go
@@ -69,7 +69,15 @@ func (nd *LitNode) PeerHandler(msg lnutil.LitMsg, q *Qchan, peer *RemotePeer) er
 		if msg.MsgType() == lnutil.MSGID_DLC_DECLINEOFFER {
 			nd.DlcDeclineHandler(msg.(lnutil.DlcOfferDeclineMsg), peer)
 		}
-
+		if msg.MsgType() == lnutil.MSGID_DLC_CONTRACTACK {
+			nd.DlcContractAckHandler(msg.(lnutil.DlcContractAckMsg), peer)
+		}
+		if msg.MsgType() == lnutil.MSGID_DLC_CONTRACTFUNDINGSIGS {
+			nd.DlcFundingSigsHandler(msg.(lnutil.DlcContractFundingSigsMsg), peer)
+		}
+		if msg.MsgType() == lnutil.MSGID_DLC_SIGPROOF {
+			nd.DlcSigProofHandler(msg.(lnutil.DlcContractSigProofMsg), peer)
+		}
 	default:
 		return fmt.Errorf("Unknown message id byte %x &f0", msg.MsgType())
 

--- a/qln/msghandler.go
+++ b/qln/msghandler.go
@@ -388,7 +388,7 @@ func (nd *LitNode) HandleContractOPEvent(c *lnutil.DlcContract, opEvent *lnutil.
 		pkhIsMine := false
 		pkhIdx := uint32(0)
 		value := int64(0)
-		myPKHPkSript := lnutil.DirectWPKHScript(c.OurPayoutPub)
+		myPKHPkSript := lnutil.DirectWPKHScriptFromPKH(c.OurPayoutPKH)
 		for i, out := range opEvent.Tx.TxOut {
 			if bytes.Equal(myPKHPkSript, out.PkScript) {
 				pkhIdx = uint32(i)
@@ -415,7 +415,7 @@ func (nd *LitNode) HandleContractOPEvent(c *lnutil.DlcContract, opEvent *lnutil.
 			kg.Depth = 5
 			kg.Step[0] = 44 | 1<<31
 			kg.Step[1] = c.CoinType | 1<<31
-			kg.Step[2] = UseContractPayout
+			kg.Step[2] = UseContractPayoutPKH
 			kg.Step[3] = c.PeerIdx | 1<<31
 			kg.Step[4] = uint32(c.Idx) | 1<<31
 			priv := wal.GetPriv(kg)

--- a/qln/msghandler.go
+++ b/qln/msghandler.go
@@ -63,8 +63,11 @@ func (nd *LitNode) PeerHandler(msg lnutil.LitMsg, q *Qchan, peer *RemotePeer) er
 		if msg.MsgType() == lnutil.MSGID_DLC_OFFER {
 			nd.DlcOfferHandler(msg.(lnutil.DlcOfferMsg), peer)
 		}
+		if msg.MsgType() == lnutil.MSGID_DLC_ACCEPTOFFER {
+			nd.DlcAcceptHandler(msg.(lnutil.DlcOfferAcceptMsg), peer)
+		}
 		if msg.MsgType() == lnutil.MSGID_DLC_DECLINEOFFER {
-			nd.DlcDeclineHandler(msg.(lnutil.DlcOfferDeclMsg), peer)
+			nd.DlcDeclineHandler(msg.(lnutil.DlcOfferDeclineMsg), peer)
 		}
 
 	default:

--- a/qln/msghandler.go
+++ b/qln/msghandler.go
@@ -77,7 +77,8 @@ func (nd *LitNode) PeerHandler(msg lnutil.LitMsg, q *Qchan, peer *RemotePeer) er
 			nd.DlcContractAckHandler(msg.(lnutil.DlcContractAckMsg), peer)
 		}
 		if msg.MsgType() == lnutil.MSGID_DLC_CONTRACTFUNDINGSIGS {
-			nd.DlcFundingSigsHandler(msg.(lnutil.DlcContractFundingSigsMsg), peer)
+			nd.DlcFundingSigsHandler(
+				msg.(lnutil.DlcContractFundingSigsMsg), peer)
 		}
 		if msg.MsgType() == lnutil.MSGID_DLC_SIGPROOF {
 			nd.DlcSigProofHandler(msg.(lnutil.DlcContractSigProofMsg), peer)
@@ -377,12 +378,15 @@ func (nd *LitNode) OPEventHandler(OPEventChan chan lnutil.OutPointEvent) {
 	}
 }
 
-func (nd *LitNode) HandleContractOPEvent(c *lnutil.DlcContract, opEvent *lnutil.OutPointEvent) error {
+func (nd *LitNode) HandleContractOPEvent(c *lnutil.DlcContract,
+	opEvent *lnutil.OutPointEvent) error {
+
 	fmt.Printf("Received OPEvent for contract %d!\n", c.Idx)
 	if opEvent.Tx != nil {
 		wal, ok := nd.SubWallet[c.CoinType]
 		if !ok {
-			return fmt.Errorf("Could not find associated wallet for type %d", c.CoinType)
+			return fmt.Errorf("Could not find associated wallet"+
+				" for type %d", c.CoinType)
 		}
 
 		pkhIsMine := false
@@ -409,7 +413,8 @@ func (nd *LitNode) HandleContractOPEvent(c *lnutil.DlcContract, opEvent *lnutil.
 			if err != nil {
 				return err
 			}
-			txClaim.AddTxOut(wire.NewTxOut(value-500, lnutil.DirectWPKHScriptFromPKH(addr))) // todo calc fee
+			txClaim.AddTxOut(wire.NewTxOut(value-500,
+				lnutil.DirectWPKHScriptFromPKH(addr))) // todo calc fee
 
 			var kg portxo.KeyGen
 			kg.Depth = 5
@@ -424,7 +429,9 @@ func (nd *LitNode) HandleContractOPEvent(c *lnutil.DlcContract, opEvent *lnutil.
 			hCache := txscript.NewTxSigHashes(txClaim)
 
 			// generate sig
-			txClaim.TxIn[0].Witness, err = txscript.WitnessScript(txClaim, hCache, 0, value, myPKHPkSript, txscript.SigHashAll, priv, true)
+			txClaim.TxIn[0].Witness, err = txscript.WitnessScript(txClaim,
+				hCache, 0, value, myPKHPkSript, txscript.SigHashAll, priv, true)
+
 			if err != nil {
 				return err
 			}

--- a/qln/msghandler.go
+++ b/qln/msghandler.go
@@ -59,6 +59,14 @@ func (nd *LitNode) PeerHandler(msg lnutil.LitMsg, q *Qchan, peer *RemotePeer) er
 			nd.LinkMsgHandler(msg.(lnutil.LinkMsg))
 		}
 
+	case 0x90: // Discreet log contract messages
+		if msg.MsgType() == lnutil.MSGID_DLC_OFFER {
+			nd.DlcOfferHandler(msg.(lnutil.DlcOfferMsg), peer)
+		}
+		if msg.MsgType() == lnutil.MSGID_DLC_DECLINEOFFER {
+			nd.DlcDeclineHandler(msg.(lnutil.DlcOfferDeclMsg), peer)
+		}
+
 	default:
 		return fmt.Errorf("Unknown message id byte %x &f0", msg.MsgType())
 

--- a/qln/msghandler.go
+++ b/qln/msghandler.go
@@ -402,6 +402,13 @@ func (nd *LitNode) HandleContractOPEvent(c *lnutil.DlcContract,
 		}
 
 		if pkhIsMine {
+			c.Status = lnutil.ContractStatusSettling
+			err := nd.DlcManager.SaveContract(c)
+			if err != nil {
+				fmt.Printf("HandleContractOPEvent SaveContract err %s\n", err.Error())
+				return err
+			}
+
 			// We need to claim this.
 			txClaim := wire.NewMsgTx()
 			txClaim.Version = 2
@@ -436,6 +443,12 @@ func (nd *LitNode) HandleContractOPEvent(c *lnutil.DlcContract,
 				return err
 			}
 			wal.DirectSendTx(txClaim)
+
+			c.Status = lnutil.ContractStatusClosed
+			err = nd.DlcManager.SaveContract(c)
+			if err != nil {
+				return err
+			}
 		}
 
 	}

--- a/qln/signtx.go
+++ b/qln/signtx.go
@@ -105,6 +105,23 @@ func (nd *LitNode) SignSettlementTx(c *lnutil.DlcContract, tx *wire.MsgTx, priv 
 	return sig64.SigCompress(mySig)
 }
 
+func (nd *LitNode) SignClaimTx(settlementTx, claimTx *wire.MsgTx, priv *btcec.PrivateKey) ([64]byte, error) {
+
+	var sig [64]byte
+	// make hash cache
+	hCache := txscript.NewTxSigHashes(claimTx)
+
+	// generate sig
+	mySig, err := txscript.RawTxInWitnessSignature(
+		claimTx, hCache, 0, settlementTx.TxOut[0].Value, settlementTx.TxOut[0].PkScript, txscript.SigHashAll, priv)
+	if err != nil {
+		return sig, err
+	}
+	// truncate sig (last byte is sighash type, always sighashAll)
+	mySig = mySig[:len(mySig)-1]
+	return sig64.SigCompress(mySig)
+}
+
 // SignNextState generates your signature for their state.
 func (nd *LitNode) SignState(q *Qchan) ([64]byte, error) {
 

--- a/qln/signtx.go
+++ b/qln/signtx.go
@@ -81,8 +81,7 @@ func (nd *LitNode) SignSimpleClose(q *Qchan, tx *wire.MsgTx) ([64]byte, error) {
 	return sig64.SigCompress(mySig)
 }
 
-// SignSimpleClose signs the given simpleClose tx, given the other signature
-// Tx is modified in place.
+// SignSettlementTx signs the given settlement tx based on the passed contract using the passed private key. Tx is modified in place.
 func (nd *LitNode) SignSettlementTx(c *lnutil.DlcContract, tx *wire.MsgTx, priv *btcec.PrivateKey) ([64]byte, error) {
 
 	var sig [64]byte
@@ -105,6 +104,9 @@ func (nd *LitNode) SignSettlementTx(c *lnutil.DlcContract, tx *wire.MsgTx, priv 
 	return sig64.SigCompress(mySig)
 }
 
+// SignClaimTx signs the given claim tx based on the passed preimage and value using the passed private key. Tx is modified in place.
+// timeout=false means it's a regular claim, timeout=true means we're claiming an output that has expired (for instance if someone)
+// published the wrong settlement TX, we can claim this output back to our wallet after the timelock expired.
 func (nd *LitNode) SignClaimTx(claimTx *wire.MsgTx, value int64, pre []byte, priv *btcec.PrivateKey, timeout bool) error {
 
 	// make hash cache

--- a/qln/signtx.go
+++ b/qln/signtx.go
@@ -81,21 +81,27 @@ func (nd *LitNode) SignSimpleClose(q *Qchan, tx *wire.MsgTx) ([64]byte, error) {
 	return sig64.SigCompress(mySig)
 }
 
-// SignSettlementTx signs the given settlement tx based on the passed contract using the passed private key. Tx is modified in place.
-func (nd *LitNode) SignSettlementTx(c *lnutil.DlcContract, tx *wire.MsgTx, priv *btcec.PrivateKey) ([64]byte, error) {
+// SignSettlementTx signs the given settlement tx based on the passed contract
+// using the passed private key. Tx is modified in place.
+func (nd *LitNode) SignSettlementTx(c *lnutil.DlcContract, tx *wire.MsgTx,
+	priv *btcec.PrivateKey) ([64]byte, error) {
 
 	var sig [64]byte
 	// make hash cache
 	hCache := txscript.NewTxSigHashes(tx)
 
 	// generate script preimage for signing (ignore key order)
-	pre, _, err := lnutil.FundTxScript(c.OurFundMultisigPub, c.TheirFundMultisigPub)
+	pre, _, err := lnutil.FundTxScript(c.OurFundMultisigPub,
+		c.TheirFundMultisigPub)
+
 	if err != nil {
 		return sig, err
 	}
 	// generate sig
 	mySig, err := txscript.RawTxInWitnessSignature(
-		tx, hCache, 0, c.TheirFundingAmount+c.OurFundingAmount, pre, txscript.SigHashAll, priv)
+		tx, hCache, 0, c.TheirFundingAmount+c.OurFundingAmount,
+		pre, txscript.SigHashAll, priv)
+
 	if err != nil {
 		return sig, err
 	}
@@ -104,10 +110,13 @@ func (nd *LitNode) SignSettlementTx(c *lnutil.DlcContract, tx *wire.MsgTx, priv 
 	return sig64.SigCompress(mySig)
 }
 
-// SignClaimTx signs the given claim tx based on the passed preimage and value using the passed private key. Tx is modified in place.
-// timeout=false means it's a regular claim, timeout=true means we're claiming an output that has expired (for instance if someone)
-// published the wrong settlement TX, we can claim this output back to our wallet after the timelock expired.
-func (nd *LitNode) SignClaimTx(claimTx *wire.MsgTx, value int64, pre []byte, priv *btcec.PrivateKey, timeout bool) error {
+// SignClaimTx signs the given claim tx based on the passed preimage and value
+// using the passed private key. Tx is modified in place. timeout=false means
+// it's a regular claim, timeout=true means we're claiming an output that has
+// expired (for instance if someone) published the wrong settlement TX, we can
+// claim this output back to our wallet after the timelock expired.
+func (nd *LitNode) SignClaimTx(claimTx *wire.MsgTx, value int64, pre []byte,
+	priv *btcec.PrivateKey, timeout bool) error {
 
 	// make hash cache
 	hCache := txscript.NewTxSigHashes(claimTx)

--- a/wallit/signsend.go
+++ b/wallit/signsend.go
@@ -400,12 +400,96 @@ func (w *Wallit) BuildDontSign(
 	return tx, nil
 }
 
+func (w *Wallit) SignMyInputs(tx *wire.MsgTx) error {
+
+	// generate tx-wide hashCache for segwit stuff
+	// might not be needed (non-witness) but make it anyway
+	hCache := txscript.NewTxSigHashes(tx)
+	// make the stashes for signatures / witnesses
+	sigStash := make([][]byte, len(tx.TxIn))
+	witStash := make([][][]byte, len(tx.TxIn))
+
+	var allUtxos portxo.TxoSliceByAmt
+	allUtxos, err := w.GetAllUtxos()
+
+	for i := range tx.TxIn {
+		var utxo *portxo.PorTxo
+		for j := range allUtxos {
+			if allUtxos[j].Op.Hash.IsEqual(&tx.TxIn[i].PreviousOutPoint.Hash) && allUtxos[j].Op.Index == tx.TxIn[i].PreviousOutPoint.Index {
+				utxo = allUtxos[j]
+				break
+			}
+		}
+
+		if utxo == nil {
+			// Not my input, or at least i don't have it in my DB
+			continue
+		}
+
+		// get key
+		priv := w.PathPrivkey(utxo.KeyGen)
+		log.Printf("signing with privkey pub %x\n", priv.PubKey().SerializeCompressed())
+
+		if priv == nil {
+			return fmt.Errorf("SignMyInputs: nil privkey")
+		}
+
+		// sign into stash.  3 possibilities:  legacy PKH, WPKH, WSH
+		if utxo.Mode == portxo.TxoP2PKHComp { // legacy PKH
+			sigStash[i], err = txscript.SignatureScript(tx, i,
+				utxo.PkScript, txscript.SigHashAll, priv, true)
+			if err != nil {
+				return err
+			}
+		}
+		if utxo.Mode == portxo.TxoP2WPKHComp { // witness PKH
+			witStash[i], err = txscript.WitnessScript(tx, hCache, i,
+				utxo.Value, utxo.PkScript, txscript.SigHashAll, priv, true)
+			if err != nil {
+				return err
+			}
+		}
+		if utxo.Mode == portxo.TxoP2WSHComp { // witness script hash
+			sig, err := txscript.RawTxInWitnessSignature(tx, hCache, i,
+				utxo.Value, utxo.PkScript, txscript.SigHashAll, priv)
+			if err != nil {
+				return err
+			}
+			// witness stack has the signature, items, then the previous full script
+			witStash[i] = make([][]byte, 2+len(utxo.PreSigStack))
+
+			// sig comes first (pushed to stack last)
+			witStash[i][0] = sig
+
+			// after stack comes PostSigStack items
+			for j, element := range utxo.PreSigStack {
+				witStash[i][j+1] = element
+			}
+
+			// last stack item is the pkscript
+			witStash[i][len(witStash[i])-1] = utxo.PkScript
+		}
+
+	}
+	// swap sigs into sigScripts in txins
+	for i, txin := range tx.TxIn {
+		if sigStash[i] != nil {
+			txin.SignatureScript = sigStash[i]
+		}
+		if witStash[i] != nil {
+			txin.Witness = witStash[i]
+			txin.SignatureScript = nil
+		}
+	}
+
+	return nil
+}
+
 // Build and sign builds a tx from a slice of utxos and txOuts.
 // It then signs all the inputs and returns the tx.  Should
 // pretty much always work for any inputs.
 func (w *Wallit) BuildAndSign(
 	utxos []*portxo.PorTxo, txos []*wire.TxOut, nlt uint32) (*wire.MsgTx, error) {
-	var err error
 
 	if len(utxos) == 0 || len(txos) == 0 {
 		return nil, fmt.Errorf("BuildAndSign args no utxos or txos")
@@ -437,69 +521,7 @@ func (w *Wallit) BuildAndSign(
 	// sort txouts in place before signing.  txins are already sorted from above
 	txsort.InPlaceSort(tx)
 
-	// generate tx-wide hashCache for segwit stuff
-	// might not be needed (non-witness) but make it anyway
-	hCache := txscript.NewTxSigHashes(tx)
-	// make the stashes for signatures / witnesses
-	sigStash := make([][]byte, len(utxos))
-	witStash := make([][][]byte, len(utxos))
-
-	for i, _ := range tx.TxIn {
-		// get key
-		priv := w.PathPrivkey(utxos[i].KeyGen)
-		log.Printf("signing with privkey pub %x\n", priv.PubKey().SerializeCompressed())
-
-		if priv == nil {
-			return nil, fmt.Errorf("SendCoins: nil privkey")
-		}
-
-		// sign into stash.  3 possibilities:  legacy PKH, WPKH, WSH
-		if utxos[i].Mode == portxo.TxoP2PKHComp { // legacy PKH
-			sigStash[i], err = txscript.SignatureScript(tx, i,
-				utxos[i].PkScript, txscript.SigHashAll, priv, true)
-			if err != nil {
-				return nil, err
-			}
-		}
-		if utxos[i].Mode == portxo.TxoP2WPKHComp { // witness PKH
-			witStash[i], err = txscript.WitnessScript(tx, hCache, i,
-				utxos[i].Value, utxos[i].PkScript, txscript.SigHashAll, priv, true)
-			if err != nil {
-				return nil, err
-			}
-		}
-		if utxos[i].Mode == portxo.TxoP2WSHComp { // witness script hash
-			sig, err := txscript.RawTxInWitnessSignature(tx, hCache, i,
-				utxos[i].Value, utxos[i].PkScript, txscript.SigHashAll, priv)
-			if err != nil {
-				return nil, err
-			}
-			// witness stack has the signature, items, then the previous full script
-			witStash[i] = make([][]byte, 2+len(utxos[i].PreSigStack))
-
-			// sig comes first (pushed to stack last)
-			witStash[i][0] = sig
-
-			// after stack comes PostSigStack items
-			for j, element := range utxos[i].PreSigStack {
-				witStash[i][j+1] = element
-			}
-
-			// last stack item is the pkscript
-			witStash[i][len(witStash[i])-1] = utxos[i].PkScript
-		}
-
-	}
-	// swap sigs into sigScripts in txins
-	for i, txin := range tx.TxIn {
-		if sigStash[i] != nil {
-			txin.SignatureScript = sigStash[i]
-		}
-		if witStash[i] != nil {
-			txin.Witness = witStash[i]
-			txin.SignatureScript = nil
-		}
-	}
+	w.SignMyInputs(tx)
 
 	log.Printf("tx: %s", TxToString(tx))
 	return tx, nil

--- a/wallit/signsend.go
+++ b/wallit/signsend.go
@@ -400,6 +400,8 @@ func (w *Wallit) BuildDontSign(
 	return tx, nil
 }
 
+// SignMyInputs finds the inputs in a transaction that came from our own wallet, and signs them with our private keys.
+// Will modify the transaction in place, but will ignore inputs that we can't sign and leave them unsigned.
 func (w *Wallit) SignMyInputs(tx *wire.MsgTx) error {
 
 	// generate tx-wide hashCache for segwit stuff


### PR DESCRIPTION
This first version allows peers to import oracles, create new contracts, offer them to peers, accept/decline, and settle. It also watches the blockchain for settlements by others to claim the correct outputs back to the wallit.