### PR TITLE
Add stopEx bool to CheckHelpCommand

### DIFF
--- a/cmd/lit-af/chancmds.go
+++ b/cmd/lit-af/chancmds.go
@@ -118,21 +118,24 @@ func (lc *litAfClient) History(textArgs []string) error {
 	return nil
 }
 
-func CheckHelpCommand(command *Command, textArgs []string, expectedLength int) (error, bool) {
+// CheckHelpCommand checks whether the user wants help regarding the command
+// or passed invalid arguments. Also checks for expected length of command
+// and returns and error if the expected length is different.
+func CheckHelpCommand(command *Command, textArgs []string, expectedLength int) (bool, error) {
 	if len(textArgs) > 0 && textArgs[0] == "-h" {
 		fmt.Fprintf(color.Output, command.Format)
 		fmt.Fprintf(color.Output, command.Description)
-		return nil, true // stop Execution if the guy just wants help
+		return true, nil // stop Execution if the guy just wants help
 	}
 	if len(textArgs) < expectedLength {
 		// if number of args are less than expected, return
-		return fmt.Errorf(command.Format), true // stop execution in case of err
+		return true, fmt.Errorf(command.Format) // stop execution in case of err
 	}
-	return nil, false
+	return false, nil
 }
 
 func (lc *litAfClient) FundChannel(textArgs []string) error {
-	err, stopEx := CheckHelpCommand(fundCommand, textArgs, 4)
+	stopEx, err := CheckHelpCommand(fundCommand, textArgs, 4)
 	if err != nil || stopEx {
 		return err
 	}
@@ -182,7 +185,7 @@ func (lc *litAfClient) FundChannel(textArgs []string) error {
 }
 
 func (lc *litAfClient) DualFund(textArgs []string) error {
-	err, stopEx := CheckHelpCommand(dualFundCommand, textArgs, 2)
+	stopEx, err := CheckHelpCommand(dualFundCommand, textArgs, 2)
 	if err != nil || stopEx {
 		return err
 	}
@@ -191,7 +194,7 @@ func (lc *litAfClient) DualFund(textArgs []string) error {
 
 // Mutually fund a channel
 func (lc *litAfClient) DualFundChannel(textArgs []string) error {
-	err, stopEx := CheckHelpCommand(dualFundStartCommand, textArgs, 4)
+	stopEx, err := CheckHelpCommand(dualFundStartCommand, textArgs, 4)
 	if err != nil || stopEx {
 		return err
 	}
@@ -234,7 +237,7 @@ func (lc *litAfClient) DualFundChannel(textArgs []string) error {
 
 // Decline mutual funding of a channel
 func (lc *litAfClient) DualFundDecline(textArgs []string) error {
-	err, stopEx := CheckHelpCommand(dualFundDeclineCommand, textArgs, 0)
+	stopEx, err := CheckHelpCommand(dualFundDeclineCommand, textArgs, 0)
 	if err != nil || stopEx {
 		return err
 	}
@@ -252,7 +255,7 @@ func (lc *litAfClient) DualFundDecline(textArgs []string) error {
 
 // Accept mutual funding of a channel
 func (lc *litAfClient) DualFundAccept(textArgs []string) error {
-	err, stopEx := CheckHelpCommand(dualFundAcceptCommand, textArgs, 0)
+	stopEx, err := CheckHelpCommand(dualFundAcceptCommand, textArgs, 0)
 	if err != nil || stopEx {
 		return err
 	}
@@ -270,7 +273,7 @@ func (lc *litAfClient) DualFundAccept(textArgs []string) error {
 
 // Request close of a channel.  Need to pass in peer, channel index
 func (lc *litAfClient) CloseChannel(textArgs []string) error {
-	err, stopEx := CheckHelpCommand(closeCommand, textArgs, 1)
+	stopEx, err := CheckHelpCommand(closeCommand, textArgs, 1)
 	if err != nil || stopEx {
 		return err
 	}
@@ -296,7 +299,7 @@ func (lc *litAfClient) CloseChannel(textArgs []string) error {
 
 // Almost exactly the same as CloseChannel.  Maybe make "break" a bool...?
 func (lc *litAfClient) BreakChannel(textArgs []string) error {
-	err, stopEx := CheckHelpCommand(breakCommand, textArgs, 1)
+	stopEx, err := CheckHelpCommand(breakCommand, textArgs, 1)
 	if err != nil || stopEx {
 		return err
 	}
@@ -322,7 +325,7 @@ func (lc *litAfClient) BreakChannel(textArgs []string) error {
 
 // Push is the shell command which calls PushChannel
 func (lc *litAfClient) Push(textArgs []string) error {
-	err, stopEx := CheckHelpCommand(pushCommand, textArgs, 2)
+	stopEx, err := CheckHelpCommand(pushCommand, textArgs, 2)
 	if err != nil || stopEx {
 		return err
 	}
@@ -406,7 +409,7 @@ func (lc *litAfClient) Dump(textArgs []string) error {
 }
 
 func (lc *litAfClient) Watch(textArgs []string) error {
-	err, stopEx := CheckHelpCommand(watchCommand, textArgs, 2)
+	stopEx, err := CheckHelpCommand(watchCommand, textArgs, 2)
 	if err != nil || stopEx {
 		return err
 	}

--- a/cmd/lit-af/chancmds.go
+++ b/cmd/lit-af/chancmds.go
@@ -118,21 +118,22 @@ func (lc *litAfClient) History(textArgs []string) error {
 	return nil
 }
 
-func CheckHelpCommand(command *Command, textArgs []string, expectedLength int) error {
+func CheckHelpCommand(command *Command, textArgs []string, expectedLength int) (error, bool) {
 	if len(textArgs) > 0 && textArgs[0] == "-h" {
 		fmt.Fprintf(color.Output, command.Format)
 		fmt.Fprintf(color.Output, command.Description)
+		return nil, true // stop Execution if the guy just wants help
 	}
 	if len(textArgs) < expectedLength {
 		// if number of args are less than expected, return
-		return fmt.Errorf(command.Format)
+		return fmt.Errorf(command.Format), true // stop execution in case of err
 	}
-	return nil
+	return nil, false
 }
 
 func (lc *litAfClient) FundChannel(textArgs []string) error {
-	err := CheckHelpCommand(fundCommand, textArgs, 4)
-	if err != nil {
+	err, stopEx := CheckHelpCommand(fundCommand, textArgs, 4)
+	if err != nil || stopEx {
 		return err
 	}
 	args := new(litrpc.FundArgs)
@@ -181,14 +182,17 @@ func (lc *litAfClient) FundChannel(textArgs []string) error {
 }
 
 func (lc *litAfClient) DualFund(textArgs []string) error {
-	err := CheckHelpCommand(dualFundCommand, textArgs, 2)
-	return err
+	err, stopEx := CheckHelpCommand(dualFundCommand, textArgs, 2)
+	if err != nil || stopEx {
+		return err
+	}
+	return nil
 }
 
 // Mutually fund a channel
 func (lc *litAfClient) DualFundChannel(textArgs []string) error {
-	err := CheckHelpCommand(dualFundStartCommand, textArgs, 4)
-	if err != nil {
+	err, stopEx := CheckHelpCommand(dualFundStartCommand, textArgs, 4)
+	if err != nil || stopEx {
 		return err
 	}
 
@@ -230,8 +234,8 @@ func (lc *litAfClient) DualFundChannel(textArgs []string) error {
 
 // Decline mutual funding of a channel
 func (lc *litAfClient) DualFundDecline(textArgs []string) error {
-	err := CheckHelpCommand(dualFundDeclineCommand, textArgs, 0)
-	if err != nil {
+	err, stopEx := CheckHelpCommand(dualFundDeclineCommand, textArgs, 0)
+	if err != nil || stopEx {
 		return err
 	}
 
@@ -248,8 +252,8 @@ func (lc *litAfClient) DualFundDecline(textArgs []string) error {
 
 // Accept mutual funding of a channel
 func (lc *litAfClient) DualFundAccept(textArgs []string) error {
-	err := CheckHelpCommand(dualFundAcceptCommand, textArgs, 0)
-	if err != nil {
+	err, stopEx := CheckHelpCommand(dualFundAcceptCommand, textArgs, 0)
+	if err != nil || stopEx {
 		return err
 	}
 
@@ -266,8 +270,8 @@ func (lc *litAfClient) DualFundAccept(textArgs []string) error {
 
 // Request close of a channel.  Need to pass in peer, channel index
 func (lc *litAfClient) CloseChannel(textArgs []string) error {
-	err := CheckHelpCommand(closeCommand, textArgs, 1)
-	if err != nil {
+	err, stopEx := CheckHelpCommand(closeCommand, textArgs, 1)
+	if err != nil || stopEx {
 		return err
 	}
 
@@ -292,8 +296,8 @@ func (lc *litAfClient) CloseChannel(textArgs []string) error {
 
 // Almost exactly the same as CloseChannel.  Maybe make "break" a bool...?
 func (lc *litAfClient) BreakChannel(textArgs []string) error {
-	err := CheckHelpCommand(breakCommand, textArgs, 1)
-	if err != nil {
+	err, stopEx := CheckHelpCommand(breakCommand, textArgs, 1)
+	if err != nil || stopEx {
 		return err
 	}
 
@@ -318,8 +322,8 @@ func (lc *litAfClient) BreakChannel(textArgs []string) error {
 
 // Push is the shell command which calls PushChannel
 func (lc *litAfClient) Push(textArgs []string) error {
-	err := CheckHelpCommand(pushCommand, textArgs, 2)
-	if err != nil {
+	err, stopEx := CheckHelpCommand(pushCommand, textArgs, 2)
+	if err != nil || stopEx {
 		return err
 	}
 
@@ -402,8 +406,8 @@ func (lc *litAfClient) Dump(textArgs []string) error {
 }
 
 func (lc *litAfClient) Watch(textArgs []string) error {
-	err := CheckHelpCommand(watchCommand, textArgs, 2)
-	if err != nil {
+	err, stopEx := CheckHelpCommand(watchCommand, textArgs, 2)
+	if err != nil || stopEx {
 		return err
 	}
 

--- a/cmd/lit-af/dlccmds.go
+++ b/cmd/lit-af/dlccmds.go
@@ -400,8 +400,8 @@ func (lc *litAfClient) DlcListOracles(textArgs []string) error {
 }
 
 func (lc *litAfClient) DlcImportOracle(textArgs []string) error {
-	err := CheckHelpCommand(importOracleCommand, textArgs, 2)
-	if err != nil {
+	err, stopEx := CheckHelpCommand(importOracleCommand, textArgs, 2)
+	if err != nil || stopEx {
 		return err
 	}
 
@@ -422,8 +422,8 @@ func (lc *litAfClient) DlcImportOracle(textArgs []string) error {
 }
 
 func (lc *litAfClient) DlcAddOracle(textArgs []string) error {
-	err := CheckHelpCommand(addOracleCommand, textArgs, 2)
-	if err != nil {
+	err, stopEx := CheckHelpCommand(addOracleCommand, textArgs, 2)
+	if err != nil || stopEx {
 		return err
 	}
 
@@ -556,8 +556,8 @@ func (lc *litAfClient) DlcNewContract(textArgs []string) error {
 }
 
 func (lc *litAfClient) DlcViewContract(textArgs []string) error {
-	err := CheckHelpCommand(viewContractCommand, textArgs, 1)
-	if err != nil {
+	err, stopEx := CheckHelpCommand(viewContractCommand, textArgs, 1)
+	if err != nil || stopEx {
 		return err
 	}
 
@@ -580,8 +580,8 @@ func (lc *litAfClient) DlcViewContract(textArgs []string) error {
 }
 
 func (lc *litAfClient) DlcViewContractPayout(textArgs []string) error {
-	err := CheckHelpCommand(viewContractPayoutCommand, textArgs, 4)
-	if err != nil {
+	err, stopEx := CheckHelpCommand(viewContractPayoutCommand, textArgs, 4)
+	if err != nil || stopEx {
 		return err
 	}
 
@@ -617,8 +617,8 @@ func (lc *litAfClient) DlcViewContractPayout(textArgs []string) error {
 }
 
 func (lc *litAfClient) DlcSetContractOracle(textArgs []string) error {
-	err := CheckHelpCommand(setContractOracleCommand, textArgs, 2)
-	if err != nil {
+	err, stopEx := CheckHelpCommand(setContractOracleCommand, textArgs, 2)
+	if err != nil || stopEx {
 		return err
 	}
 
@@ -647,8 +647,8 @@ func (lc *litAfClient) DlcSetContractOracle(textArgs []string) error {
 }
 
 func (lc *litAfClient) DlcSetContractDatafeed(textArgs []string) error {
-	err := CheckHelpCommand(setContractDatafeedCommand, textArgs, 2)
-	if err != nil {
+	err, stopEx := CheckHelpCommand(setContractDatafeedCommand, textArgs, 2)
+	if err != nil || stopEx {
 		return err
 	}
 
@@ -677,8 +677,8 @@ func (lc *litAfClient) DlcSetContractDatafeed(textArgs []string) error {
 }
 
 func (lc *litAfClient) DlcSetContractRPoint(textArgs []string) error {
-	err := CheckHelpCommand(setContractRPointCommand, textArgs, 2)
-	if err != nil {
+	err, stopEx := CheckHelpCommand(setContractRPointCommand, textArgs, 2)
+	if err != nil || stopEx {
 		return err
 	}
 
@@ -707,8 +707,8 @@ func (lc *litAfClient) DlcSetContractRPoint(textArgs []string) error {
 }
 
 func (lc *litAfClient) DlcSetContractSettlementTime(textArgs []string) error {
-	err := CheckHelpCommand(setContractSettlementTimeCommand, textArgs, 2)
-	if err != nil {
+	err, stopEx := CheckHelpCommand(setContractSettlementTimeCommand, textArgs, 2)
+	if err != nil || stopEx {
 		return err
 	}
 
@@ -737,8 +737,8 @@ func (lc *litAfClient) DlcSetContractSettlementTime(textArgs []string) error {
 }
 
 func (lc *litAfClient) DlcSetContractFunding(textArgs []string) error {
-	err := CheckHelpCommand(setContractFundingCommand, textArgs, 3)
-	if err != nil {
+	err, stopEx := CheckHelpCommand(setContractFundingCommand, textArgs, 3)
+	if err != nil || stopEx {
 		return err
 	}
 
@@ -772,8 +772,8 @@ func (lc *litAfClient) DlcSetContractFunding(textArgs []string) error {
 }
 
 func (lc *litAfClient) DlcSetContractCoinType(textArgs []string) error {
-	err := CheckHelpCommand(setContractCoinTypeCommand, textArgs, 2)
-	if err != nil {
+	err, stopEx := CheckHelpCommand(setContractCoinTypeCommand, textArgs, 2)
+	if err != nil || stopEx {
 		return err
 	}
 
@@ -803,8 +803,8 @@ func (lc *litAfClient) DlcSetContractCoinType(textArgs []string) error {
 }
 
 func (lc *litAfClient) DlcSetContractDivision(textArgs []string) error {
-	err := CheckHelpCommand(setContractDivisionCommand, textArgs, 3)
-	if err != nil {
+	err, stopEx := CheckHelpCommand(setContractDivisionCommand, textArgs, 3)
+	if err != nil || stopEx {
 		return err
 	}
 
@@ -838,8 +838,8 @@ func (lc *litAfClient) DlcSetContractDivision(textArgs []string) error {
 }
 
 func (lc *litAfClient) DlcOfferContract(textArgs []string) error {
-	err := CheckHelpCommand(offerContractCommand, textArgs, 2)
-	if err != nil {
+	err, stopEx := CheckHelpCommand(offerContractCommand, textArgs, 2)
+	if err != nil || stopEx {
 		return err
 	}
 
@@ -869,8 +869,8 @@ func (lc *litAfClient) DlcOfferContract(textArgs []string) error {
 }
 
 func (lc *litAfClient) DlcDeclineContract(textArgs []string) error {
-	err := CheckHelpCommand(declineContractCommand, textArgs, 1)
-	if err != nil {
+	err, stopEx := CheckHelpCommand(declineContractCommand, textArgs, 1)
+	if err != nil || stopEx {
 		return err
 	}
 
@@ -895,8 +895,8 @@ func (lc *litAfClient) DlcDeclineContract(textArgs []string) error {
 }
 
 func (lc *litAfClient) DlcAcceptContract(textArgs []string) error {
-	err := CheckHelpCommand(acceptContractCommand, textArgs, 1)
-	if err != nil {
+	err, stopEx := CheckHelpCommand(acceptContractCommand, textArgs, 1)
+	if err != nil || stopEx {
 		return err
 	}
 
@@ -921,8 +921,8 @@ func (lc *litAfClient) DlcAcceptContract(textArgs []string) error {
 }
 
 func (lc *litAfClient) DlcSettleContract(textArgs []string) error {
-	err := CheckHelpCommand(settleContractCommand, textArgs, 3)
-	if err != nil {
+	err, stopEx := CheckHelpCommand(settleContractCommand, textArgs, 3)
+	if err != nil || stopEx {
 		return err
 	}
 

--- a/cmd/lit-af/dlccmds.go
+++ b/cmd/lit-af/dlccmds.go
@@ -400,7 +400,7 @@ func (lc *litAfClient) DlcListOracles(textArgs []string) error {
 }
 
 func (lc *litAfClient) DlcImportOracle(textArgs []string) error {
-	err, stopEx := CheckHelpCommand(importOracleCommand, textArgs, 2)
+	stopEx, err := CheckHelpCommand(importOracleCommand, textArgs, 2)
 	if err != nil || stopEx {
 		return err
 	}
@@ -422,7 +422,7 @@ func (lc *litAfClient) DlcImportOracle(textArgs []string) error {
 }
 
 func (lc *litAfClient) DlcAddOracle(textArgs []string) error {
-	err, stopEx := CheckHelpCommand(addOracleCommand, textArgs, 2)
+	stopEx, err := CheckHelpCommand(addOracleCommand, textArgs, 2)
 	if err != nil || stopEx {
 		return err
 	}
@@ -556,7 +556,7 @@ func (lc *litAfClient) DlcNewContract(textArgs []string) error {
 }
 
 func (lc *litAfClient) DlcViewContract(textArgs []string) error {
-	err, stopEx := CheckHelpCommand(viewContractCommand, textArgs, 1)
+	stopEx, err := CheckHelpCommand(viewContractCommand, textArgs, 1)
 	if err != nil || stopEx {
 		return err
 	}
@@ -580,7 +580,7 @@ func (lc *litAfClient) DlcViewContract(textArgs []string) error {
 }
 
 func (lc *litAfClient) DlcViewContractPayout(textArgs []string) error {
-	err, stopEx := CheckHelpCommand(viewContractPayoutCommand, textArgs, 4)
+	stopEx, err := CheckHelpCommand(viewContractPayoutCommand, textArgs, 4)
 	if err != nil || stopEx {
 		return err
 	}
@@ -617,7 +617,7 @@ func (lc *litAfClient) DlcViewContractPayout(textArgs []string) error {
 }
 
 func (lc *litAfClient) DlcSetContractOracle(textArgs []string) error {
-	err, stopEx := CheckHelpCommand(setContractOracleCommand, textArgs, 2)
+	stopEx, err := CheckHelpCommand(setContractOracleCommand, textArgs, 2)
 	if err != nil || stopEx {
 		return err
 	}
@@ -647,7 +647,7 @@ func (lc *litAfClient) DlcSetContractOracle(textArgs []string) error {
 }
 
 func (lc *litAfClient) DlcSetContractDatafeed(textArgs []string) error {
-	err, stopEx := CheckHelpCommand(setContractDatafeedCommand, textArgs, 2)
+	stopEx, err := CheckHelpCommand(setContractDatafeedCommand, textArgs, 2)
 	if err != nil || stopEx {
 		return err
 	}
@@ -677,7 +677,7 @@ func (lc *litAfClient) DlcSetContractDatafeed(textArgs []string) error {
 }
 
 func (lc *litAfClient) DlcSetContractRPoint(textArgs []string) error {
-	err, stopEx := CheckHelpCommand(setContractRPointCommand, textArgs, 2)
+	stopEx, err := CheckHelpCommand(setContractRPointCommand, textArgs, 2)
 	if err != nil || stopEx {
 		return err
 	}
@@ -707,7 +707,7 @@ func (lc *litAfClient) DlcSetContractRPoint(textArgs []string) error {
 }
 
 func (lc *litAfClient) DlcSetContractSettlementTime(textArgs []string) error {
-	err, stopEx := CheckHelpCommand(setContractSettlementTimeCommand, textArgs, 2)
+	stopEx, err := CheckHelpCommand(setContractSettlementTimeCommand, textArgs, 2)
 	if err != nil || stopEx {
 		return err
 	}
@@ -737,7 +737,7 @@ func (lc *litAfClient) DlcSetContractSettlementTime(textArgs []string) error {
 }
 
 func (lc *litAfClient) DlcSetContractFunding(textArgs []string) error {
-	err, stopEx := CheckHelpCommand(setContractFundingCommand, textArgs, 3)
+	stopEx, err := CheckHelpCommand(setContractFundingCommand, textArgs, 3)
 	if err != nil || stopEx {
 		return err
 	}
@@ -772,7 +772,7 @@ func (lc *litAfClient) DlcSetContractFunding(textArgs []string) error {
 }
 
 func (lc *litAfClient) DlcSetContractCoinType(textArgs []string) error {
-	err, stopEx := CheckHelpCommand(setContractCoinTypeCommand, textArgs, 2)
+	stopEx, err := CheckHelpCommand(setContractCoinTypeCommand, textArgs, 2)
 	if err != nil || stopEx {
 		return err
 	}
@@ -803,7 +803,7 @@ func (lc *litAfClient) DlcSetContractCoinType(textArgs []string) error {
 }
 
 func (lc *litAfClient) DlcSetContractDivision(textArgs []string) error {
-	err, stopEx := CheckHelpCommand(setContractDivisionCommand, textArgs, 3)
+	stopEx, err := CheckHelpCommand(setContractDivisionCommand, textArgs, 3)
 	if err != nil || stopEx {
 		return err
 	}
@@ -838,7 +838,7 @@ func (lc *litAfClient) DlcSetContractDivision(textArgs []string) error {
 }
 
 func (lc *litAfClient) DlcOfferContract(textArgs []string) error {
-	err, stopEx := CheckHelpCommand(offerContractCommand, textArgs, 2)
+	stopEx, err := CheckHelpCommand(offerContractCommand, textArgs, 2)
 	if err != nil || stopEx {
 		return err
 	}
@@ -869,7 +869,7 @@ func (lc *litAfClient) DlcOfferContract(textArgs []string) error {
 }
 
 func (lc *litAfClient) DlcDeclineContract(textArgs []string) error {
-	err, stopEx := CheckHelpCommand(declineContractCommand, textArgs, 1)
+	stopEx, err := CheckHelpCommand(declineContractCommand, textArgs, 1)
 	if err != nil || stopEx {
 		return err
 	}
@@ -895,7 +895,7 @@ func (lc *litAfClient) DlcDeclineContract(textArgs []string) error {
 }
 
 func (lc *litAfClient) DlcAcceptContract(textArgs []string) error {
-	err, stopEx := CheckHelpCommand(acceptContractCommand, textArgs, 1)
+	stopEx, err := CheckHelpCommand(acceptContractCommand, textArgs, 1)
 	if err != nil || stopEx {
 		return err
 	}
@@ -921,7 +921,7 @@ func (lc *litAfClient) DlcAcceptContract(textArgs []string) error {
 }
 
 func (lc *litAfClient) DlcSettleContract(textArgs []string) error {
-	err, stopEx := CheckHelpCommand(settleContractCommand, textArgs, 3)
+	stopEx, err := CheckHelpCommand(settleContractCommand, textArgs, 3)
 	if err != nil || stopEx {
 		return err
 	}

--- a/cmd/lit-af/netcmds.go
+++ b/cmd/lit-af/netcmds.go
@@ -136,8 +136,8 @@ func (lc *litAfClient) Connect(textArgs []string) error {
 }
 
 func (lc *litAfClient) Say(textArgs []string) error {
-	err := CheckHelpCommand(sayCommand, textArgs, 2)
-	if err != nil {
+	err, stopEx := CheckHelpCommand(sayCommand, textArgs, 2)
+	if err != nil || stopEx {
 		return err
 	}
 

--- a/cmd/lit-af/netcmds.go
+++ b/cmd/lit-af/netcmds.go
@@ -136,7 +136,7 @@ func (lc *litAfClient) Connect(textArgs []string) error {
 }
 
 func (lc *litAfClient) Say(textArgs []string) error {
-	err, stopEx := CheckHelpCommand(sayCommand, textArgs, 2)
+	stopEx, err := CheckHelpCommand(sayCommand, textArgs, 2)
 	if err != nil || stopEx {
 		return err
 	}

--- a/cmd/lit-af/walletcmds.go
+++ b/cmd/lit-af/walletcmds.go
@@ -42,8 +42,8 @@ var sweepCommand = &Command{
 
 // Send sends coins somewhere
 func (lc *litAfClient) Send(textArgs []string) error {
-	err := CheckHelpCommand(sendCommand, textArgs, 2)
-	if err != nil {
+	err, stopEx := CheckHelpCommand(sendCommand, textArgs, 2)
+	if err != nil || stopEx {
 		return err
 	}
 
@@ -80,8 +80,8 @@ func (lc *litAfClient) Send(textArgs []string) error {
 
 // Sweep moves utxos with many 1-in-1-out txs
 func (lc *litAfClient) Sweep(textArgs []string) error {
-	err := CheckHelpCommand(sweepCommand, textArgs, 2)
-	if err != nil {
+	err, stopEx := CheckHelpCommand(sweepCommand, textArgs, 2)
+	if err != nil || stopEx {
 		return err
 	}
 
@@ -118,8 +118,8 @@ func (lc *litAfClient) Sweep(textArgs []string) error {
 //}
 
 func (lc *litAfClient) Fan(textArgs []string) error {
-	err := CheckHelpCommand(fanCommand, textArgs, 3)
-	if err != nil {
+	err, stopEx := CheckHelpCommand(fanCommand, textArgs, 3)
+	if err != nil || stopEx {
 		return err
 	}
 
@@ -231,8 +231,8 @@ func (lc *litAfClient) SetFee(textArgs []string) error {
 
 // Address makes new addresses
 func (lc *litAfClient) Address(textArgs []string) error {
-	err := CheckHelpCommand(addressCommand, textArgs, 0)
-	if err != nil {
+	err, stopEx := CheckHelpCommand(addressCommand, textArgs, 0)
+	if err != nil || stopEx {
 		return err
 	}
 

--- a/cmd/lit-af/walletcmds.go
+++ b/cmd/lit-af/walletcmds.go
@@ -42,7 +42,7 @@ var sweepCommand = &Command{
 
 // Send sends coins somewhere
 func (lc *litAfClient) Send(textArgs []string) error {
-	err, stopEx := CheckHelpCommand(sendCommand, textArgs, 2)
+	stopEx, err := CheckHelpCommand(sendCommand, textArgs, 2)
 	if err != nil || stopEx {
 		return err
 	}
@@ -80,7 +80,7 @@ func (lc *litAfClient) Send(textArgs []string) error {
 
 // Sweep moves utxos with many 1-in-1-out txs
 func (lc *litAfClient) Sweep(textArgs []string) error {
-	err, stopEx := CheckHelpCommand(sweepCommand, textArgs, 2)
+	stopEx, err := CheckHelpCommand(sweepCommand, textArgs, 2)
 	if err != nil || stopEx {
 		return err
 	}
@@ -118,7 +118,7 @@ func (lc *litAfClient) Sweep(textArgs []string) error {
 //}
 
 func (lc *litAfClient) Fan(textArgs []string) error {
-	err, stopEx := CheckHelpCommand(fanCommand, textArgs, 3)
+	stopEx, err := CheckHelpCommand(fanCommand, textArgs, 3)
 	if err != nil || stopEx {
 		return err
 	}
@@ -231,7 +231,7 @@ func (lc *litAfClient) SetFee(textArgs []string) error {
 
 // Address makes new addresses
 func (lc *litAfClient) Address(textArgs []string) error {
-	err, stopEx := CheckHelpCommand(addressCommand, textArgs, 0)
+	stopEx, err := CheckHelpCommand(addressCommand, textArgs, 0)
 	if err != nil || stopEx {
 		return err
 	}


### PR DESCRIPTION
Earlier, we didn't have a way whether we should stop execution, instead we relied on the code that follow to do that for us. But this caused side effects like that in #231, which should now be solved with the introduction of this bool.