### PR TITLE
Add ipv6 to lndc and uspv

### DIFF
--- a/lndc/conn.go
+++ b/lndc/conn.go
@@ -64,15 +64,11 @@ func IP4(ipAddress string) bool {
 func parseAdr(netAddress string) (string, string, error) {
 	colonCount := strings.Count(netAddress, ":")
 	var conMode string
-	if IP4(netAddress) {
-		// only ipv4 clears this since ipv6 has colons
+	if colonCount == 1 && IP4(strings.Split(netAddress, ":")[0]) {
+		// only ipv4 clears this since ipv6 has 6 colons (with port no)
 		conMode = "tcp4"
 		return netAddress, conMode, nil
-	} else if colonCount == 5 || colonCount == 6 {
-		// ipv6 without remote port
-		if colonCount == 5 {
-			netAddress = "[" + netAddress + "]" + ":"
-		}
+	} else if colonCount == 6 {
 		conMode = "tcp6"
 		return netAddress, conMode, nil
 	} else {

--- a/lndc/conn.go
+++ b/lndc/conn.go
@@ -68,7 +68,7 @@ func parseAdr(netAddress string) (string, string, error) {
 		// only ipv4 clears this since ipv6 has 6 colons (with port no)
 		conMode = "tcp4"
 		return netAddress, conMode, nil
-	} else if colonCount == 6 {
+	} else if colonCount >= 5 {
 		conMode = "tcp6"
 		return netAddress, conMode, nil
 	} else {
@@ -96,12 +96,21 @@ func (c *LNDConn) Dial(
 				return err
 			}
 
-			c.Conn, err = d.Dial("tcp", netAddress)
+			netAddress, conMode, err := parseAdr(netAddress)
+			if err != nil {
+				return fmt.Errorf("Invalid ip")
+			}
+			c.Conn, err = d.Dial(conMode, netAddress)
 			if err != nil {
 				return err
 			}
 		} else {
-			c.Conn, err = net.Dial("tcp", netAddress)
+			// First, open the TCP connection itself.
+			netAddress, conMode, err := parseAdr(netAddress)
+			if err != nil {
+				return fmt.Errorf("Invalid ip")
+			}
+			c.Conn, err = net.Dial(conMode, netAddress)
 			if err != nil {
 				return err
 			}

--- a/qln/netio.go
+++ b/qln/netio.go
@@ -108,7 +108,7 @@ func (nd *LitNode) DialPeer(connectAdr string) error {
 
 	// If we couldn't deduce a URL, look it up on the tracker
 	if where == "" {
-		where, err = Lookup(who, nd.TrackerURL, nd.ProxyURL)
+		where, _, err = Lookup(who, nd.TrackerURL, nd.ProxyURL)
 		if err != nil {
 			return err
 		}
@@ -120,6 +120,7 @@ func (nd *LitNode) DialPeer(connectAdr string) error {
 	// Assign remote connection
 	newConn := new(lndc.LNDConn)
 
+	// TODO: handle IPv6 connections
 	err = newConn.Dial(idPriv, where, who, nd.ProxyURL)
 	if err != nil {
 		return err

--- a/qln/tracker.go
+++ b/qln/tracker.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"log"
 	"net/http"
 	"net/url"
 	"strings"
@@ -15,7 +16,8 @@ import (
 )
 
 type announcement struct {
-	url  string
+	ipv4 string
+	ipv6 string
 	addr string
 	sig  string
 	pbk  string
@@ -24,13 +26,14 @@ type announcement struct {
 type nodeinfo struct {
 	Success bool
 	Node    struct {
-		Url  string
+		IPv4 string
+		IPv6 string
 		Addr string
 	}
 }
 
 func Announce(priv *btcec.PrivateKey, litport string, litadr string, trackerURL string) error {
-	resp, err := http.Get("http://myexternalip.com/raw")
+	resp, err := http.Get("https://ipv4.myexternalip.com/raw")
 	if err != nil {
 		return err
 	}
@@ -39,9 +42,25 @@ func Announce(priv *btcec.PrivateKey, litport string, litadr string, trackerURL 
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(resp.Body)
 
-	liturl := strings.TrimSpace(buf.String()) + litport
+	liturlIPv4 := strings.TrimSpace(buf.String()) + litport
 
-	urlBytes := []byte(liturl)
+	var liturlIPv6 string
+
+	/* TODO: Find a better way to get this information. Their
+	 * SSL cert doesn't work for IPv6.
+	 */
+	resp, err = http.Get("http://ipv6.myexternalip.com/raw")
+	if err != nil {
+		log.Printf("%v", err)
+	} else {
+		defer resp.Body.Close()
+
+		buf = new(bytes.Buffer)
+		buf.ReadFrom(resp.Body)
+		liturlIPv6 = strings.TrimSpace(buf.String()) + litport
+	}
+
+	urlBytes := []byte(liturlIPv4 + liturlIPv6)
 
 	urlHash := sha256.Sum256(urlBytes)
 
@@ -52,13 +71,15 @@ func Announce(priv *btcec.PrivateKey, litport string, litadr string, trackerURL 
 
 	var ann announcement
 
-	ann.url = liturl
+	ann.ipv4 = liturlIPv4
+	ann.ipv6 = liturlIPv6
 	ann.addr = litadr
 	ann.sig = hex.EncodeToString(urlSig.Serialize())
 	ann.pbk = hex.EncodeToString(priv.PubKey().SerializeCompressed())
 
 	_, err = http.PostForm(trackerURL+"/announce",
-		url.Values{"url": {ann.url},
+		url.Values{"ipv4": {ann.ipv4},
+			"ipv6": {ann.ipv6},
 			"addr": {ann.addr},
 			"sig":  {ann.sig},
 			"pbk":  {ann.pbk}})
@@ -86,7 +107,7 @@ func Lookup(litadr string, trackerURL string, proxyURL string) (string, error) {
 
 	resp, err := client.Get(trackerURL + "/" + litadr)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	defer resp.Body.Close()
 
@@ -94,12 +115,12 @@ func Lookup(litadr string, trackerURL string, proxyURL string) (string, error) {
 	var node nodeinfo
 	err = decoder.Decode(&node)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	if !node.Success {
-		return "", errors.New("Node not found")
+		return "", "", errors.New("Node not found")
 	}
 
-	return node.Node.Url, nil
+	return node.Node.IPv4, node.Node.IPv6, nil
 }

--- a/qln/tracker.go
+++ b/qln/tracker.go
@@ -91,13 +91,13 @@ func Announce(priv *btcec.PrivateKey, litport string, litadr string, trackerURL 
 	return nil
 }
 
-func Lookup(litadr string, trackerURL string, proxyURL string) (string, error) {
+func Lookup(litadr string, trackerURL string, proxyURL string) (string, string, error) {
 	var client http.Client
 
 	if proxyURL != "" {
 		dialer, err := proxy.SOCKS5("tcp", proxyURL, nil, proxy.Direct)
 		if err != nil {
-			return "", err
+			return "", "", err
 		}
 
 		client.Transport = &http.Transport{

--- a/uspv/chainhook.go
+++ b/uspv/chainhook.go
@@ -116,6 +116,7 @@ func (s *SPVCon) Start(
 	err = s.Connect(host)
 	if err != nil {
 		log.Printf("Can't connect to host %s\n", host)
+		log.Println(err)
 		return nil, nil, err
 	}
 

--- a/uspv/init.go
+++ b/uspv/init.go
@@ -13,6 +13,41 @@ import (
 	"github.com/mit-dci/lit/lnutil"
 )
 
+func IP4(ipAddress string) bool {
+	parseIp := net.ParseIP(ipAddress)
+	if parseIp.To4() == nil {
+		return false
+	}
+	return true
+}
+
+func (s *SPVCon) parseRemoteNode(remoteNode string) (string, string, error) {
+	colonCount := strings.Count(remoteNode, ":")
+	var conMode string
+	if colonCount == 0 {
+		if IP4(remoteNode) || remoteNode == "localhost" { // need this to connect to locahost
+			remoteNode = remoteNode + ":" + s.Param.DefaultPort
+		}
+		// only ipv4 clears this since ipv6 has colons
+		conMode = "tcp4"
+		log.Println("HERE")
+		return remoteNode, conMode, nil
+	} else if colonCount == 1 && IP4(strings.Split(remoteNode, ":")[0]) {
+		// custom port on ipv4
+		return remoteNode, "tcp4", nil
+	} else if colonCount >= 5 {
+		// ipv6 without remote port
+		// assume users don't give ports with ipv6 nodes
+		if !strings.Contains(remoteNode, "[") && !strings.Contains(remoteNode, "]") {
+			remoteNode = "[" + remoteNode + "]" + ":" + s.Param.DefaultPort
+		}
+		conMode = "tcp6"
+		return remoteNode, conMode, nil
+	} else {
+		return "", "", fmt.Errorf("Invalid ip")
+	}
+}
+
 // GetListOfNodes contacts all DNSSeeds for the coin specified and then contacts
 // each one of them in order to receive a list of ips and then returns a combined
 // list
@@ -44,16 +79,12 @@ func (s *SPVCon) DialNode(listOfNodes []string) error {
 	var err error
 	for i, ip := range listOfNodes {
 		// try to connect to all nodes in this range
-		var conString string
-		if strings.Contains(ip, ":") {
-			// user has given us a port, take that
-			conString = ip
-		} else {
-			conString = ip + ":" + s.Param.DefaultPort
-		}
+		var conString, conMode string
+		// need to check whether conString is ipv4 or ipv6
+		conString, conMode, err = s.parseRemoteNode(ip)
 		log.Printf("Attempting connection to node at %s\n",
 			conString)
-		s.con, err = net.Dial("tcp", conString)
+		s.con, err = net.Dial(conMode, conString)
 		if err != nil {
 			if i != len(listOfNodes)-1 {
 				log.Println(err.Error())
@@ -151,9 +182,6 @@ func (s *SPVCon) Connect(remoteNode string) error {
 			return err
 		}
 	} else { // else connect to user-specified node
-		if !strings.Contains(remoteNode, ":") {
-			remoteNode = remoteNode + ":" + s.Param.DefaultPort
-		}
 		listOfNodes = []string{remoteNode}
 	}
 	handShakeFailed := false //need to be in this scope to access it here


### PR DESCRIPTION
Built upon #200, functions are a bit ugly, could move them to `lnutil` if need be. View https://github.com/mit-dci/lit/commit/55249ed5517bf32820945eb5be47791ff477938b for standalone changes via this PR.