### PR TITLE
Re-register channel outpoints on restart

### DIFF
--- a/qln/init.go
+++ b/qln/init.go
@@ -2,6 +2,7 @@ package qln
 
 import (
 	"fmt"
+	"log"
 	"path/filepath"
 
 	"github.com/adiabat/btcutil"
@@ -123,6 +124,10 @@ func (nd *LitNode) LinkBaseWallet(
 		pkhSlice := btcutil.Hash160(qChan.MyRefundPub[:])
 		copy(pkh[:], pkhSlice)
 		nd.SubWallet[WallitIdx].ExportHook().RegisterAddress(pkh)
+
+		log.Printf("Registering outpoint %v", qChan.PorTxo.Op)
+
+		nd.SubWallet[WallitIdx].WatchThis(qChan.PorTxo.Op)
 	}
 
 	go nd.OPEventHandler(nd.SubWallet[WallitIdx].LetMeKnow())


### PR DESCRIPTION
Similarly to wallet addresses, upon restarting lit channel outpoints were forgotten. This meant that restarting lit before a channel was confirmed meant that it would never be confirmed.