### PR TITLE
Only show those channels whose daemons are running

### DIFF
--- a/cmd/lit-af/shell.go
+++ b/cmd/lit-af/shell.go
@@ -229,7 +229,11 @@ func (lc *litAfClient) Ls(textArgs []string) error {
 	lReply := new(litrpc.ListeningPortsReply)
 	dfReply := new(litrpc.PendingDualFundReply)
 
-	err := lc.Call("LitRPC.ListConnections", nil, pReply)
+	err := lc.Call("LitRPC.Balance", nil, bReply)
+	if err != nil {
+		return err
+	}
+	err = lc.Call("LitRPC.ListConnections", nil, pReply)
 	if err != nil {
 		return err
 	}
@@ -264,14 +268,18 @@ func (lc *litAfClient) Ls(textArgs []string) error {
 	}
 
 	for _, c := range closedChannels {
-		fmt.Fprintf(color.Output, lnutil.Red("Closed:       "))
-		fmt.Fprintf(
-			color.Output,
-			"%s (peer %d) type %d %s\n\t cap: %s bal: %s h: %d state: %d data: %x pkh: %x\n",
-			lnutil.White(c.CIdx), c.PeerIdx, c.CoinType,
-			lnutil.OutPoint(c.OutPoint),
-			lnutil.SatoshiColor(c.Capacity), lnutil.SatoshiColor(c.MyBalance),
-			c.Height, c.StateNum, c.Data, c.Pkh)
+		for _, walBal := range bReply.Balances {
+			if walBal.CoinType == c.CoinType {
+				fmt.Fprintf(color.Output, lnutil.Red("Closed:       "))
+				fmt.Fprintf(
+					color.Output,
+					"%s (peer %d) type %d %s\n\t cap: %s bal: %s h: %d state: %d data: %x pkh: %x\n",
+					lnutil.White(c.CIdx), c.PeerIdx, c.CoinType,
+					lnutil.OutPoint(c.OutPoint),
+					lnutil.SatoshiColor(c.Capacity), lnutil.SatoshiColor(c.MyBalance),
+					c.Height, c.StateNum, c.Data, c.Pkh)
+			}
+		}
 	}
 
 	for _, c := range openChannels {
@@ -283,13 +291,17 @@ func (lc *litAfClient) Ls(textArgs []string) error {
 		} else {
 			fmt.Fprintf(color.Output, lnutil.Green("Open:         "))
 		}
-		fmt.Fprintf(
-			color.Output,
-			"%s (peer %d) type %d %s\n\t cap: %s bal: %s h: %d state: %d data: %x pkh: %x\n",
-			lnutil.White(c.CIdx), c.PeerIdx, c.CoinType,
-			lnutil.OutPoint(c.OutPoint),
-			lnutil.SatoshiColor(c.Capacity), lnutil.SatoshiColor(c.MyBalance),
-			c.Height, c.StateNum, c.Data, c.Pkh)
+		for _, walBal := range bReply.Balances {
+			if walBal.CoinType == c.CoinType {
+				fmt.Fprintf(
+					color.Output,
+					"%s (peer %d) type %d %s\n\t cap: %s bal: %s h: %d state: %d data: %x pkh: %x\n",
+					lnutil.White(c.CIdx), c.PeerIdx, c.CoinType,
+					lnutil.OutPoint(c.OutPoint),
+					lnutil.SatoshiColor(c.Capacity), lnutil.SatoshiColor(c.MyBalance),
+					c.Height, c.StateNum, c.Data, c.Pkh)
+			}
+		}
 	}
 
 	err = lc.Call("LitRPC.PendingDualFund", nil, dfReply)
@@ -297,14 +309,18 @@ func (lc *litAfClient) Ls(textArgs []string) error {
 		return err
 	}
 	if dfReply.Pending {
-		fmt.Fprintf(color.Output, "\t%s\n", lnutil.Header("Pending Dual Funding Request:"))
-		fmt.Fprintf(
-			color.Output, "\t%s %d\t%s %d\t%s %s\t%s %s\n\n",
-			lnutil.Header("Peer:"), dfReply.PeerIdx,
-			lnutil.Header("Type:"), dfReply.CoinType,
-			lnutil.Header("Their Amt:"), lnutil.SatoshiColor(dfReply.TheirAmount),
-			lnutil.Header("Req Amt:"), lnutil.SatoshiColor(dfReply.RequestedAmount),
-		)
+		for _, walBal := range bReply.Balances {
+			if walBal.CoinType == dfReply.CoinType {
+				fmt.Fprintf(color.Output, "\t%s\n", lnutil.Header("Pending Dual Funding Request:"))
+				fmt.Fprintf(
+					color.Output, "\t%s %d\t%s %d\t%s %s\t%s %s\n\n",
+					lnutil.Header("Peer:"), dfReply.PeerIdx,
+					lnutil.Header("Type:"), dfReply.CoinType,
+					lnutil.Header("Their Amt:"), lnutil.SatoshiColor(dfReply.TheirAmount),
+					lnutil.Header("Req Amt:"), lnutil.SatoshiColor(dfReply.RequestedAmount),
+				)
+			}
+		}
 	}
 
 	err = lc.Call("LitRPC.TxoList", nil, tReply)
@@ -347,11 +363,6 @@ func (lc *litAfClient) Ls(textArgs []string) error {
 	for i, a := range aReply.WitAddresses {
 		fmt.Fprintf(color.Output, "%d %s (%s)\n", i+1,
 			lnutil.Address(a), lnutil.Address(aReply.LegacyAddresses[i]))
-	}
-
-	err = lc.Call("LitRPC.Balance", nil, bReply)
-	if err != nil {
-		return err
 	}
 
 	for _, walBal := range bReply.Balances {
@@ -398,7 +409,7 @@ func printHelp(commands []*Command) {
 func printCointypes() {
 	for k, v := range coinparam.RegisteredNets {
 		fmt.Fprintf(color.Output, "CoinType: %s\n", strconv.Itoa(int(k)))
-		fmt.Fprintf(color.Output, "└────── Name: %-13sBech32Prefix: %s\n\n", v.Name + ",", v.Bech32Prefix)
+		fmt.Fprintf(color.Output, "└────── Name: %-13sBech32Prefix: %s\n\n", v.Name+",", v.Bech32Prefix)
 	}
 }
 


### PR DESCRIPTION
It doesn't make sense to show these channels since this causes confusion and people would be like "why is this channel unconfirmed" when in reality its  another channel which had a bug due to insufficient funding or something.