### PR TITLE
Allows configuring the host to listen for RPC connections

### DIFF
--- a/lit.go
+++ b/lit.go
@@ -32,6 +32,7 @@ type config struct { // define a struct for usage with go-flags
 	Verbose bool `short:"v" long:"verbose" description:"Set verbosity to true."`
 
 	Rpcport uint16 `short:"p" long:"rpcport" description:"Set RPC port to connect to"`
+	Rpchost string `short:"h" long:"rpchost" description:"Set RPC host to listen to"`
 
 	Params *coinparam.Params
 }
@@ -43,6 +44,7 @@ var (
 	defaultConfigFilename = "lit.conf"
 	defaultHomeDir        = os.Getenv("HOME")
 	defaultRpcport        = uint16(8001)
+	defaultRpchost        = "localhost"
 )
 
 func fileExists(name string) bool {
@@ -134,6 +136,7 @@ func main() {
 	conf := config{
 		LitHomeDir: defaultLitHomeDirName,
 		Rpcport:    defaultRpcport,
+		Rpchost:    defaultRpchost,
 		TrackerURL: defaultTrackerURL,
 	}
 
@@ -156,7 +159,7 @@ func main() {
 	rpcl.Node = node
 	rpcl.OffButton = make(chan bool, 1)
 
-	go litrpc.RPCListen(rpcl, conf.Rpcport)
+	go litrpc.RPCListen(rpcl, conf.Rpchost, conf.Rpcport)
 	litbamf.BamfListen(conf.Rpcport, conf.LitHomeDir)
 
 	<-rpcl.OffButton

--- a/litrpc/listener.go
+++ b/litrpc/listener.go
@@ -42,11 +42,11 @@ func serveWS(ws *websocket.Conn) {
 	jsonrpc.ServeConn(ws)
 }
 
-func RPCListen(rpcl *LitRPC, port uint16) {
+func RPCListen(rpcl *LitRPC, host string, port uint16) {
 
 	rpc.Register(rpcl)
 
-	listenString := fmt.Sprintf("localhost:%d", port)
+	listenString := fmt.Sprintf("%s:%d", host, port)
 
 	http.Handle("/ws", websocket.Handler(serveWS))
 	log.Fatal(http.ListenAndServe(listenString, nil))


### PR DESCRIPTION
When trying to run coordinated tests by talking to two LIT instances running in Docker via RPC, it's necessary to connect to the RPC from a remote machine. Since localhost was hardcoded, this was not possible. I added a configuration option for rpchost, that defaults to the (current) localhost, but allows you to set it to 0.0.0.0.