### PR TITLE
Automatic re-connection

### DIFF
--- a/lit.go
+++ b/lit.go
@@ -34,21 +34,23 @@ type config struct { // define a struct for usage with go-flags
 	Rpcport uint16 `short:"p" long:"rpcport" description:"Set RPC port to connect to"`
 	Rpchost string `long:"rpchost" description:"Set RPC host to listen to"`
 
-	AutoReconnect  bool   `short:"arc" long:"autoReconnect" description:"Attempts to automatically reconnect to known peers every minute."`
-	AutoListenPort string `short:"alp" long:"autoListenPort" description:"When auto reconnect enabled, starts listening on this port"`
-	Params         *coinparam.Params
+	AutoReconnect         bool   `long:"autoReconnect" description:"Attempts to automatically reconnect to known peers periodically."`
+	AutoReconnectInterval int64  `long:"autoReconnectInterval" description:"The interval (in seconds) the reconnect logic should be executed"`
+	AutoListenPort        string `long:"autoListenPort" description:"When auto reconnect enabled, starts listening on this port"`
+	Params                *coinparam.Params
 }
 
 var (
-	defaultLitHomeDirName = os.Getenv("HOME") + "/.lit"
-	defaultTrackerURL     = "http://ni.media.mit.edu:46580"
-	defaultKeyFileName    = "privkey.hex"
-	defaultConfigFilename = "lit.conf"
-	defaultHomeDir        = os.Getenv("HOME")
-	defaultRpcport        = uint16(8001)
-	defaultRpchost        = "localhost"
-	defaultAutoReconnect  = false
-	defaultAutoListenPort = ":2448"
+	defaultLitHomeDirName        = os.Getenv("HOME") + "/.lit"
+	defaultTrackerURL            = "http://ni.media.mit.edu:46580"
+	defaultKeyFileName           = "privkey.hex"
+	defaultConfigFilename        = "lit.conf"
+	defaultHomeDir               = os.Getenv("HOME")
+	defaultRpcport               = uint16(8001)
+	defaultRpchost               = "localhost"
+	defaultAutoReconnect         = false
+	defaultAutoListenPort        = ":2448"
+	defaultAutoReconnectInterval = int64(60)
 )
 
 func fileExists(name string) bool {
@@ -137,19 +139,20 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *config) error {
 func main() {
 
 	conf := config{
-		LitHomeDir:     defaultLitHomeDirName,
-		Rpcport:        defaultRpcport,
-		Rpchost:        defaultRpchost,
-		TrackerURL:     defaultTrackerURL,
-		AutoReconnect:  defaultAutoReconnect,
-		AutoListenPort: defaultAutoListenPort,
+		LitHomeDir:            defaultLitHomeDirName,
+		Rpcport:               defaultRpcport,
+		Rpchost:               defaultRpchost,
+		TrackerURL:            defaultTrackerURL,
+		AutoReconnect:         defaultAutoReconnect,
+		AutoListenPort:        defaultAutoListenPort,
+		AutoReconnectInterval: defaultAutoReconnectInterval,
 	}
 
 	key := litSetup(&conf)
 
 	// Setup LN node.  Activate Tower if in hard mode.
 	// give node and below file pathof lit home directory
-	node, err := qln.NewLitNode(key, conf.LitHomeDir, conf.TrackerURL, conf.AutoReconnect, conf.AutoListenPort)
+	node, err := qln.NewLitNode(key, conf.LitHomeDir, conf.TrackerURL, conf.AutoReconnect, conf.AutoListenPort, conf.AutoReconnectInterval)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/lit.go
+++ b/lit.go
@@ -152,7 +152,7 @@ func main() {
 
 	// Setup LN node.  Activate Tower if in hard mode.
 	// give node and below file pathof lit home directory
-	node, err := qln.NewLitNode(key, conf.LitHomeDir, conf.TrackerURL, conf.AutoReconnect, conf.AutoListenPort, conf.AutoReconnectInterval)
+	node, err := qln.NewLitNode(key, conf.LitHomeDir, conf.TrackerURL)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -169,6 +169,10 @@ func main() {
 
 	go litrpc.RPCListen(rpcl, conf.Rpchost, conf.Rpcport)
 	litbamf.BamfListen(conf.Rpcport, conf.LitHomeDir)
+
+	if conf.AutoReconnect {
+		node.AutoReconnect(conf.AutoListenPort, conf.AutoReconnectInterval)
+	}
 
 	<-rpcl.OffButton
 	fmt.Printf("Got stop request\n")

--- a/lit.go
+++ b/lit.go
@@ -34,7 +34,9 @@ type config struct { // define a struct for usage with go-flags
 	Rpcport uint16 `short:"p" long:"rpcport" description:"Set RPC port to connect to"`
 	Rpchost string `long:"rpchost" description:"Set RPC host to listen to"`
 
-	Params *coinparam.Params
+	AutoReconnect  bool   `short:"arc" long:"autoReconnect" description:"Attempts to automatically reconnect to known peers every minute."`
+	AutoListenPort string `short:"alp" long:"autoListenPort" description:"When auto reconnect enabled, starts listening on this port"`
+	Params         *coinparam.Params
 }
 
 var (
@@ -45,6 +47,8 @@ var (
 	defaultHomeDir        = os.Getenv("HOME")
 	defaultRpcport        = uint16(8001)
 	defaultRpchost        = "localhost"
+	defaultAutoReconnect  = false
+	defaultAutoListenPort = ":2448"
 )
 
 func fileExists(name string) bool {
@@ -96,7 +100,6 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *config) error {
 			return err
 		}
 	}
-
 	// try litecoin testnet4
 	if !lnutil.NopeString(conf.Lt4host) {
 		p := &coinparam.LiteCoinTestNet4Params
@@ -134,17 +137,19 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *config) error {
 func main() {
 
 	conf := config{
-		LitHomeDir: defaultLitHomeDirName,
-		Rpcport:    defaultRpcport,
-		Rpchost:    defaultRpchost,
-		TrackerURL: defaultTrackerURL,
+		LitHomeDir:     defaultLitHomeDirName,
+		Rpcport:        defaultRpcport,
+		Rpchost:        defaultRpchost,
+		TrackerURL:     defaultTrackerURL,
+		AutoReconnect:  defaultAutoReconnect,
+		AutoListenPort: defaultAutoListenPort,
 	}
 
 	key := litSetup(&conf)
 
 	// Setup LN node.  Activate Tower if in hard mode.
 	// give node and below file pathof lit home directory
-	node, err := qln.NewLitNode(key, conf.LitHomeDir, conf.TrackerURL)
+	node, err := qln.NewLitNode(key, conf.LitHomeDir, conf.TrackerURL, conf.AutoReconnect, conf.AutoListenPort)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/qln/autoconnect.go
+++ b/qln/autoconnect.go
@@ -14,17 +14,22 @@ import (
 // previously known peers.
 func (nd *LitNode) AutoReconnect(listenPort string, interval int64) {
 	// Listen myself
-	// TODO : configurable port for this?
 	nd.TCPListener(listenPort)
 
 	// Reconnect to other nodes after a timeout
 	ticker := time.NewTicker(time.Duration(interval) * time.Second)
 	go func() {
 		for range ticker.C {
+			fmt.Println("Reconnecting to known peers")
 			var empty [33]byte
 			i := uint32(0)
-			pubKey, _ := nd.GetPubHostFromPeerIdx(i)
 			for {
+				pubKey, _ := nd.GetPubHostFromPeerIdx(i)
+				if pubKey == empty {
+					fmt.Printf("Done, tried %d hosts\n", i)
+					break
+				}
+				i++
 				alreadyConnected := false
 
 				nd.RemoteMtx.Lock()
@@ -46,11 +51,6 @@ func (nd *LitNode) AutoReconnect(listenPort string, interval int64) {
 
 				if err != nil {
 					fmt.Printf("Could not restore connection to %s: %s\n", adr, err.Error())
-				}
-				i++
-				pubKey, _ = nd.GetPubHostFromPeerIdx(i)
-				if pubKey == empty {
-					break
 				}
 			}
 		}

--- a/qln/autoconnect.go
+++ b/qln/autoconnect.go
@@ -1,0 +1,59 @@
+package qln
+
+import (
+	"bytes"
+	"fmt"
+	"time"
+
+	"github.com/adiabat/bech32"
+	"github.com/btcsuite/fastsha256"
+)
+
+// AutoReconnect will start listening for incoming connections
+// and attempt to automatically reconnect to all
+// previously known peers.
+func (nd *LitNode) AutoReconnect() {
+	// Listen myself
+	// TODO : configurable port for this?
+	nd.TCPListener(":2448")
+
+	// Reconnect to other nodes after a timeout
+	ticker := time.NewTicker(5 * time.Second)
+	go func() {
+		for range ticker.C {
+			var empty [33]byte
+			i := uint32(0)
+			pubKey, _ := nd.GetPubHostFromPeerIdx(i)
+			for {
+				alreadyConnected := false
+
+				nd.RemoteMtx.Lock()
+				for _, con := range nd.RemoteCons {
+					if bytes.Equal(con.Con.RemotePub.SerializeCompressed(), pubKey[:]) {
+						alreadyConnected = true
+					}
+				}
+				nd.RemoteMtx.Unlock()
+
+				if alreadyConnected {
+					continue
+				}
+
+				idHash := fastsha256.Sum256(pubKey[:])
+				adr := bech32.Encode("ln", idHash[:20])
+
+				err := nd.DialPeer(adr)
+
+				if err != nil {
+					fmt.Printf("Could not restore connection to %s: %s\n", adr, err.Error())
+				}
+				i++
+				pubKey, _ = nd.GetPubHostFromPeerIdx(i)
+				if pubKey == empty {
+					break
+				}
+			}
+		}
+	}()
+
+}

--- a/qln/autoconnect.go
+++ b/qln/autoconnect.go
@@ -12,13 +12,13 @@ import (
 // AutoReconnect will start listening for incoming connections
 // and attempt to automatically reconnect to all
 // previously known peers.
-func (nd *LitNode) AutoReconnect(listenPort string) {
+func (nd *LitNode) AutoReconnect(listenPort string, interval int64) {
 	// Listen myself
 	// TODO : configurable port for this?
 	nd.TCPListener(listenPort)
 
 	// Reconnect to other nodes after a timeout
-	ticker := time.NewTicker(5 * time.Second)
+	ticker := time.NewTicker(time.Duration(interval) * time.Second)
 	go func() {
 		for range ticker.C {
 			var empty [33]byte

--- a/qln/autoconnect.go
+++ b/qln/autoconnect.go
@@ -12,10 +12,10 @@ import (
 // AutoReconnect will start listening for incoming connections
 // and attempt to automatically reconnect to all
 // previously known peers.
-func (nd *LitNode) AutoReconnect() {
+func (nd *LitNode) AutoReconnect(listenPort string) {
 	// Listen myself
 	// TODO : configurable port for this?
-	nd.TCPListener(":2448")
+	nd.TCPListener(listenPort)
 
 	// Reconnect to other nodes after a timeout
 	ticker := time.NewTicker(5 * time.Second)

--- a/qln/init.go
+++ b/qln/init.go
@@ -17,7 +17,7 @@ import (
 
 // Init starts up a lit node.  Needs priv key, and a path.
 // Does not activate a subwallet; do that after init.
-func NewLitNode(privKey *[32]byte, path string, trackerURL string) (*LitNode, error) {
+func NewLitNode(privKey *[32]byte, path string, trackerURL string, autoReconnect bool, autoListenPort string) (*LitNode, error) {
 
 	nd := new(LitNode)
 	nd.LitFolder = path
@@ -77,7 +77,9 @@ func NewLitNode(privKey *[32]byte, path string, trackerURL string) (*LitNode, er
 	//	go nd.OmniHandler()
 	go nd.OutMessager()
 
-	nd.AutoReconnect()
+	if autoReconnect {
+		nd.AutoReconnect(autoListenPort)
+	}
 
 	return nd, nil
 }

--- a/qln/init.go
+++ b/qln/init.go
@@ -73,8 +73,11 @@ func NewLitNode(privKey *[32]byte, path string, trackerURL string) (*LitNode, er
 
 	nd.OmniOut = make(chan lnutil.LitMsg, 10)
 	nd.OmniIn = make(chan lnutil.LitMsg, 10)
+
 	//	go nd.OmniHandler()
 	go nd.OutMessager()
+
+	nd.AutoReconnect()
 
 	return nd, nil
 }

--- a/qln/init.go
+++ b/qln/init.go
@@ -17,7 +17,7 @@ import (
 
 // Init starts up a lit node.  Needs priv key, and a path.
 // Does not activate a subwallet; do that after init.
-func NewLitNode(privKey *[32]byte, path string, trackerURL string, autoReconnect bool, autoListenPort string, autoReconnectInterval int64) (*LitNode, error) {
+func NewLitNode(privKey *[32]byte, path string, trackerURL string) (*LitNode, error) {
 
 	nd := new(LitNode)
 	nd.LitFolder = path
@@ -76,10 +76,6 @@ func NewLitNode(privKey *[32]byte, path string, trackerURL string, autoReconnect
 
 	//	go nd.OmniHandler()
 	go nd.OutMessager()
-
-	if autoReconnect {
-		nd.AutoReconnect(autoListenPort, autoReconnectInterval)
-	}
 
 	return nd, nil
 }

--- a/qln/init.go
+++ b/qln/init.go
@@ -17,7 +17,7 @@ import (
 
 // Init starts up a lit node.  Needs priv key, and a path.
 // Does not activate a subwallet; do that after init.
-func NewLitNode(privKey *[32]byte, path string, trackerURL string, autoReconnect bool, autoListenPort string) (*LitNode, error) {
+func NewLitNode(privKey *[32]byte, path string, trackerURL string, autoReconnect bool, autoListenPort string, autoReconnectInterval int64) (*LitNode, error) {
 
 	nd := new(LitNode)
 	nd.LitFolder = path
@@ -78,7 +78,7 @@ func NewLitNode(privKey *[32]byte, path string, trackerURL string, autoReconnect
 	go nd.OutMessager()
 
 	if autoReconnect {
-		nd.AutoReconnect(autoListenPort)
+		nd.AutoReconnect(autoListenPort, autoReconnectInterval)
 	}
 
 	return nd, nil


### PR DESCRIPTION
This pull request will allow lit to automatically start listening on a configurable port (default 2448), and periodically reconnect to peers it knows, in case their connection dropped. Interval for re-connection is configurable, default is 1 minute.

So when you restart LIT, it will automatically be listening for incoming connections and re-connect to peers it previously was connected to. For keeping up a network of channels, this is highly preferable over having to manually do all this.