### PR TITLE
Adds CA Roots to docker container. Can't use HTTPS without it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ WORKDIR /usr/local/go/src/github.com/mit-dci/lit/cmd/lit-af
 RUN go build
 
 FROM alpine
+RUN apk add --no-cache ca-certificates
 WORKDIR /app
 RUN cd /app
 COPY --from=build /usr/local/go/src/github.com/mit-dci/lit/lit /app/bin/lit


### PR DESCRIPTION
Plain Alpine is missing SSL root CA's, therefore doing a HTTPS request from within the container will not work. Ran into this when working with Oracles (will probably also affect the tracker). This change to the Dockerfile fixes that issue.