### PR TITLE
Optional SOCKS5 for LNDC connections

### DIFF
--- a/lit.go
+++ b/lit.go
@@ -25,6 +25,7 @@ type config struct { // define a struct for usage with go-flags
 	LitHomeDir  string `long:"dir" description:"Specify Home Directory of lit as an absolute path."`
 	TrackerURL  string `long:"tracker" description:"LN address tracker URL http|https://host:port"`
 	ConfigFile  string
+	ProxyURL    string `long:"proxy" description:"SOCKS5 proxy to use for communicating with the network"`
 
 	ReSync  bool `short:"r" long:"reSync" description:"Resync from the given tip."`
 	Tower   bool `long:"tower" description:"Watchtower: Run a watching node"`
@@ -152,7 +153,7 @@ func main() {
 
 	// Setup LN node.  Activate Tower if in hard mode.
 	// give node and below file pathof lit home directory
-	node, err := qln.NewLitNode(key, conf.LitHomeDir, conf.TrackerURL)
+	node, err := qln.NewLitNode(key, conf.LitHomeDir, conf.TrackerURL, conf.ProxyURL)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/lndc/conn.go
+++ b/lndc/conn.go
@@ -73,14 +73,12 @@ func (c *LNDConn) Dial(
 			}
 
 			c.Conn, err = d.Dial("tcp", netAddress)
-			if err != nil {
-				return err
-			}
 		} else {
 			c.Conn, err = net.Dial("tcp", netAddress)
-			if err != nil {
-				return err
-			}
+		}
+
+		if err != nil {
+			return err
 		}
 	}
 

--- a/lndc/conn.go
+++ b/lndc/conn.go
@@ -73,12 +73,14 @@ func (c *LNDConn) Dial(
 			}
 
 			c.Conn, err = d.Dial("tcp", netAddress)
+			if err != nil {
+				return err
+			}
 		} else {
 			c.Conn, err = net.Dial("tcp", netAddress)
-		}
-
-		if err != nil {
-			return err
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/lndc/lndc_test.go
+++ b/lndc/lndc_test.go
@@ -43,7 +43,7 @@ func TestConnectionCorrectness(t *testing.T) {
 	// main one. If both errors are nil, then encryption+auth was successful.
 	wg.Add(1)
 	go func() {
-		dialErr = conn.Dial(remotePriv, listener.Addr().String(), myAddress)
+		dialErr = conn.Dial(remotePriv, listener.Addr().String(), myAddress, "")
 		wg.Done()
 	}()
 

--- a/qln/init.go
+++ b/qln/init.go
@@ -18,7 +18,7 @@ import (
 
 // Init starts up a lit node.  Needs priv key, and a path.
 // Does not activate a subwallet; do that after init.
-func NewLitNode(privKey *[32]byte, path string, trackerURL string) (*LitNode, error) {
+func NewLitNode(privKey *[32]byte, path string, trackerURL string, proxyURL string) (*LitNode, error) {
 
 	nd := new(LitNode)
 	nd.LitFolder = path
@@ -49,6 +49,8 @@ func NewLitNode(privKey *[32]byte, path string, trackerURL string) (*LitNode, er
 	}
 
 	nd.TrackerURL = trackerURL
+
+	nd.ProxyURL = proxyURL
 
 	nd.InitRouting()
 

--- a/qln/lndb.go
+++ b/qln/lndb.go
@@ -132,6 +132,9 @@ type LitNode struct {
 
 	ChannelMap map[[20]byte][]lnutil.LinkMsg
 	AdvTimeout *time.Ticker
+
+	// Contains the URL string to connect to a SOCKS5 proxy, if provided
+	ProxyURL string
 }
 
 type RemotePeer struct {

--- a/qln/netio.go
+++ b/qln/netio.go
@@ -41,9 +41,12 @@ func (nd *LitNode) TCPListener(
 
 	adr := lnutil.LitAdrFromPubkey(idPub)
 
-	err = Announce(idPriv, lisIpPort, adr, nd.TrackerURL)
-	if err != nil {
-		log.Printf("Announcement error %s", err.Error())
+	// Don't announce on the tracker if we are communicating via SOCKS proxy
+	if nd.ProxyURL == "" {
+		err = Announce(idPriv, lisIpPort, adr, nd.TrackerURL)
+		if err != nil {
+			log.Printf("Announcement error %s", err.Error())
+		}
 	}
 
 	fmt.Printf("Listening on %s\n", listener.Addr().String())
@@ -105,7 +108,7 @@ func (nd *LitNode) DialPeer(connectAdr string) error {
 
 	// If we couldn't deduce a URL, look it up on the tracker
 	if where == "" {
-		where, err = Lookup(who, nd.TrackerURL)
+		where, err = Lookup(who, nd.TrackerURL, nd.ProxyURL)
 		if err != nil {
 			return err
 		}

--- a/qln/netio.go
+++ b/qln/netio.go
@@ -117,7 +117,7 @@ func (nd *LitNode) DialPeer(connectAdr string) error {
 	// Assign remote connection
 	newConn := new(lndc.LNDConn)
 
-	err = newConn.Dial(idPriv, where, who)
+	err = newConn.Dial(idPriv, where, who, nd.ProxyURL)
 	if err != nil {
 		return err
 	}

--- a/qln/tracker.go
+++ b/qln/tracker.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/adiabat/btcd/btcec"
+	"golang.org/x/net/proxy"
 )
 
 type announcement struct {
@@ -69,8 +70,21 @@ func Announce(priv *btcec.PrivateKey, litport string, litadr string, trackerURL 
 	return nil
 }
 
-func Lookup(litadr string, trackerURL string) (string, error) {
-	resp, err := http.Get(trackerURL + "/" + litadr)
+func Lookup(litadr string, trackerURL string, proxyURL string) (string, error) {
+	var client http.Client
+
+	if proxyURL != "" {
+		dialer, err := proxy.SOCKS5("tcp", proxyURL, nil, proxy.Direct)
+		if err != nil {
+			return "", err
+		}
+
+		client.Transport = &http.Transport{
+			Dial: dialer.Dial,
+		}
+	}
+
+	resp, err := client.Get(trackerURL + "/" + litadr)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
With this PR you can specify a SOCKS5 proxy with the --proxy option to Lit. Currently connections to full nodes and powless APIs still take place via the normal network. When the proxy is enabled Lit does not attempt to announce itself on the tracker and uses the proxy for tracker lookups. 