### PR TITLE
Re-register refund addresses with wallit after restarting lit

### DIFF
--- a/qln/init.go
+++ b/qln/init.go
@@ -2,7 +2,6 @@ package qln
 
 import (
 	"fmt"
-	"log"
 	"path/filepath"
 
 	"github.com/adiabat/btcutil"
@@ -123,7 +122,6 @@ func (nd *LitNode) LinkBaseWallet(
 		var pkh [20]byte
 		pkhSlice := btcutil.Hash160(qChan.MyRefundPub[:])
 		copy(pkh[:], pkhSlice)
-		log.Printf("Re-registering %x", pkh)
 		nd.SubWallet[WallitIdx].ExportHook().RegisterAddress(pkh)
 	}
 


### PR DESCRIPTION
When a channel is first funded your refund address is registered with wallit so the resulting UTXO is picked up by a close. After Lit was restarted we were not re-registering those refund addresses with the wallit. As a result, closing a channel resulted in you receiving no new UTXO.