### PR TITLE
Use a tracker that is online

### DIFF
--- a/lit.go
+++ b/lit.go
@@ -39,7 +39,7 @@ type config struct { // define a struct for usage with go-flags
 
 var (
 	defaultLitHomeDirName = os.Getenv("HOME") + "/.lit"
-	defaultTrackerURL     = "http://ni.media.mit.edu:46580"
+	defaultTrackerURL     = "http://hubris.media.mit.edu:46580"
 	defaultKeyFileName    = "privkey.hex"
 	defaultConfigFilename = "lit.conf"
 	defaultHomeDir        = os.Getenv("HOME")


### PR DESCRIPTION
ni.media.mit.edu has been down for a while. Hubris is hosting a tracker now instead. 