### PR TITLE
Batch connections on startup

### DIFF
--- a/lit.go
+++ b/lit.go
@@ -39,7 +39,7 @@ type config struct { // define a struct for usage with go-flags
 	ReSync bool `short:"r" long:"reSync" description:"Resync from the given tip."`
 	Tower  bool `long:"tower" description:"Watchtower: Run a watching node"`
 	Hard   bool `short:"t" long:"hard" description:"Flag to set networks."`
-  
+
 	Verbose bool `short:"v" long:"verbose" description:"Set verbosity to true."`
 	// rpc server config
 	Rpcport uint16 `short:"p" long:"rpcport" description:"Set RPC port to connect to"`
@@ -48,6 +48,8 @@ type config struct { // define a struct for usage with go-flags
 	AutoReconnect         bool   `long:"autoReconnect" description:"Attempts to automatically reconnect to known peers periodically."`
 	AutoReconnectInterval int64  `long:"autoReconnectInterval" description:"The interval (in seconds) the reconnect logic should be executed"`
 	AutoListenPort        string `long:"autoListenPort" description:"When auto reconnect enabled, starts listening on this port"`
+
+	MaxConnections int `short:"m" long:"maxConnections" description:"Define the maximum number of nodes to connect to"`
 	Params                *coinparam.Params
 }
 
@@ -63,6 +65,7 @@ var (
 	defaultAutoListenPort        = ":2448"
 	defaultAutoReconnectInterval = int64(60)
 	defaultUpnPFlag              = false
+	defaultMaxConnections = 120
 )
 
 func fileExists(name string) bool {
@@ -92,7 +95,7 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *config) error {
 		p := &coinparam.RegressionNetParams
 		fmt.Printf("reg: %s\n", conf.Reghost)
 		err = node.LinkBaseWallet(key, 120, conf.ReSync,
-			conf.Tower, conf.Reghost, conf.ChainProxyURL, p)
+			conf.Tower, conf.Reghost, conf.ChainProxyURL, conf.MaxConnections, p)
 		if err != nil {
 			return err
 		}
@@ -102,7 +105,7 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *config) error {
 		p := &coinparam.TestNet3Params
 		err = node.LinkBaseWallet(
 			key, 1256000, conf.ReSync, conf.Tower,
-			conf.Tn3host, conf.ChainProxyURL, p)
+			conf.Tn3host, conf.ChainProxyURL, conf.MaxConnections, p)
 		if err != nil {
 			return err
 		}
@@ -111,7 +114,7 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *config) error {
 	if !lnutil.NopeString(conf.Litereghost) {
 		p := &coinparam.LiteRegNetParams
 		err = node.LinkBaseWallet(key, 120, conf.ReSync,
-			conf.Tower, conf.Litereghost, conf.ChainProxyURL, p)
+			conf.Tower, conf.Litereghost, conf.ChainProxyURL, conf.MaxConnections, p)
 		if err != nil {
 			return err
 		}
@@ -121,7 +124,7 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *config) error {
 		p := &coinparam.LiteCoinTestNet4Params
 		err = node.LinkBaseWallet(
 			key, p.StartHeight, conf.ReSync, conf.Tower,
-			conf.Lt4host, conf.ChainProxyURL, p)
+			conf.Lt4host, conf.ChainProxyURL, conf.MaxConnections, p)
 		if err != nil {
 			return err
 		}
@@ -131,7 +134,7 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *config) error {
 		p := &coinparam.VertcoinTestNetParams
 		err = node.LinkBaseWallet(
 			key, 25000, conf.ReSync, conf.Tower,
-			conf.Tvtchost, conf.ChainProxyURL, p)
+			conf.Tvtchost, conf.ChainProxyURL, conf.MaxConnections, p)
 		if err != nil {
 			return err
 		}
@@ -141,7 +144,7 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *config) error {
 		p := &coinparam.VertcoinParams
 		err = node.LinkBaseWallet(
 			key, p.StartHeight, conf.ReSync, conf.Tower,
-			conf.Vtchost, conf.ChainProxyURL, p)
+			conf.Vtchost, conf.ChainProxyURL, conf.MaxConnections, p)
 		if err != nil {
 			return err
 		}
@@ -160,6 +163,7 @@ func main() {
 		AutoReconnect:         defaultAutoReconnect,
 		AutoListenPort:        defaultAutoListenPort,
 		AutoReconnectInterval: defaultAutoReconnectInterval,
+		MaxConnections : defaultMaxConnections,
 	}
 
 	key := litSetup(&conf)

--- a/litinit.go
+++ b/litinit.go
@@ -100,7 +100,6 @@ func litSetup(conf *config) *[32]byte {
 	logFilePath := filepath.Join(conf.LitHomeDir, "lit.log")
 
 	logfile, err := os.OpenFile(logFilePath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
-	// TODO ... what's this do?
 	defer logfile.Close()
 
 	log.SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds)

--- a/powless/powless.go
+++ b/powless/powless.go
@@ -105,7 +105,7 @@ type APILink struct {
 
 // Start starts the APIlink
 func (a *APILink) Start(
-	startHeight int32, host, path string, proxyURL string, params *coinparam.Params) (
+	startHeight int32, host, path string, proxyURL string, maxConnections int, params *coinparam.Params) (
 	chan lnutil.TxAndHeight, chan int32, error) {
 
 	a.proxyURL = proxyURL

--- a/qln/init.go
+++ b/qln/init.go
@@ -91,7 +91,7 @@ func NewLitNode(privKey *[32]byte, path string, trackerURL string, proxyURL stri
 // LinkBaseWallet activates a wallet and hooks it into the litnode.
 func (nd *LitNode) LinkBaseWallet(
 	privKey *[32]byte, birthHeight int32, resync bool, tower bool,
-	host string, proxy string, param *coinparam.Params) error {
+	host string, proxy string, maxConnections int, param *coinparam.Params) error {
 
 	rootpriv, err := hdkeychain.NewMaster(privKey[:], param)
 	if err != nil {
@@ -120,7 +120,7 @@ func (nd *LitNode) LinkBaseWallet(
 	// be the first & default
 	var cointype int
 	nd.SubWallet[WallitIdx], cointype, err = wallit.NewWallit(
-		rootpriv, birthHeight, resync, host, nd.LitFolder, proxy, param)
+		rootpriv, birthHeight, resync, host, nd.LitFolder, proxy, maxConnections, param)
 
 	if err != nil {
 		log.Println(err)

--- a/uspv/chainhook.go
+++ b/uspv/chainhook.go
@@ -34,8 +34,8 @@ type ChainHook interface {
 
 	// Note that for reorgs, the height chan just sends a lower height than you
 	// already have, and that means "reorg back!"
-	Start(height int32, host, path string, proxyURL string, params *coinparam.Params) (
-		chan lnutil.TxAndHeight, chan int32, error)
+	Start(height int32, host, path string, proxyURL string, maxConnections int,
+		params *coinparam.Params) (chan lnutil.TxAndHeight, chan int32, error)
 
 	// The Register functions send information to the ChainHook about what txs to
 	// return.  Txs matching either the addresses or outpoints will be returned
@@ -88,7 +88,8 @@ type ChainHook interface {
 // --- implementation of ChainHook interface ----
 
 func (s *SPVCon) Start(
-	startHeight int32, host, path string, proxyURL string, params *coinparam.Params) (
+	startHeight int32, host, path string, proxyURL string,
+	maxConnections int, params *coinparam.Params) (
 	chan lnutil.TxAndHeight, chan int32, error) {
 
 	// These can be set before calling Start()
@@ -97,7 +98,7 @@ func (s *SPVCon) Start(
 	s.ProxyURL = proxyURL
 
 	s.Param = params
-
+	s.maxConnections = maxConnections
 	s.TrackingAdrs = make(map[[20]byte]bool)
 	s.TrackingOPs = make(map[wire.OutPoint]bool)
 

--- a/uspv/init.go
+++ b/uspv/init.go
@@ -135,7 +135,6 @@ func (s *SPVCon) DialNode(listOfNodes []string) error {
 		}
 	}()
 	wg.Wait()
-	s.conns[0] = s.conns[0] // remove this
 	return nil
 }
 

--- a/uspv/init.go
+++ b/uspv/init.go
@@ -8,6 +8,8 @@ import (
 	"net"
 	"os"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/wire"
@@ -77,7 +79,10 @@ func (s *SPVCon) GetListOfNodes() ([]string, error) {
 func (s *SPVCon) DialNode(listOfNodes []string) error {
 	// now have some IPs, go through and try to connect to one.
 	var err error
-	for i, ip := range listOfNodes {
+	var wg sync.WaitGroup
+	queue := make(chan net.Conn, 1)
+	wg.Add(len(listOfNodes))
+	for i, ip := range listOfNodes { // Maintaining 10 parallel connections should be enough?
 		// try to connect to all nodes in this range
 		var conString, conMode string
 		// need to check whether conString is ipv4 or ipv6
@@ -92,10 +97,16 @@ func (s *SPVCon) DialNode(listOfNodes []string) error {
 			if err != nil {
 				return err
 			}
-
-			s.con, err = d.Dial(conMode, conString)
+			s.conns[0], err = d.Dial(conMode, conString)
 		} else {
-			s.con, err = net.Dial(conMode, conString)
+			d := net.Dialer{Timeout: time.Millisecond * 500}
+			// get only the fastest nodes, drop the other ones
+			// disconnect nodes if they don't respond within 1 sec
+			// put all ips into a go routine and collect them later
+			go func(i int) {
+				dummy, _ := d.Dial(conMode, conString)
+				queue <- dummy
+			}(i)
 		}
 
 		if err != nil {
@@ -108,15 +119,24 @@ func (s *SPVCon) DialNode(listOfNodes []string) error {
 				return fmt.Errorf(" Tried to connect to all available node Addresses. Failed")
 			}
 		}
-		break
 	}
+	go func() {
+		for conn := range queue {
+			if conn != nil {
+				s.conns = append(s.conns, conn)
+			}
+			wg.Done()
+		}
+	}()
+	wg.Wait()
+	s.conns[0] = s.conns[0] // remove this
 	return nil
 }
 
 func (s *SPVCon) Handshake(listOfNodes []string) error {
 	// assign version bits for local node
 	s.localVersion = VERSION
-	myMsgVer, err := wire.NewMsgVersionFromConn(s.con, 0, 0)
+	myMsgVer, err := wire.NewMsgVersionFromConn(s.conns[0], 0, 0)
 	if err != nil {
 		return err
 	}
@@ -130,16 +150,16 @@ func (s *SPVCon) Handshake(listOfNodes []string) error {
 	myMsgVer.AddService(wire.SFNodeWitness)
 	// this actually sends
 	n, err := wire.WriteMessageWithEncodingN(
-		s.con, myMsgVer, s.localVersion,
+		s.conns[0], myMsgVer, s.localVersion,
 		wire.BitcoinNet(s.Param.NetMagicBytes), wire.LatestEncoding)
 	if err != nil {
 		return err
 	}
 	s.WBytes += uint64(n)
 	log.Printf("wrote %d byte version message to %s\n",
-		n, s.con.RemoteAddr().String())
+		n, s.conns[0].RemoteAddr().String())
 	n, m, b, err := wire.ReadMessageWithEncodingN(
-		s.con, s.localVersion,
+		s.conns[0], s.localVersion,
 		wire.BitcoinNet(s.Param.NetMagicBytes), wire.LatestEncoding)
 	if err != nil {
 		return err
@@ -172,7 +192,7 @@ func (s *SPVCon) Handshake(listOfNodes []string) error {
 
 	mva := wire.NewMsgVerAck()
 	n, err = wire.WriteMessageWithEncodingN(
-		s.con, mva, s.localVersion,
+		s.conns[0], mva, s.localVersion,
 		wire.BitcoinNet(s.Param.NetMagicBytes), wire.LatestEncoding)
 	if err != nil {
 		return err
@@ -202,33 +222,27 @@ func (s *SPVCon) Connect(remoteNode string) error {
 	}
 	handShakeFailed := false //need to be in this scope to access it here
 	connEstablished := false
-	for len(listOfNodes) != 0 {
-		err = s.DialNode(listOfNodes)
-		if err != nil {
-			log.Println(err)
-			log.Printf("Couldn't dial node %s, Moving on", listOfNodes[0])
-			listOfNodes = listOfNodes[1:]
-			continue
-		}
+	err = s.DialNode(listOfNodes)
+	if err != nil {
+		log.Println(err)
+		log.Fatalf("Couldn't dial any node, quitting!")
+	}
+	for len(s.conns) != 0 {
 		err = s.Handshake(listOfNodes)
 		if err != nil {
 			handShakeFailed = true
-			log.Printf("Handshake with %s failed. Moving on. Error: %s", listOfNodes[0], err.Error())
+			log.Printf("Handshake failed. Moving on. Error: %s", err.Error())
 			if len(listOfNodes) == 1 { // when the list is empty, error out
 				return fmt.Errorf("Couldn't establish connection with any remote node. Exiting.")
 			}
 			// means we either have a sapm node or didn't get a resonse. So we Try again
-			log.Println(err)
-			log.Println("Couldn't establish connection with node. Proceeding to the next one")
-			listOfNodes = listOfNodes[1:]
-			connEstablished = false
+			log.Println("Couldn't establish connection with node. Proceeding to the next one", err)
+			s.conns = s.conns[1:]
 		} else {
 			connEstablished = true
 		}
 		if connEstablished { // connection should be established, still checking for safety
 			break
-		} else {
-			continue
 		}
 	}
 

--- a/uspv/init.go
+++ b/uspv/init.go
@@ -71,7 +71,6 @@ func (s *SPVCon) GetListOfNodes() ([]string, error) {
 	if len(listOfNodes) == 0 {
 		return nil, fmt.Errorf("No peers found connected to DNS Seeds. Please provide a host to connect to.")
 	}
-	log.Println(listOfNodes)
 	return listOfNodes, nil
 }
 
@@ -80,9 +79,16 @@ func (s *SPVCon) DialNode(listOfNodes []string) error {
 	// now have some IPs, go through and try to connect to one.
 	var err error
 	var wg sync.WaitGroup
+	// attempt sonnecting to only ot as many nodes specified by the user.
+	var slice int
+	slice = len(listOfNodes)
+	if s.maxConnections < len(listOfNodes) {
+		slice = s.maxConnections
+	}
+	listOfNodes = listOfNodes[:slice]
 	queue := make(chan net.Conn, 1)
 	wg.Add(len(listOfNodes))
-	for i, ip := range listOfNodes { // Maintaining 10 parallel connections should be enough?
+	for i, ip := range listOfNodes[:slice] { // Maintaining 10 parallel connections should be enough?
 		// try to connect to all nodes in this range
 		var conString, conMode string
 		// need to check whether conString is ipv4 or ipv6

--- a/uspv/msghandler.go
+++ b/uspv/msghandler.go
@@ -10,14 +10,14 @@ import (
 
 func (s *SPVCon) incomingMessageHandler() {
 	for {
-		n, xm, _, err := wire.ReadMessageWithEncodingN(s.con, s.localVersion,
+		n, xm, _, err := wire.ReadMessageWithEncodingN(s.conns[0], s.localVersion,
 			wire.BitcoinNet(s.Param.NetMagicBytes), wire.LatestEncoding)
 		if err != nil {
 			log.Printf("ReadMessageWithEncodingN error.  Disconnecting from given peer. %s\n", err.Error())
 			if s.randomNodesOK { // if user wants to connect to localhost, let him do so
 				s.Connect("yes") // really any YupString here
 			} else {
-				s.con.Close()
+				s.conns[0].Close()
 				return
 			}
 		}
@@ -78,7 +78,7 @@ func (s *SPVCon) outgoingMessageHandler() {
 			log.Printf("ERROR: nil message to outgoingMessageHandler\n")
 			continue
 		}
-		n, err := wire.WriteMessageWithEncodingN(s.con, msg, s.localVersion,
+		n, err := wire.WriteMessageWithEncodingN(s.conns[0], msg, s.localVersion,
 			wire.BitcoinNet(s.Param.NetMagicBytes), wire.LatestEncoding)
 
 		if err != nil {

--- a/uspv/spvcon.go
+++ b/uspv/spvcon.go
@@ -12,8 +12,9 @@ import (
 )
 
 type SPVCon struct {
-	con net.Conn // the (probably tcp) connection to the node
-
+	// store all open tcp connections to bitcoin nodes
+	// can just drop the connection if it misbehaves
+	conns []net.Conn
 	// Enhanced SPV modes for users who have outgrown easy mode SPV
 	// but have not yet graduated to full nodes.
 	HardMode bool   // hard mode doesn't use filters.

--- a/uspv/spvcon.go
+++ b/uspv/spvcon.go
@@ -15,6 +15,7 @@ type SPVCon struct {
 	// store all open tcp connections to bitcoin nodes
 	// can just drop the connection if it misbehaves
 	conns []net.Conn
+	maxConnections int
 	// Enhanced SPV modes for users who have outgrown easy mode SPV
 	// but have not yet graduated to full nodes.
 	HardMode bool   // hard mode doesn't use filters.

--- a/wallit/init.go
+++ b/wallit/init.go
@@ -18,7 +18,7 @@ import (
 
 func NewWallit(
 	rootkey *hdkeychain.ExtendedKey, birthHeight int32, resync bool,
-	spvhost, path string, proxyURL string, p *coinparam.Params) (*Wallit, int, error) {
+	spvhost, path string, proxyURL string, maxConnections int, p *coinparam.Params) (*Wallit, int, error) {
 
 	var w Wallit
 	w.rootPrivKey = rootkey
@@ -65,7 +65,7 @@ func NewWallit(
 	}
 	hookFail := false
 	log.Printf("DB corrected height %d\n", height)
-	incomingTx, incomingBlockheight, err := w.Hook.Start(height, spvhost, wallitpath, proxyURL, p)
+	incomingTx, incomingBlockheight, err := w.Hook.Start(height, spvhost, wallitpath, proxyURL, maxConnections, p)
 	if err != nil {
 		hookFail = true
 		log.Printf("NewWallit Hook.Start crash  %s ", err.Error())


### PR DESCRIPTION
On startup, we only  connect to a single node and if it fails, we proceed to dial the next node in `listOfNodes`. Instead, we can batch connections and open parallel connections with all of them and simply drop a peer if it doesn't respond / does something weird.

This is also configurable via a command line option `maxConnections` or `-m`. Issue: #275 