### PR TITLE
[trivial] edit log messages

### DIFF
--- a/uspv/init.go
+++ b/uspv/init.go
@@ -30,7 +30,6 @@ func (s *SPVCon) parseRemoteNode(remoteNode string) (string, string, error) {
 		}
 		// only ipv4 clears this since ipv6 has colons
 		conMode = "tcp4"
-		log.Println("HERE")
 		return remoteNode, conMode, nil
 	} else if colonCount == 1 && IP4(strings.Split(remoteNode, ":")[0]) {
 		// custom port on ipv4

--- a/wallit/init.go
+++ b/wallit/init.go
@@ -55,7 +55,7 @@ func NewWallit(
 	}
 	// get height
 	height := w.CurrentHeight()
-	log.Printf("DB height %d\n", height)
+	log.Printf("DB current height %d\n", height)
 
 	// bring height up to birthheight, or back down in case of resync
 	if height < birthHeight || resync {
@@ -63,7 +63,7 @@ func NewWallit(
 		w.SetDBSyncHeight(height)
 	}
 
-	log.Printf("DB height %d\n", height)
+	log.Printf("DB corrected height %d\n", height)
 	incomingTx, incomingBlockheight, err := w.Hook.Start(height, spvhost, wallitpath, p)
 	if err != nil {
 		log.Printf("NewWallit Hook.Start crash  %s ", err.Error())


### PR DESCRIPTION
Delete one rogue `log.Println`message and modify another one. In most cases, the log reads 
```
DB height 1325523
DB height 1325523
```
and in the event of resync, something like 
```
DB height 1325523
DB height 1300000
```
which is somewhat weird.