### PR TITLE
remove small flag for arg rpchost

### DIFF
--- a/lit.go
+++ b/lit.go
@@ -32,7 +32,7 @@ type config struct { // define a struct for usage with go-flags
 	Verbose bool `short:"v" long:"verbose" description:"Set verbosity to true."`
 
 	Rpcport uint16 `short:"p" long:"rpcport" description:"Set RPC port to connect to"`
-	Rpchost string `short:"h" long:"rpchost" description:"Set RPC host to listen to"`
+	Rpchost string `long:"rpchost" description:"Set RPC host to listen to"`
 
 	Params *coinparam.Params
 }


### PR DESCRIPTION
`-h` is already used for the help client by library `go-flags`, so we can't use it here. Trying to assign something will get you the error:

```
2018/06/06 11:18:02 bool flag `-h, --help' cannot have an argument
```