### PR TITLE
Initial version of the pay command

### DIFF
--- a/cmd/lit-af/shell.go
+++ b/cmd/lit-af/shell.go
@@ -87,6 +87,12 @@ func (lc *litAfClient) Shellparse(cmdslice []string) error {
 		return parseErr(err, "send")
 	}
 
+	// pay a lit address either on or off chain
+	if cmd == "pay" {
+		err = lc.Pay(args)
+		return parseErr(err, "pay")
+	}
+
 	if cmd == "lis" { // listen for lnd peers
 		err = lc.Lis(args)
 		return parseErr(err, "lis")
@@ -398,7 +404,7 @@ func printHelp(commands []*Command) {
 func printCointypes() {
 	for k, v := range coinparam.RegisteredNets {
 		fmt.Fprintf(color.Output, "CoinType: %s\n", strconv.Itoa(int(k)))
-		fmt.Fprintf(color.Output, "└────── Name: %-13sBech32Prefix: %s\n\n", v.Name + ",", v.Bech32Prefix)
+		fmt.Fprintf(color.Output, "└────── Name: %-13sBech32Prefix: %s\n\n", v.Name+",", v.Bech32Prefix)
 	}
 }
 

--- a/lnutil/msglib.go
+++ b/lnutil/msglib.go
@@ -60,6 +60,8 @@ const (
 	MSGID_DUALFUNDINGDECL    = 0xA2 // Declines the funding request
 	MSGID_DUALFUNDINGCHANACK = 0xA3 // Acknowledges channel and sends along signatures for funding
 
+	MSGID_ONCHAIN_PAYMENT_REQ   = 0xC0 // Requests an on-chain address from the remote node to send money if a channel is unavailable
+	MSGID_ONCHAIN_PAYMENT_REPLY = 0xC1 // Response containing an on-chain address to use
 )
 
 //interface that all messages follow, for easy use
@@ -151,6 +153,11 @@ func LitMsgFromBytes(b []byte, peerid uint32) (LitMsg, error) {
 		return NewDlcContractFundingSigsMsgFromBytes(b, peerid)
 	case MSGID_DLC_SIGPROOF:
 		return NewDlcContractSigProofMsgFromBytes(b, peerid)
+
+	case MSGID_ONCHAIN_PAYMENT_REQ:
+		return NewOnChainPaymentRequestMsgFromBytes(b, peerid)
+	case MSGID_ONCHAIN_PAYMENT_REPLY:
+		return NewOnChainPaymentReplyMsgFromBytes(b, peerid)
 
 	default:
 		return nil, fmt.Errorf("Unknown message of type %d ", msgType)
@@ -1721,4 +1728,119 @@ func (msg DlcContractSigProofMsg) Peer() uint32 {
 // MsgType returns the type of this message
 func (msg DlcContractSigProofMsg) MsgType() uint8 {
 	return MSGID_DLC_SIGPROOF
+}
+
+type OnChainPaymentRequestMsg struct {
+	// The index of the peer we're communicating with
+	PeerIdx uint32
+	// The coin we need an address for
+	CoinType uint32
+	// The data for the payment
+	Data [32]byte
+}
+
+func NewOnChainPaymentRequestMsg(peerIdx, coinType uint32, data [32]byte) OnChainPaymentRequestMsg {
+
+	msg := new(OnChainPaymentRequestMsg)
+	msg.PeerIdx = peerIdx
+	msg.CoinType = coinType
+	msg.Data = data
+	return *msg
+}
+
+func NewOnChainPaymentRequestMsgFromBytes(b []byte,
+	peerIdx uint32) (OnChainPaymentRequestMsg, error) {
+
+	msg := new(OnChainPaymentRequestMsg)
+	msg.PeerIdx = peerIdx
+
+	// TODO
+	if len(b) < 34 {
+		return *msg, fmt.Errorf("OnChainPaymentRequestMsg %d bytes, expect"+
+			" at least 34", len(b))
+	}
+
+	buf := bytes.NewBuffer(b[1:]) // get rid of messageType
+	coinType, _ := wire.ReadVarInt(buf, 0)
+	msg.CoinType = uint32(coinType)
+	copy(msg.Data[:], buf.Next(32))
+
+	return *msg, nil
+}
+
+// Bytes serializes a OnChainPaymentRequestMsg into a byte array
+func (msg OnChainPaymentRequestMsg) Bytes() []byte {
+	var buf bytes.Buffer
+
+	buf.WriteByte(msg.MsgType())
+	wire.WriteVarInt(&buf, 0, uint64(msg.CoinType))
+	buf.Write(msg.Data[:])
+	return buf.Bytes()
+}
+
+// Peer returns the peer index this message was received from/sent to
+func (msg OnChainPaymentRequestMsg) Peer() uint32 {
+	return msg.PeerIdx
+}
+
+// MsgType returns the type of this message
+func (msg OnChainPaymentRequestMsg) MsgType() uint8 {
+	return MSGID_ONCHAIN_PAYMENT_REQ
+}
+
+type OnChainPaymentReplyMsg struct {
+	// The index of the peer we're communicating with
+	PeerIdx uint32
+	// The data for the payment
+	Data [32]byte
+	// The address the on-chain funds should go to
+	PKH [20]byte
+}
+
+func NewOnChainPaymentReplyMsg(peerIdx uint32, data [32]byte, pkh [20]byte) OnChainPaymentReplyMsg {
+
+	msg := new(OnChainPaymentReplyMsg)
+	msg.PeerIdx = peerIdx
+	msg.Data = data
+	msg.PKH = pkh
+	return *msg
+}
+
+func NewOnChainPaymentReplyMsgFromBytes(b []byte,
+	peerIdx uint32) (OnChainPaymentReplyMsg, error) {
+
+	msg := new(OnChainPaymentReplyMsg)
+	msg.PeerIdx = peerIdx
+
+	// TODO
+	if len(b) < 53 {
+		return *msg, fmt.Errorf("OnChainPaymentReplyMsg %d bytes, expect"+
+			" at least 34", len(b))
+	}
+
+	buf := bytes.NewBuffer(b[1:]) // get rid of messageType
+	copy(msg.Data[:], buf.Next(32))
+	copy(msg.PKH[:], buf.Next(20))
+
+	return *msg, nil
+}
+
+// Bytes serializes a OnChainPaymentReplyMsg into a byte array
+func (msg OnChainPaymentReplyMsg) Bytes() []byte {
+	var buf bytes.Buffer
+
+	buf.WriteByte(msg.MsgType())
+	buf.Write(msg.Data[:])
+	buf.Write(msg.PKH[:])
+	return buf.Bytes()
+}
+
+// Peer returns the peer index this message was received from/sent to
+func (msg OnChainPaymentReplyMsg) Peer() uint32 {
+	return msg.PeerIdx
+}
+
+// MsgType returns the type of this message
+func (msg OnChainPaymentReplyMsg) MsgType() uint8 {
+	return MSGID_ONCHAIN_PAYMENT_REPLY
 }

--- a/qln/init.go
+++ b/qln/init.go
@@ -73,6 +73,8 @@ func NewLitNode(privKey *[32]byte, path string, trackerURL string, proxyURL stri
 	nd.InProgDual = new(InFlightDualFund)
 	nd.InProgDual.done = make(chan *DualFundingResult, 1)
 
+	nd.InFlightSends = make([]*InFlightSend, 0)
+
 	nd.RemoteCons = make(map[uint32]*RemotePeer)
 
 	nd.SubWallet = make(map[uint32]UWallet)

--- a/qln/lndb.go
+++ b/qln/lndb.go
@@ -6,15 +6,15 @@ import (
 	"sync"
 	"time"
 
-	"github.com/mit-dci/lit/btcutil/btcec"
-	"github.com/mit-dci/lit/wire"
-	"github.com/mit-dci/lit/btcutil"
 	"github.com/boltdb/bolt"
+	"github.com/mit-dci/lit/btcutil"
+	"github.com/mit-dci/lit/btcutil/btcec"
 	"github.com/mit-dci/lit/dlc"
 	"github.com/mit-dci/lit/elkrem"
 	"github.com/mit-dci/lit/lndc"
 	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/watchtower"
+	"github.com/mit-dci/lit/wire"
 )
 
 /*
@@ -122,6 +122,7 @@ type LitNode struct {
 	// the current channel in process of being dual funded
 	InProgDual *InFlightDualFund
 
+	InFlightSends []*InFlightSend
 	// Nodes don't have Params; their SubWallets do
 	// Param *chaincfg.Params // network parameters (testnet3, segnet, etc)
 
@@ -148,6 +149,13 @@ type RemotePeer struct {
 	Con      *lndc.LNDConn
 	QCs      map[uint32]*Qchan   // keep map of all peer's channels in ram
 	OpMap    map[[36]byte]uint32 // quick lookup for channels
+}
+
+// InFlightSend is a send transaction that is waiting for an on-chain address
+type InFlightSend struct {
+	PeerIdx, CoinType uint32
+	Amt               int64
+	Data              [32]byte
 }
 
 // InFlightFund is a funding transaction that has not yet been broadcast
@@ -245,6 +253,21 @@ func (nd *LitNode) GetPubHostFromPeerIdx(idx uint32) ([33]byte, string) {
 		log.Printf(err.Error())
 	}
 	return pub, host
+}
+
+func (nd *LitNode) GetPeerIdxFromAdr(lnAdr string) uint32 {
+	peerIdx := uint32(0)
+	nd.RemoteMtx.Lock()
+	var pubKey [33]byte
+	for _, c := range nd.RemoteCons {
+		copy(pubKey[:], c.Con.RemotePub.SerializeCompressed())
+		adr := lnutil.LitAdrFromPubkey(pubKey)
+		if adr == lnAdr {
+			peerIdx = c.Idx
+		}
+	}
+	nd.RemoteMtx.Unlock()
+	return peerIdx
 }
 
 // GetNicknameFromPeerIdx gets the nickname for a peer

--- a/qln/msghandler.go
+++ b/qln/msghandler.go
@@ -6,9 +6,9 @@ import (
 	"log"
 
 	"github.com/mit-dci/lit/btcutil/txscript"
-	"github.com/mit-dci/lit/wire"
 	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/portxo"
+	"github.com/mit-dci/lit/wire"
 )
 
 // handles stuff that comes in over the wire.  Not user-initiated.
@@ -62,6 +62,14 @@ func (nd *LitNode) PeerHandler(msg lnutil.LitMsg, q *Qchan, peer *RemotePeer) er
 
 	case 0xA0: // Dual Funding messages
 		return nd.DualFundingHandler(msg, peer)
+
+	case 0xC0: // On-chain payment messages
+		if msg.MsgType() == lnutil.MSGID_ONCHAIN_PAYMENT_REQ {
+			nd.OnChainPaymentRequestMsgHandler(msg.(lnutil.OnChainPaymentRequestMsg), peer)
+		}
+		if msg.MsgType() == lnutil.MSGID_ONCHAIN_PAYMENT_REPLY {
+			nd.OnChainPaymentReplyMsgHandler(msg.(lnutil.OnChainPaymentReplyMsg), peer)
+		}
 
 	case 0x90: // Discreet log contract messages
 		if msg.MsgType() == lnutil.MSGID_DLC_OFFER {

--- a/qln/onchainsend.go
+++ b/qln/onchainsend.go
@@ -1,0 +1,102 @@
+package qln
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/mit-dci/lit/lnutil"
+	"github.com/mit-dci/lit/wire"
+)
+
+func (nd *LitNode) OnChainSend(lnAdr string, coinType uint32, amt int64, data [32]byte) error {
+
+	// Check if we have a wallet of the requested coin type
+	wal, ok := nd.SubWallet[coinType]
+	if !ok {
+		return fmt.Errorf("No wallet for coinType [%d]", coinType)
+	}
+
+	// OK, so pushing over a channel was not possible. Let's check if
+	// we still have enough funds in our "on-chain wallet"
+	_, _, err := wal.PickUtxos(amt, 500, wal.Fee(), false)
+	if err != nil {
+		return err
+	}
+
+	inFlight := new(InFlightSend)
+	inFlight.PeerIdx = nd.GetPeerIdxFromAdr(lnAdr)
+
+	if inFlight.PeerIdx == 0 {
+		// Connect first!
+		err := nd.DialPeer(lnAdr)
+		if err != nil {
+			return err
+		}
+		inFlight.PeerIdx = nd.GetPeerIdxFromAdr(lnAdr)
+	}
+
+	inFlight.Amt = amt
+	inFlight.CoinType = coinType
+	inFlight.Data = data
+
+	nd.RemoteMtx.Lock()
+	nd.InFlightSends = append(nd.InFlightSends, inFlight)
+	nd.RemoteMtx.Unlock()
+
+	msg := lnutil.NewOnChainPaymentRequestMsg(inFlight.PeerIdx, coinType, data)
+	nd.OmniOut <- msg
+	return nil
+}
+
+func (nd *LitNode) OnChainPaymentRequestMsgHandler(msg lnutil.OnChainPaymentRequestMsg, peer *RemotePeer) error {
+	wal, ok := nd.SubWallet[msg.CoinType]
+	if !ok {
+		return fmt.Errorf("Someone requested a payment address for cointype [%d] but we have no wallet for that.", msg.CoinType)
+	}
+
+	pkh, err := wal.NewAdr()
+	if err != nil {
+		return err
+	}
+
+	outMsg := lnutil.NewOnChainPaymentReplyMsg(msg.PeerIdx, msg.Data, pkh)
+	nd.OmniOut <- outMsg
+	return nil
+}
+
+func (nd *LitNode) OnChainPaymentReplyMsgHandler(msg lnutil.OnChainPaymentReplyMsg, peer *RemotePeer) error {
+	// Received address. Find inflight send
+	var inFlight *InFlightSend
+
+	for _, ifs := range nd.InFlightSends {
+		if ifs.PeerIdx == msg.PeerIdx && bytes.Equal(ifs.Data[:], msg.Data[:]) {
+			inFlight = ifs
+		}
+	}
+
+	if inFlight == nil {
+		return fmt.Errorf("Someone sent us a payment address, but we don't have a matching inflight send waiting for them.")
+	}
+
+	wal, ok := nd.SubWallet[inFlight.CoinType]
+	if !ok {
+		// This should never happen
+		return fmt.Errorf("Somehow we have an inflight send for a cointype %d we don't support", inFlight.CoinType)
+	}
+
+	txOuts := make([]*wire.TxOut, 1)
+	txOuts[0] = wire.NewTxOut(inFlight.Amt, lnutil.DirectWPKHScriptFromPKH(msg.PKH))
+
+	// we don't care if it's witness or not
+	ops, err := wal.MaybeSend(txOuts, false)
+	if err != nil {
+		return err
+	}
+
+	err = wal.ReallySend(&ops[0].Hash)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
This is a first implementation of the pay command described in #234 

You simply say `pay [ln address] [coin type] [amount] [data]`

The node will look for an existing channel to the given address and enough capacity. If found, it will execute a regular `push`. If this isn't found, we will ask the given node for an on-chain address and then send funds from our wallet to that on-chain address via a regular on-chain transaction.