### PR TITLE
Handle updates to the tracker for IPv6 support

### DIFF
--- a/qln/netio.go
+++ b/qln/netio.go
@@ -105,7 +105,7 @@ func (nd *LitNode) DialPeer(connectAdr string) error {
 
 	// If we couldn't deduce a URL, look it up on the tracker
 	if where == "" {
-		where, err = Lookup(who, nd.TrackerURL)
+		where, _, err = Lookup(who, nd.TrackerURL)
 		if err != nil {
 			return err
 		}
@@ -117,6 +117,7 @@ func (nd *LitNode) DialPeer(connectAdr string) error {
 	// Assign remote connection
 	newConn := new(lndc.LNDConn)
 
+	// TODO: handle IPv6 connections
 	err = newConn.Dial(idPriv, where, who)
 	if err != nil {
 		return err

--- a/qln/tracker.go
+++ b/qln/tracker.go
@@ -97,7 +97,7 @@ func Lookup(litadr string, trackerURL string, proxyURL string) (string, string, 
 	if proxyURL != "" {
 		dialer, err := proxy.SOCKS5("tcp", proxyURL, nil, proxy.Direct)
 		if err != nil {
-			return "", err
+			return "", "", err
 		}
 
 		client.Transport = &http.Transport{

--- a/qln/tracker.go
+++ b/qln/tracker.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"log"
 	"net/http"
 	"net/url"
 	"strings"
@@ -14,7 +15,8 @@ import (
 )
 
 type announcement struct {
-	url  string
+	ipv4 string
+	ipv6 string
 	addr string
 	sig  string
 	pbk  string
@@ -23,13 +25,14 @@ type announcement struct {
 type nodeinfo struct {
 	Success bool
 	Node    struct {
-		Url  string
+		IPv4 string
+		IPv6 string
 		Addr string
 	}
 }
 
 func Announce(priv *btcec.PrivateKey, litport string, litadr string, trackerURL string) error {
-	resp, err := http.Get("http://myexternalip.com/raw")
+	resp, err := http.Get("https://ipv4.myexternalip.com/raw")
 	if err != nil {
 		return err
 	}
@@ -38,9 +41,25 @@ func Announce(priv *btcec.PrivateKey, litport string, litadr string, trackerURL 
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(resp.Body)
 
-	liturl := strings.TrimSpace(buf.String()) + litport
+	liturlIPv4 := strings.TrimSpace(buf.String()) + litport
 
-	urlBytes := []byte(liturl)
+	var liturlIPv6 string
+
+	/* TODO: Find a better way to get this information. Their
+	 * SSL cert doesn't work for IPv6.
+	 */
+	resp, err = http.Get("http://ipv6.myexternalip.com/raw")
+	if err != nil {
+		log.Printf("%v", err)
+	} else {
+		defer resp.Body.Close()
+
+		buf = new(bytes.Buffer)
+		buf.ReadFrom(resp.Body)
+		liturlIPv6 = strings.TrimSpace(buf.String()) + litport
+	}
+
+	urlBytes := []byte(liturlIPv4 + liturlIPv6)
 
 	urlHash := sha256.Sum256(urlBytes)
 
@@ -51,13 +70,15 @@ func Announce(priv *btcec.PrivateKey, litport string, litadr string, trackerURL 
 
 	var ann announcement
 
-	ann.url = liturl
+	ann.ipv4 = liturlIPv4
+	ann.ipv6 = liturlIPv6
 	ann.addr = litadr
 	ann.sig = hex.EncodeToString(urlSig.Serialize())
 	ann.pbk = hex.EncodeToString(priv.PubKey().SerializeCompressed())
 
 	_, err = http.PostForm(trackerURL+"/announce",
-		url.Values{"url": {ann.url},
+		url.Values{"ipv4": {ann.ipv4},
+			"ipv6": {ann.ipv6},
 			"addr": {ann.addr},
 			"sig":  {ann.sig},
 			"pbk":  {ann.pbk}})
@@ -69,10 +90,10 @@ func Announce(priv *btcec.PrivateKey, litport string, litadr string, trackerURL 
 	return nil
 }
 
-func Lookup(litadr string, trackerURL string) (string, error) {
+func Lookup(litadr string, trackerURL string) (string, string, error) {
 	resp, err := http.Get(trackerURL + "/" + litadr)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	defer resp.Body.Close()
 
@@ -80,12 +101,12 @@ func Lookup(litadr string, trackerURL string) (string, error) {
 	var node nodeinfo
 	err = decoder.Decode(&node)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	if !node.Success {
-		return "", errors.New("Node not found")
+		return "", "", errors.New("Node not found")
 	}
 
-	return node.Node.Url, nil
+	return node.Node.IPv4, node.Node.IPv6, nil
 }


### PR DESCRIPTION
Sometimes our default interface is IPv6, and Lit currently cannot connect to IPv6 nodes. Therefore I updated lit-tracker to accept both an IPv4 and IPv6 address on announce. This update sends both types of IP address to the tracker if available, but only attempts to connect to the IPv4 version for now. LNDC needs to be updated to handle IPv6 to use the other address potentially returned by the tracker.