### PR TITLE
Fix a bunch of compile errors when running go tests

### DIFF
--- a/cmd/lit-af/chancmds.go
+++ b/cmd/lit-af/chancmds.go
@@ -25,7 +25,7 @@ var fundCommand = &Command{
 var watchCommand = &Command{
 	Format: fmt.Sprintf("%s%s\n", lnutil.White("watch"),
 		lnutil.ReqColor("channel idx", "watchPeerIdx")),
-	Description: fmt.Sprintf("%s\n%s\n%s%s\n",
+	Description: fmt.Sprintf("%s\n%s\n",
 		"Send channel data to a watcher",
 		"The watcher can defend your channel while you're offline."),
 	ShortDescription: "Send channel watch data to watcher.\n",

--- a/cmd/lit-af/dlccmds.go
+++ b/cmd/lit-af/dlccmds.go
@@ -15,7 +15,7 @@ import (
 var dlcCommand = &Command{
 	Format: fmt.Sprintf("%s%s%s\n", lnutil.White("dlc"),
 		lnutil.ReqColor("subcommand"), lnutil.OptColor("parameters...")),
-	Description: fmt.Sprintf("%s%2\n%s\n%s\n",
+	Description: fmt.Sprintf("%s\n%s\n%s\n%s\n",
 		"Command for working with discreet log contracts. ",
 		"Subcommand can be one of:",
 		fmt.Sprintf("%-10s %s",
@@ -157,10 +157,10 @@ var viewContractCommand = &Command{
 }
 
 var viewContractPayoutCommand = &Command{
-	Format: fmt.Sprintf("%s%s%s%s\n", lnutil.White("dlc contract viewpayout"),
+	Format: fmt.Sprintf("%s%s%s%s%s\n", lnutil.White("dlc contract viewpayout"),
 		lnutil.ReqColor("id"), lnutil.ReqColor("start"),
 		lnutil.ReqColor("end"), lnutil.ReqColor("increment")),
-	Description: fmt.Sprintf("%s\n%s\n%s\n%s\n",
+	Description: fmt.Sprintf("%s\n%s\n%s\n%s\n%s\n",
 		"Views the payout table of a contract",
 		fmt.Sprintf("%-10s %s",
 			lnutil.White("id"),

--- a/litinit.go
+++ b/litinit.go
@@ -54,7 +54,7 @@ func litSetup(conf *config) *[32]byte {
 	// Load config from file and parse
 	parser := newConfigParser(conf, flags.Default)
 
- 	// create home directory
+	// create home directory
 	_, err = os.Stat(preconf.LitHomeDir)
 	if err != nil {
 		log.Println("Error while creating a directory")
@@ -65,7 +65,7 @@ func litSetup(conf *config) *[32]byte {
 		log.Println("Creating a new config file")
 		err := createDefaultConfigFile(preconf.LitHomeDir) // Source of error
 		if err != nil {
-			log.Println("Error creating a default config file: %v\n")
+			log.Printf("Error creating a default config file: %v", preconf.LitHomeDir)
 			log.Fatal(err)
 		}
 	}

--- a/qln/buildtx.go
+++ b/qln/buildtx.go
@@ -3,8 +3,8 @@ package qln
 import (
 	"fmt"
 
-	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/consts"
+	"github.com/mit-dci/lit/lnutil"
 
 	"github.com/adiabat/btcd/wire"
 	"github.com/adiabat/btcutil/txsort"

--- a/qln/pushpull.go
+++ b/qln/pushpull.go
@@ -288,7 +288,7 @@ func (nd *LitNode) DeltaSigHandler(msg lnutil.DeltaSigMsg, qc *Qchan) error {
 		collision = true
 	}
 
-	fmt.Printf("COLLISION is (%b)\n", collision)
+	fmt.Printf("COLLISION is (%t)\n", collision)
 
 	// load state from disk
 	err := nd.ReloadQchanState(qc)

--- a/qln/pushpull.go
+++ b/qln/pushpull.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/adiabat/btcd/wire"
-	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/consts"
+	"github.com/mit-dci/lit/lnutil"
 )
 
 // Grab the coins that are rightfully yours! Plus some more.
@@ -195,7 +195,7 @@ func (nd LitNode) PushChannel(qc *Qchan, amt uint32, data [32]byte) error {
 		qc.ClearToSend <- true
 		return fmt.Errorf("want to push %s but %s available after %s fee and %s consts.MinOutput",
 			lnutil.SatoshiColor(int64(amt)),
-			lnutil.SatoshiColor(qc.State.MyAmt - qc.State.Fee - consts.MinOutput),
+			lnutil.SatoshiColor(qc.State.MyAmt-qc.State.Fee-consts.MinOutput),
 			lnutil.SatoshiColor(qc.State.Fee),
 			lnutil.SatoshiColor(consts.MinOutput))
 	}
@@ -288,7 +288,7 @@ func (nd *LitNode) DeltaSigHandler(msg lnutil.DeltaSigMsg, qc *Qchan) error {
 		collision = true
 	}
 
-	fmt.Printf("COLLISION is (%s)\n", collision)
+	fmt.Printf("COLLISION is (%b)\n", collision)
 
 	// load state from disk
 	err := nd.ReloadQchanState(qc)

--- a/uspv/init.go
+++ b/uspv/init.go
@@ -38,7 +38,7 @@ func (s *SPVCon) Connect(remoteNode string) error {
 				break
 			}
 			// gotta keep trying for those IPs
-			log.Println("DNS seed %s error", seed)
+			log.Printf("DNS seed %s error", seed)
 		}
 
 		if len(seedAdrs) == 0 {

--- a/uspv/msghandler.go
+++ b/uspv/msghandler.go
@@ -48,7 +48,7 @@ func (s *SPVCon) incomingMessageHandler() {
 		case *wire.MsgNotFound:
 			log.Printf("Got not found response from remote:")
 			for i, thing := range m.InvList {
-				log.Printf("\t$d) %s: %s", i, thing.Type, thing.Hash)
+				log.Printf("\t%d) %s: %s", i, thing.Type, thing.Hash)
 			}
 		case *wire.MsgGetData:
 			s.GetDataHandler(m)

--- a/watchtower/justice.go
+++ b/watchtower/justice.go
@@ -38,7 +38,7 @@ func (w *WatchTower) BuildJusticeTx(
 		txid := badTx.TxHash()
 		idxSigBytes := txidbkt.Get(txid[:16])
 		if idxSigBytes == nil {
-			return fmt.Errorf("couldn't get txid %x")
+			return fmt.Errorf("couldn't get txid %x", idxSigBytes)
 		}
 		iSig, err = IdxSigFromBytes(idxSigBytes)
 		if err != nil {

--- a/watchtower/watchdb.go
+++ b/watchtower/watchdb.go
@@ -149,7 +149,7 @@ func (w *WatchTower) NewChannel(m lnutil.WatchDescMsg) error {
 		// save truncated descriptor for static info (drop elk0)
 		wdBytes := m.Bytes()
 		if len(wdBytes) < 96 {
-			return fmt.Errorf("watchdescriptor %d bytes, expect 96")
+			return fmt.Errorf("watchdescriptor %d bytes, expect 96", len(wdBytes))
 		}
 		chanBucket.Put(KEYStatic, wdBytes[:96])
 		log.Printf("saved new channel to pkh %x\n", m.DestPKHScript)


### PR DESCRIPTION
Mostly problems with misuse of `Printf` and `Println`. This PR is required to make the tests/build pass.