### PR TITLE
Fix segfault caused by nil htlcTxo

### DIFF
--- a/qln/htlc.go
+++ b/qln/htlc.go
@@ -900,7 +900,8 @@ func GetHTLCOut(q *Qchan, h HTLC, tx *wire.MsgTx, mine bool) (*wire.TxOut, uint3
 			return out, uint32(i), nil
 		}
 	}
-	return nil, 0, nil
+
+	return nil, 0, fmt.Errorf("Could not find HTLC output with desired PkScript")
 }
 
 func (q *Qchan) GetCloseTxs() (*wire.MsgTx, []*wire.MsgTx, bool, error) {
@@ -950,6 +951,9 @@ func (nd *LitNode) ClaimHTLCOnChain(q *Qchan, h HTLC) (*wire.MsgTx, error) {
 	stateTxID := stateTx.TxHash()
 
 	htlcTxo, i, err := GetHTLCOut(q, h, stateTx, mine)
+	if err != nil {
+		return nil, err
+	}
 
 	curElk, err := q.ElkSnd.AtIndex(q.State.StateIdx)
 	if err != nil {


### PR DESCRIPTION
When searching for the desired htlcTxo in a commitment transaction, if it wasn't found it returned nil. Instead return an error and check for it to stop the nil pointer dereference

```
2018/07/31 20:42:26.764116 Generating offer HTLC with localPub [02a810776fa2aaab630ce39ee6aa1c865cc34a82fc9f993f27c8bfb49639d896a6] and remotePub [02486fdc31e81e0f856c945fa24bc966ba57578637921ac78b5706f6e36b477cb7]
2018/07/31 20:42:26.764322 HTLC 0, script: 76a9144456ff83ba271edbe7099a1273188ab630d9167d8763ac672102486fdc31e81e0f856c945fa24bc966ba57578637921ac78b5706f6e36b477cb77c8260876475527c2102a810776fa2aaab630ce39ee6aa1c865cc34a82fc9f993f27c8bfb49639d896a652ae67a82086a1c25150ce1677025e0275e434de2c0c2eb598864cf4976e12df973326cceb88ac6868, myBase: 03bdf9d73da54baa9dabb5a9fa253cbd80f591f50987521010af5ae696b4c02465, theirBase: 02dd92a97e64976f9008c37dbd2cdabe2b9411f6656e2d99b0b65d4551ee46fa91, Incoming: false, Amt: 250000, RHash: 86a1c25150ce1677025e0275e434de2c0c2eb598864cf4976e12df973326cceb
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x87c4e5]

goroutine 7 [running]:
github.com/mit-dci/lit/qln.(*LitNode).ClaimHTLCOnChain(0xc4201301e0, 0xc4201c34a0, 0x0, 0x3d090, 0x7716ce5051c2a186, 0x2cde34e475025e02, 0x97f44c8698b52e0c, 0xebcc263397df126e, 0xd7f9bd030014b22e, 0xa9b5ab9daa4ba53d, ...)
	/home/james/go/src/github.com/mit-dci/lit/qln/htlc.go:1011 +0x6c5
github.com/mit-dci/lit/qln.(*LitNode).ClaimHTLCTimeouts(0xc4201301e0, 0x14b23100000001, 0x0, 0x0, 0x0, 0x0, 0x0)
	/home/james/go/src/github.com/mit-dci/lit/qln/htlc.go:791 +0x6e9
github.com/mit-dci/lit/qln.(*LitNode).HeightEventHandler(0xc4201301e0, 0xc42026ee70)
	/home/james/go/src/github.com/mit-dci/lit/qln/msghandler.go:502 +0x18d
created by github.com/mit-dci/lit/qln.(*LitNode).LinkBaseWallet
	/home/james/go/src/github.com/mit-dci/lit/qln/init.go:153 +0x5db
```