### PR TITLE
Fix race condition in pushpull code to allow colliding pushes

### DIFF
--- a/qln/lnchannels.go
+++ b/qln/lnchannels.go
@@ -3,6 +3,7 @@ package qln
 import (
 	"bytes"
 	"fmt"
+	"sync"
 
 	"github.com/mit-dci/lit/elkrem"
 	"github.com/mit-dci/lit/lnutil"
@@ -41,6 +42,7 @@ type Qchan struct {
 	State *StatCom // S current state of channel
 
 	ClearToSend chan bool // send a true here when you get a rev
+	ChanMtx     sync.Mutex
 	// exists only in ram, doesn't touch disk
 }
 

--- a/qln/msghandler.go
+++ b/qln/msghandler.go
@@ -235,6 +235,8 @@ func (nd *LitNode) CloseHandler(msg lnutil.LitMsg) error {
 // need a go routine for each qchan.
 
 func (nd *LitNode) PushPullHandler(routedMsg lnutil.LitMsg, q *Qchan) error {
+	q.ChanMtx.Lock()
+	defer q.ChanMtx.Unlock()
 	switch message := routedMsg.(type) {
 	case lnutil.DeltaSigMsg:
 		fmt.Printf("Got DELTASIG from %x\n", routedMsg.Peer())

--- a/qln/pushpull.go
+++ b/qln/pushpull.go
@@ -160,9 +160,8 @@ func (nd *LitNode) PushChannel(qc *Qchan, amt uint32, data [32]byte) error {
 	// see if channel is busy, error if so, lock if not
 	// lock this channel
 
-	qc.ChanMtx.Lock()
-
 	<-qc.ClearToSend
+	qc.ChanMtx.Lock()
 
 	/*select {
 	case <-qc.ClearToSend:

--- a/qln/pushpull.go
+++ b/qln/pushpull.go
@@ -308,9 +308,6 @@ func (nd *LitNode) SendDeltaSig(q *Qchan) error {
 // or a GapSigRev (if there's a collision)
 // Leaves the channel either expecting a Rev (normally) or a GapSigRev (collision)
 func (nd *LitNode) DeltaSigHandler(msg lnutil.DeltaSigMsg, qc *Qchan) error {
-	qc.ChanMtx.Lock()
-	defer qc.ChanMtx.Unlock()
-
 	log.Printf("Got DeltaSig: %v", msg)
 
 	var collision bool
@@ -521,9 +518,6 @@ func (nd *LitNode) SendSigRev(q *Qchan) error {
 // GapSigRevHandler takes in a GapSigRev, responds with a Rev, and
 // leaves the channel in a state expecting a Rev.
 func (nd *LitNode) GapSigRevHandler(msg lnutil.GapSigRevMsg, q *Qchan) error {
-	q.ChanMtx.Lock()
-	defer q.ChanMtx.Unlock()
-
 	log.Printf("Got GapSigRev: %v", msg)
 
 	// load qchan & state from DB
@@ -594,9 +588,6 @@ func (nd *LitNode) GapSigRevHandler(msg lnutil.GapSigRevMsg, q *Qchan) error {
 // SIGREVHandler takes in a SIGREV and responds with a REV (if everything goes OK)
 // Leaves the channel in a clear / rest state.
 func (nd *LitNode) SigRevHandler(msg lnutil.SigRevMsg, qc *Qchan) error {
-	qc.ChanMtx.Lock()
-	defer qc.ChanMtx.Unlock()
-
 	log.Printf("Got SigRev: %v", msg)
 
 	// load qchan & state from DB
@@ -701,9 +692,6 @@ func (nd *LitNode) SendREV(q *Qchan) error {
 // final message in the state update process and there is no response.
 // Leaves the channel in a clear / rest state.
 func (nd *LitNode) RevHandler(msg lnutil.RevMsg, qc *Qchan) error {
-	qc.ChanMtx.Lock()
-	defer qc.ChanMtx.Unlock()
-
 	log.Printf("Got Rev: %v", msg)
 
 	// load qchan & state from DB

--- a/qln/pushpull.go
+++ b/qln/pushpull.go
@@ -159,12 +159,12 @@ func (nd *LitNode) PushChannel(qc *Qchan, amt uint32, data [32]byte) error {
 
 	// see if channel is busy, error if so, lock if not
 	// lock this channel
-
-	for {
+	cts := false
+	for !cts {
 		qc.ChanMtx.Lock()
 		select {
 		case <-qc.ClearToSend:
-			break
+			cts = true
 		default:
 			qc.ChanMtx.Unlock()
 		}

--- a/qln/pushpull.go
+++ b/qln/pushpull.go
@@ -160,8 +160,15 @@ func (nd *LitNode) PushChannel(qc *Qchan, amt uint32, data [32]byte) error {
 	// see if channel is busy, error if so, lock if not
 	// lock this channel
 
-	<-qc.ClearToSend
-	qc.ChanMtx.Lock()
+	for {
+		qc.ChanMtx.Lock()
+		select {
+		case <-qc.ClearToSend:
+			break
+		default:
+			qc.ChanMtx.Unlock()
+		}
+	}
 
 	/*select {
 	case <-qc.ClearToSend:

--- a/qln/pushpull.go
+++ b/qln/pushpull.go
@@ -157,7 +157,7 @@ func (nd *LitNode) PushChannel(qc *Qchan, amt uint32, data [32]byte) error {
 		return fmt.Errorf("have to send non-zero amount")
 	}
 
-	// see if channel is busy, error if so, lock if not
+	// see if channel is busy
 	// lock this channel
 	cts := false
 	for !cts {
@@ -169,13 +169,6 @@ func (nd *LitNode) PushChannel(qc *Qchan, amt uint32, data [32]byte) error {
 			qc.ChanMtx.Unlock()
 		}
 	}
-
-	/*select {
-	case <-qc.ClearToSend:
-		// keep going
-		default:
-		return fmt.Errorf("Channel %d busy", qc.Idx())
-	}*/
 	// ClearToSend is now empty
 
 	// reload from disk here, after unlock

--- a/qln/pushpull.go
+++ b/qln/pushpull.go
@@ -243,11 +243,15 @@ func (nd *LitNode) PushChannel(qc *Qchan, amt uint32, data [32]byte) error {
 	}
 	// move unlock to here so that delta is saved before
 
+	log.Printf("PushChannel: Sending DeltaSig")
+
 	err = nd.SendDeltaSig(qc)
 	if err != nil {
 		// don't clear; something is wrong with the network
 		return err
 	}
+
+	log.Printf("PushChannel: Done: sent DeltaSig")
 
 	fmt.Printf("got pre CTS... \n")
 	// block until clear to send is full again

--- a/qln/pushpull.go
+++ b/qln/pushpull.go
@@ -182,14 +182,14 @@ func (nd *LitNode) PushChannel(qc *Qchan, amt uint32, data [32]byte) error {
 	// check that channel is confirmed, if non-test coin
 	wal, ok := nd.SubWallet[qc.Coin()]
 	if !ok {
-		qc.ClearToSend <- true
 		qc.ChanMtx.Unlock()
+		qc.ClearToSend <- true
 		return fmt.Errorf("Not connected to coin type %d\n", qc.Coin())
 	}
 
 	if !wal.Params().TestCoin && qc.Height < 100 {
-		qc.ClearToSend <- true
 		qc.ChanMtx.Unlock()
+		qc.ClearToSend <- true
 		return fmt.Errorf(
 			"height %d; must wait min 1 conf for non-test coin\n", qc.Height)
 	}
@@ -200,8 +200,8 @@ func (nd *LitNode) PushChannel(qc *Qchan, amt uint32, data [32]byte) error {
 
 	// check if this push would lower my balance below minBal
 	if myNewOutputSize < consts.MinOutput {
-		qc.ClearToSend <- true
 		qc.ChanMtx.Unlock()
+		qc.ClearToSend <- true
 		return fmt.Errorf("want to push %s but %s available after %s fee and %s consts.MinOutput",
 			lnutil.SatoshiColor(int64(amt)),
 			lnutil.SatoshiColor(qc.State.MyAmt-qc.State.Fee-consts.MinOutput),
@@ -210,8 +210,8 @@ func (nd *LitNode) PushChannel(qc *Qchan, amt uint32, data [32]byte) error {
 	}
 	// check if this push is sufficient to get them above minBal
 	if theirNewOutputSize < consts.MinOutput {
-		qc.ClearToSend <- true
 		qc.ChanMtx.Unlock()
+		qc.ClearToSend <- true
 		return fmt.Errorf(
 			"pushing %s insufficient; counterparty bal %s fee %s consts.MinOutput %s",
 			lnutil.SatoshiColor(int64(amt)),
@@ -224,12 +224,12 @@ func (nd *LitNode) PushChannel(qc *Qchan, amt uint32, data [32]byte) error {
 	if qc.State.Delta != 0 {
 		err = nd.ReSendMsg(qc)
 		if err != nil {
-			qc.ClearToSend <- true
 			qc.ChanMtx.Unlock()
+			qc.ClearToSend <- true
 			return err
 		}
-		qc.ClearToSend <- true
 		qc.ChanMtx.Unlock()
+		qc.ClearToSend <- true
 		return fmt.Errorf("Didn't send.  Recovered though, so try again!")
 	}
 


### PR DESCRIPTION
Some handlers would run while others were in-flight meaning that the channel state got messed up. Add an extra mutex to `Qchan` to ensure only one message handler runs at a time. 

This also means rather than erroring out when the channel is busy, we can now make colliding pushes that resolve simultanous pushes.

This PR also adds a bunch of useful logging to the pushpull code.