### PR TITLE
Concurrent Connections on Startup

### DIFF
--- a/consts/consts.go
+++ b/consts/consts.go
@@ -2,14 +2,16 @@ package consts
 
 // commonly used constants that can be used anywhere, without ambiguity
 const (
-	MaxChanCapacity = int64(100000000) // Maximum Channel Capacity (at 1 coin now)
-	MinChanCapacity = int64(1000000)   // minimum Channle Capacity
-	SafeFee         = int64(50000)     // safeFee while initializing a chan
-	MaxKeys         = uint32(1 << 20)  // max number of keys lit can store (could be infinite, still)
-	MaxTxCount      = int64(10000)     // max tx's associated with an address
-	DustCutoff      = int64(20000)     // below this, give to miners
-	MinOutput       = 100000           // minOutput is the minimum output amt, post fee. This (plus fees) is also the minimum channel balance
-	MinSendAmt      = 10000            // minimum amount that can be sent through a chan
-	MaxTxLen        = 100000           // maximum number of tx's that can be ingested at once
-	DefaultLockTime = 500
+	MaxChanCapacity      = int64(100000000) // Maximum Channel Capacity (at 1 coin now)
+	MinChanCapacity      = int64(1000000)   // minimum Channle Capacity
+	SafeFee              = int64(50000)     // safeFee while initializing a chan
+	MaxKeys              = uint32(1 << 20)  // max number of keys lit can store (could be infinite, still)
+	MaxTxCount           = int64(10000)     // max tx's associated with an address
+	DustCutoff           = int64(20000)     // below this, give to miners
+	MinOutput            = 100000           // minOutput is the minimum output amt, post fee. This (plus fees) is also the minimum channel balance
+	MinSendAmt           = 10000            // minimum amount that can be sent through a chan
+	MaxTxLen             = 100000           // maximum number of tx's that can be ingested at once
+	DefaultLockTime      = 500              // default lock time for timeouts
+	MaxConns             = 120              // maximum number of connections that a given lit node can make with other peers, 120 by default according to bitcoind
+	LastSupportedVersion = 70014            //70014 -> core v0.13.1, so we should be fine
 )

--- a/lit.go
+++ b/lit.go
@@ -65,7 +65,7 @@ var (
 	defaultAutoListenPort        = ":2448"
 	defaultAutoReconnectInterval = int64(60)
 	defaultUpnPFlag              = false
-	defaultMaxConnections = 120
+	defaultMaxConnections = 5
 )
 
 func fileExists(name string) bool {

--- a/lit.go
+++ b/lit.go
@@ -39,7 +39,7 @@ type config struct { // define a struct for usage with go-flags
 	ReSync bool `short:"r" long:"reSync" description:"Resync from the given tip."`
 	Tower  bool `long:"tower" description:"Watchtower: Run a watching node"`
 	Hard   bool `short:"t" long:"hard" description:"Flag to set networks."`
-  
+
 	Verbose bool `short:"v" long:"verbose" description:"Set verbosity to true."`
 	// rpc server config
 	Rpcport uint16 `short:"p" long:"rpcport" description:"Set RPC port to connect to"`
@@ -48,6 +48,8 @@ type config struct { // define a struct for usage with go-flags
 	AutoReconnect         bool   `long:"autoReconnect" description:"Attempts to automatically reconnect to known peers periodically."`
 	AutoReconnectInterval int64  `long:"autoReconnectInterval" description:"The interval (in seconds) the reconnect logic should be executed"`
 	AutoListenPort        string `long:"autoListenPort" description:"When auto reconnect enabled, starts listening on this port"`
+
+	MaxConnections int `short:"m" long:"maxConnections" description:"Define the maximum number of nodes to connect to"`
 	Params                *coinparam.Params
 }
 
@@ -63,6 +65,7 @@ var (
 	defaultAutoListenPort        = ":2448"
 	defaultAutoReconnectInterval = int64(60)
 	defaultUpnPFlag              = false
+	defaultMaxConnections = 120
 )
 
 func fileExists(name string) bool {
@@ -92,7 +95,7 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *config) error {
 		p := &coinparam.RegressionNetParams
 		fmt.Printf("reg: %s\n", conf.Reghost)
 		err = node.LinkBaseWallet(key, 120, conf.ReSync,
-			conf.Tower, conf.Reghost, conf.ChainProxyURL, p)
+			conf.Tower, conf.Reghost, conf.ChainProxyURL, conf.MaxConnections, p)
 		if err != nil {
 			return err
 		}
@@ -102,7 +105,7 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *config) error {
 		p := &coinparam.TestNet3Params
 		err = node.LinkBaseWallet(
 			key, 1256000, conf.ReSync, conf.Tower,
-			conf.Tn3host, conf.ChainProxyURL, p)
+			conf.Tn3host, conf.ChainProxyURL, conf.MaxConnections, p)
 		if err != nil {
 			return err
 		}
@@ -111,7 +114,7 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *config) error {
 	if !lnutil.NopeString(conf.Litereghost) {
 		p := &coinparam.LiteRegNetParams
 		err = node.LinkBaseWallet(key, 120, conf.ReSync,
-			conf.Tower, conf.Litereghost, conf.ChainProxyURL, p)
+			conf.Tower, conf.Litereghost, conf.ChainProxyURL, conf.MaxConnections, p)
 		if err != nil {
 			return err
 		}
@@ -121,7 +124,7 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *config) error {
 		p := &coinparam.LiteCoinTestNet4Params
 		err = node.LinkBaseWallet(
 			key, p.StartHeight, conf.ReSync, conf.Tower,
-			conf.Lt4host, conf.ChainProxyURL, p)
+			conf.Lt4host, conf.ChainProxyURL, conf.MaxConnections, p)
 		if err != nil {
 			return err
 		}
@@ -131,7 +134,7 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *config) error {
 		p := &coinparam.VertcoinTestNetParams
 		err = node.LinkBaseWallet(
 			key, 25000, conf.ReSync, conf.Tower,
-			conf.Tvtchost, conf.ChainProxyURL, p)
+			conf.Tvtchost, conf.ChainProxyURL, conf.MaxConnections, p)
 		if err != nil {
 			return err
 		}
@@ -141,7 +144,7 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *config) error {
 		p := &coinparam.VertcoinParams
 		err = node.LinkBaseWallet(
 			key, p.StartHeight, conf.ReSync, conf.Tower,
-			conf.Vtchost, conf.ChainProxyURL, p)
+			conf.Vtchost, conf.ChainProxyURL, conf.MaxConnections, p)
 		if err != nil {
 			return err
 		}
@@ -160,6 +163,7 @@ func main() {
 		AutoReconnect:         defaultAutoReconnect,
 		AutoListenPort:        defaultAutoListenPort,
 		AutoReconnectInterval: defaultAutoReconnectInterval,
+		MaxConnections : defaultMaxConnections,
 	}
 
 	key := litSetup(&conf)

--- a/litinit.go
+++ b/litinit.go
@@ -100,7 +100,6 @@ func litSetup(conf *config) *[32]byte {
 	logFilePath := filepath.Join(conf.LitHomeDir, "lit.log")
 
 	logfile, err := os.OpenFile(logFilePath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
-	// TODO ... what's this do?
 	defer logfile.Close()
 
 	log.SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds)

--- a/powless/powless.go
+++ b/powless/powless.go
@@ -105,7 +105,7 @@ type APILink struct {
 
 // Start starts the APIlink
 func (a *APILink) Start(
-	startHeight int32, host, path string, proxyURL string, params *coinparam.Params) (
+	startHeight int32, host, path string, proxyURL string, maxConnections int, params *coinparam.Params) (
 	chan lnutil.TxAndHeight, chan int32, error) {
 
 	a.proxyURL = proxyURL

--- a/qln/init.go
+++ b/qln/init.go
@@ -91,7 +91,7 @@ func NewLitNode(privKey *[32]byte, path string, trackerURL string, proxyURL stri
 // LinkBaseWallet activates a wallet and hooks it into the litnode.
 func (nd *LitNode) LinkBaseWallet(
 	privKey *[32]byte, birthHeight int32, resync bool, tower bool,
-	host string, proxy string, param *coinparam.Params) error {
+	host string, proxy string, maxConnections int, param *coinparam.Params) error {
 
 	rootpriv, err := hdkeychain.NewMaster(privKey[:], param)
 	if err != nil {
@@ -120,7 +120,7 @@ func (nd *LitNode) LinkBaseWallet(
 	// be the first & default
 	var cointype int
 	nd.SubWallet[WallitIdx], cointype, err = wallit.NewWallit(
-		rootpriv, birthHeight, resync, host, nd.LitFolder, proxy, param)
+		rootpriv, birthHeight, resync, host, nd.LitFolder, proxy, maxConnections, param)
 
 	if err != nil {
 		log.Println(err)

--- a/uspv/chainhook.go
+++ b/uspv/chainhook.go
@@ -34,8 +34,8 @@ type ChainHook interface {
 
 	// Note that for reorgs, the height chan just sends a lower height than you
 	// already have, and that means "reorg back!"
-	Start(height int32, host, path string, proxyURL string, params *coinparam.Params) (
-		chan lnutil.TxAndHeight, chan int32, error)
+	Start(height int32, host, path string, proxyURL string, maxConnections int,
+		params *coinparam.Params) (chan lnutil.TxAndHeight, chan int32, error)
 
 	// The Register functions send information to the ChainHook about what txs to
 	// return.  Txs matching either the addresses or outpoints will be returned
@@ -88,7 +88,8 @@ type ChainHook interface {
 // --- implementation of ChainHook interface ----
 
 func (s *SPVCon) Start(
-	startHeight int32, host, path string, proxyURL string, params *coinparam.Params) (
+	startHeight int32, host, path string, proxyURL string,
+	maxConnections int, params *coinparam.Params) (
 	chan lnutil.TxAndHeight, chan int32, error) {
 
 	// These can be set before calling Start()
@@ -97,7 +98,7 @@ func (s *SPVCon) Start(
 	s.ProxyURL = proxyURL
 
 	s.Param = params
-
+	s.maxConnections = maxConnections
 	s.TrackingAdrs = make(map[[20]byte]bool)
 	s.TrackingOPs = make(map[wire.OutPoint]bool)
 

--- a/uspv/eight333.go
+++ b/uspv/eight333.go
@@ -5,10 +5,10 @@ import (
 	"log"
 	"os"
 
-	"github.com/mit-dci/lit/btcutil/chaincfg/chainhash"
-	"github.com/mit-dci/lit/wire"
 	"github.com/mit-dci/lit/btcutil/bloom"
+	"github.com/mit-dci/lit/btcutil/chaincfg/chainhash"
 	"github.com/mit-dci/lit/lnutil"
+	"github.com/mit-dci/lit/wire"
 )
 
 const (
@@ -127,7 +127,7 @@ func (s *SPVCon) OKTxid(txid *chainhash.Hash, height int32) error {
 // AskForTx requests a tx we heard about from an inv message.
 // It's one at a time but should be fast enough.
 // I don't like this function because SPV shouldn't even ask...
-func (s *SPVCon) AskForTx(txid chainhash.Hash) {
+func (s *SPVCon) AskForTx(txid chainhash.Hash, peerIdx int) {
 	gdata := wire.NewMsgGetData()
 	inv := wire.NewInvVect(wire.InvTypeTx, &txid)
 	// no longer get wit txs if in hardmode... don't need to, right?
@@ -135,8 +135,8 @@ func (s *SPVCon) AskForTx(txid chainhash.Hash) {
 	//		inv.Type = wire.InvTypeWitnessTx
 	//	}
 	gdata.AddInvVect(inv)
-	log.Printf("asking for tx %s\n", txid.String())
-	s.outMsgQueue <- gdata
+	log.Printf("asking for tx %s from peer %d\n", txid.String(), peerIdx)
+	s.outMsgQueue[peerIdx] <- gdata
 }
 
 // HashAndHeight is needed instead of just height in case a fullnode
@@ -158,7 +158,7 @@ func NewRootAndHeight(b chainhash.Hash, h int32) (hah HashAndHeight) {
 	return
 }
 
-func (s *SPVCon) IngestMerkleBlock(m *wire.MsgMerkleBlock) {
+func (s *SPVCon) IngestMerkleBlock(m *wire.MsgMerkleBlock, peerIdx int) {
 
 	txids, err := checkMBlock(m) // check self-consistency
 	if err != nil {
@@ -200,7 +200,7 @@ func (s *SPVCon) IngestMerkleBlock(m *wire.MsgMerkleBlock) {
 		// this way the only thing that triggers waitstate is asking for headers,
 		// getting 0, calling AskForMerkBlocks(), and seeing you don't need any.
 		// that way you are pretty sure you're synced up.
-		err = s.AskForHeaders()
+		err = s.AskForHeaders(peerIdx)
 		if err != nil {
 			log.Printf("Merkle block error: %s\n", err.Error())
 			return
@@ -276,7 +276,7 @@ func (s *SPVCon) IngestHeaders(m *wire.MsgHeaders) (bool, error) {
 	return true, nil
 }
 
-func (s *SPVCon) AskForHeaders() error {
+func (s *SPVCon) AskForHeaders(peerIdx int) error {
 	ghdr := wire.NewMsgGetHeaders()
 	ghdr.ProtocolVersion = s.localVersion
 
@@ -322,15 +322,14 @@ func (s *SPVCon) AskForHeaders() error {
 
 	log.Printf("get headers message has %d header hashes, first one is %s\n",
 		len(ghdr.BlockLocatorHashes), ghdr.BlockLocatorHashes[0].String())
-
-	s.outMsgQueue <- ghdr
+	s.outMsgQueue[peerIdx] <- ghdr
 	return nil
 }
 
 // AskForMerkBlocks requests blocks from current to last
 // right now this asks for 1 block per getData message.
 // Maybe it's faster to ask for many in each message?
-func (s *SPVCon) AskForBlocks() error {
+func (s *SPVCon) AskForBlocks(peerIdx int) error {
 	var hdr wire.BlockHeader
 
 	s.headerMutex.Lock() // lock just to check filesize
@@ -415,7 +414,7 @@ func (s *SPVCon) AskForBlocks() error {
 		}
 		// waits here most of the time for the queue to empty out
 		s.blockQueue <- hah // push height and mroot of requested block on queue
-		s.outMsgQueue <- gdataMsg
+		s.outMsgQueue[peerIdx] <- gdataMsg
 	}
 	return nil
 }

--- a/uspv/hardmode.go
+++ b/uspv/hardmode.go
@@ -133,9 +133,9 @@ func calcRoot(hashes []*chainhash.Hash) *chainhash.Hash {
 
 // RefilterLocal reconstructs the local in-memory bloom filter.  It does
 // this by calling GimmeFilter() but doesn't broadcast the result.
-func (s *SPVCon) Refilter(f *bloom.Filter) {
+func (s *SPVCon) Refilter(f *bloom.Filter, peerIdx int) {
 	if !s.HardMode {
-		s.SendFilter(f)
+		s.SendFilter(f, peerIdx)
 	}
 }
 
@@ -193,10 +193,16 @@ func (s *SPVCon) IngestBlock(m *wire.MsgBlock) {
 		// this way the only thing that triggers waitstate is asking for headers,
 		// getting 0, calling AskForMerkBlocks(), and seeing you don't need any.
 		// that way you are pretty sure you're synced up.
-		err = s.AskForHeaders()
-		if err != nil {
-			log.Printf("Merkle block error: %s\n", err.Error())
-			return
+
+		// ask all nodes for headers
+		for k := 0 ; k < len(s.conns) ; k ++ {
+			err = s.AskForHeaders(k)
+			if err != nil {
+				log.Printf("Merkle block error: %s\n", err.Error())
+				// should we actually return here considering we're
+				// asking many node for headers?
+				return
+			}
 		}
 	}
 	return

--- a/uspv/init.go
+++ b/uspv/init.go
@@ -135,7 +135,6 @@ func (s *SPVCon) DialNode(listOfNodes []string) error {
 		}
 	}()
 	wg.Wait()
-	s.conns[0] = s.conns[0] // remove this
 	return nil
 }
 

--- a/uspv/init.go
+++ b/uspv/init.go
@@ -8,6 +8,8 @@ import (
 	"net"
 	"os"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/wire"
@@ -77,7 +79,10 @@ func (s *SPVCon) GetListOfNodes() ([]string, error) {
 func (s *SPVCon) DialNode(listOfNodes []string) error {
 	// now have some IPs, go through and try to connect to one.
 	var err error
-	for i, ip := range listOfNodes {
+	var wg sync.WaitGroup
+	queue := make(chan net.Conn, 1)
+	wg.Add(len(listOfNodes))
+	for i, ip := range listOfNodes { // Maintaining 10 parallel connections should be enough?
 		// try to connect to all nodes in this range
 		var conString, conMode string
 		// need to check whether conString is ipv4 or ipv6
@@ -92,10 +97,16 @@ func (s *SPVCon) DialNode(listOfNodes []string) error {
 			if err != nil {
 				return err
 			}
-
-			s.con, err = d.Dial(conMode, conString)
+			s.conns[0], err = d.Dial(conMode, conString)
 		} else {
-			s.con, err = net.Dial(conMode, conString)
+			d := net.Dialer{Timeout: time.Millisecond * 500}
+			// get only the fastest nodes, drop the other ones
+			// disconnect nodes if they don't respond within 1 sec
+			// put all ips into a go routine and collect them later
+			go func(i int) {
+				dummy, _ := d.Dial(conMode, conString)
+				queue <- dummy
+			}(i)
 		}
 
 		if err != nil {
@@ -108,15 +119,24 @@ func (s *SPVCon) DialNode(listOfNodes []string) error {
 				return fmt.Errorf(" Tried to connect to all available node Addresses. Failed")
 			}
 		}
-		break
 	}
+	go func() {
+		for conn := range queue {
+			if conn != nil {
+				s.conns = append(s.conns, conn)
+			}
+			wg.Done()
+		}
+	}()
+	wg.Wait()
+	s.conns[0] = s.conns[0] // remove this
 	return nil
 }
 
 func (s *SPVCon) Handshake(listOfNodes []string) error {
 	// assign version bits for local node
 	s.localVersion = VERSION
-	myMsgVer, err := wire.NewMsgVersionFromConn(s.con, 0, 0)
+	myMsgVer, err := wire.NewMsgVersionFromConn(s.conns[0], 0, 0)
 	if err != nil {
 		return err
 	}
@@ -130,16 +150,16 @@ func (s *SPVCon) Handshake(listOfNodes []string) error {
 	myMsgVer.AddService(wire.SFNodeWitness)
 	// this actually sends
 	n, err := wire.WriteMessageWithEncodingN(
-		s.con, myMsgVer, s.localVersion,
+		s.conns[0], myMsgVer, s.localVersion,
 		wire.BitcoinNet(s.Param.NetMagicBytes), wire.LatestEncoding)
 	if err != nil {
 		return err
 	}
 	s.WBytes += uint64(n)
 	log.Printf("wrote %d byte version message to %s\n",
-		n, s.con.RemoteAddr().String())
+		n, s.conns[0].RemoteAddr().String())
 	n, m, b, err := wire.ReadMessageWithEncodingN(
-		s.con, s.localVersion,
+		s.conns[0], s.localVersion,
 		wire.BitcoinNet(s.Param.NetMagicBytes), wire.LatestEncoding)
 	if err != nil {
 		return err
@@ -172,7 +192,7 @@ func (s *SPVCon) Handshake(listOfNodes []string) error {
 
 	mva := wire.NewMsgVerAck()
 	n, err = wire.WriteMessageWithEncodingN(
-		s.con, mva, s.localVersion,
+		s.conns[0], mva, s.localVersion,
 		wire.BitcoinNet(s.Param.NetMagicBytes), wire.LatestEncoding)
 	if err != nil {
 		return err
@@ -202,33 +222,27 @@ func (s *SPVCon) Connect(remoteNode string) error {
 	}
 	handShakeFailed := false //need to be in this scope to access it here
 	connEstablished := false
-	for len(listOfNodes) != 0 {
-		err = s.DialNode(listOfNodes)
-		if err != nil {
-			log.Println(err)
-			log.Printf("Couldn't dial node %s, Moving on", listOfNodes[0])
-			listOfNodes = listOfNodes[1:]
-			continue
-		}
+	err = s.DialNode(listOfNodes)
+	if err != nil {
+		log.Println(err)
+		log.Fatalf("Couldn't dial any node, quitting!")
+	}
+	for len(s.conns) != 0 {
 		err = s.Handshake(listOfNodes)
 		if err != nil {
 			handShakeFailed = true
-			log.Printf("Handshake with %s failed. Moving on. Error: %s", listOfNodes[0], err.Error())
+			log.Printf("Handshake failed. Moving on. Error: %s", err.Error())
 			if len(listOfNodes) == 1 { // when the list is empty, error out
 				return fmt.Errorf("Couldn't establish connection with any remote node. Exiting.")
 			}
 			// means we either have a sapm node or didn't get a resonse. So we Try again
-			log.Println(err)
-			log.Println("Couldn't establish connection with node. Proceeding to the next one")
-			listOfNodes = listOfNodes[1:]
-			connEstablished = false
+			log.Println("Couldn't establish connection with node. Proceeding to the next one", err)
+			s.conns = s.conns[1:]
 		} else {
 			connEstablished = true
 		}
 		if connEstablished { // connection should be established, still checking for safety
 			break
-		} else {
-			continue
 		}
 	}
 

--- a/uspv/init.go
+++ b/uspv/init.go
@@ -71,7 +71,6 @@ func (s *SPVCon) GetListOfNodes() ([]string, error) {
 	if len(listOfNodes) == 0 {
 		return nil, fmt.Errorf("No peers found connected to DNS Seeds. Please provide a host to connect to.")
 	}
-	log.Println(listOfNodes)
 	return listOfNodes, nil
 }
 
@@ -80,9 +79,16 @@ func (s *SPVCon) DialNode(listOfNodes []string) error {
 	// now have some IPs, go through and try to connect to one.
 	var err error
 	var wg sync.WaitGroup
+	// attempt sonnecting to only ot as many nodes specified by the user.
+	var slice int
+	slice = len(listOfNodes)
+	if s.maxConnections < len(listOfNodes) {
+		slice = s.maxConnections
+	}
+	listOfNodes = listOfNodes[:slice]
 	queue := make(chan net.Conn, 1)
 	wg.Add(len(listOfNodes))
-	for i, ip := range listOfNodes { // Maintaining 10 parallel connections should be enough?
+	for i, ip := range listOfNodes[:slice] { // Maintaining 10 parallel connections should be enough?
 		// try to connect to all nodes in this range
 		var conString, conMode string
 		// need to check whether conString is ipv4 or ipv6

--- a/uspv/init.go
+++ b/uspv/init.go
@@ -75,17 +75,17 @@ func (s *SPVCon) GetListOfNodes() ([]string, error) {
 }
 
 // DialNode receives a list of node ips and then tries to connect to them one by one.
-func (s *SPVCon) DialNode(listOfNodes []string) error {
+func (s *SPVCon) DialNode(listOfNodesParent []string) error {
 	// now have some IPs, go through and try to connect to one.
 	var err error
 	var wg sync.WaitGroup
 	// attempt sonnecting to only ot as many nodes specified by the user.
 	var slice int
-	slice = len(listOfNodes)
-	if s.maxConnections < len(listOfNodes) {
+	slice = len(listOfNodesParent)
+	if s.maxConnections < len(listOfNodesParent) {
 		slice = s.maxConnections
 	}
-	listOfNodes = listOfNodes[:slice]
+	listOfNodes := listOfNodesParent[:slice]
 	queue := make(chan net.Conn, 1)
 	wg.Add(len(listOfNodes))
 	for i, ip := range listOfNodes[:slice] { // Maintaining 10 parallel connections should be enough?
@@ -105,7 +105,7 @@ func (s *SPVCon) DialNode(listOfNodes []string) error {
 			}
 			s.conns[0], err = d.Dial(conMode, conString)
 		} else {
-			d := net.Dialer{Timeout: time.Millisecond * 500}
+			d := net.Dialer{Timeout: time.Millisecond * 1000}
 			// get only the fastest nodes, drop the other ones
 			// disconnect nodes if they don't respond within 1 sec
 			// put all ips into a go routine and collect them later
@@ -138,10 +138,10 @@ func (s *SPVCon) DialNode(listOfNodes []string) error {
 	return nil
 }
 
-func (s *SPVCon) Handshake(listOfNodes []string) error {
+func (s *SPVCon) Handshake(peerIdx int) error {
 	// assign version bits for local node
 	s.localVersion = VERSION
-	myMsgVer, err := wire.NewMsgVersionFromConn(s.conns[0], 0, 0)
+	myMsgVer, err := wire.NewMsgVersionFromConn(s.conns[peerIdx], 0, 0)
 	if err != nil {
 		return err
 	}
@@ -155,16 +155,16 @@ func (s *SPVCon) Handshake(listOfNodes []string) error {
 	myMsgVer.AddService(wire.SFNodeWitness)
 	// this actually sends
 	n, err := wire.WriteMessageWithEncodingN(
-		s.conns[0], myMsgVer, s.localVersion,
+		s.conns[peerIdx], myMsgVer, s.localVersion,
 		wire.BitcoinNet(s.Param.NetMagicBytes), wire.LatestEncoding)
 	if err != nil {
 		return err
 	}
 	s.WBytes += uint64(n)
 	log.Printf("wrote %d byte version message to %s\n",
-		n, s.conns[0].RemoteAddr().String())
+		n, s.conns[peerIdx].RemoteAddr().String())
 	n, m, b, err := wire.ReadMessageWithEncodingN(
-		s.conns[0], s.localVersion,
+		s.conns[peerIdx], s.localVersion,
 		wire.BitcoinNet(s.Param.NetMagicBytes), wire.LatestEncoding)
 	if err != nil {
 		return err
@@ -182,28 +182,62 @@ func (s *SPVCon) Handshake(listOfNodes []string) error {
 		return fmt.Errorf("Remote node version: %x too old, disconnecting.", mv.ProtocolVersion)
 	}
 
-	if !((strings.Contains(s.Param.Name, "lite") && strings.Contains(mv.UserAgent, "LitecoinCore")) || strings.Contains(mv.UserAgent, "Satoshi") || strings.Contains(mv.UserAgent, "btcd")) && (len(listOfNodes) != 0) {
+	if !((strings.Contains(s.Param.Name, "lite") && strings.Contains(mv.UserAgent, "LitecoinCore")) || strings.Contains(mv.UserAgent, "Satoshi") || strings.Contains(mv.UserAgent, "btcd")) {
 		// TODO: improve this filtering criterion
-		return fmt.Errorf("Couldn't connect to this node. Returning!")
+		return fmt.Errorf("Spam node. Returning!")
 	}
 
 	log.Printf("remote reports version %x (dec %d)\n",
 		mv.ProtocolVersion, mv.ProtocolVersion)
 
 	// set remote height
-	s.remoteHeight = mv.LastBlock
+	s.remoteHeight = append(s.remoteHeight, mv.LastBlock)
+	log.Printf("node reports %d as height of the last block", mv.LastBlock)
 	// set remote version
-	s.remoteVersion = uint32(mv.ProtocolVersion)
+	s.remoteVersion = append(s.remoteVersion, uint32(mv.ProtocolVersion))
 
 	mva := wire.NewMsgVerAck()
 	n, err = wire.WriteMessageWithEncodingN(
-		s.conns[0], mva, s.localVersion,
+		s.conns[peerIdx], mva, s.localVersion,
 		wire.BitcoinNet(s.Param.NetMagicBytes), wire.LatestEncoding)
 	if err != nil {
 		return err
 	}
 	s.WBytes += uint64(n)
 	return nil
+}
+
+func ConnCheck(in []bool) bool {
+	for _, val := range in {
+		if val == true {
+			return val
+		}
+	}
+	return false
+}
+
+func (s *SPVCon) ConnectToMaxConns(listOfNodes []string) ([]string, error) {
+	var empty []string
+	var err error
+	if !s.randomNodesOK { // conneect to user provided node
+		err = s.DialNode(listOfNodes)
+		return listOfNodes, err
+	}
+	for len(listOfNodes)-s.maxConnections > 0 && len(s.conns) < s.maxConnections {
+		// make sure we get atleast one active connection from the DNS Seeds
+		log.Printf("Active Conns: %d", len(s.conns))
+		err = s.DialNode(listOfNodes)
+		if err != nil {
+			log.Println(err) // no need to take action on this error since this doesn't
+			// affect what we do below
+		}
+		if len(s.conns) >= s.maxConnections {
+			s.conns = s.conns[:s.maxConnections] // restrict number of maximum connections
+			return listOfNodes, nil
+		}
+		listOfNodes = listOfNodes[s.maxConnections:]
+	}
+	return empty, fmt.Errorf("Couldn't connect to any node from the list of peers obtained, exiting!")
 }
 
 // Connect dials out and connects to full nodes. Calls GetListOfNodes to get the
@@ -213,6 +247,8 @@ func (s *SPVCon) Handshake(listOfNodes []string) error {
 func (s *SPVCon) Connect(remoteNode string) error {
 	var err error
 	var listOfNodes []string
+	var handshakeEstablished []bool
+	var connEstablished []bool
 	if lnutil.YupString(remoteNode) {
 		s.randomNodesOK = true
 		// if remoteNode is "yes" but no IP specified, use DNS seed
@@ -225,45 +261,47 @@ func (s *SPVCon) Connect(remoteNode string) error {
 	} else { // else connect to user-specified node
 		listOfNodes = []string{remoteNode}
 	}
-	handShakeFailed := false //need to be in this scope to access it here
-	connEstablished := false
-	err = s.DialNode(listOfNodes)
+	log.Println("LSIT OF NODES", listOfNodes)
+	// Connect to maxConns nodes
+	listOfNodes, err = s.ConnectToMaxConns(listOfNodes)
 	if err != nil {
 		log.Println(err)
-		log.Fatalf("Couldn't dial any node, quitting!")
+		return err
 	}
-	for len(s.conns) != 0 {
-		err = s.Handshake(listOfNodes)
+	// Now we have the connections, try handshakes
+	// Some peers might have weird version numbers, etc, so we drop them
+	// hence we collect maxConns from above since there are bound to be spam nodes
+	// which would get dropped and reduce the number of active connections
+	log.Printf("Trying to connect to %d node(s)", len(s.conns))
+	for k := 0; k < len(s.conns); k++ {
+		err := s.Handshake(k)
 		if err != nil {
-			handShakeFailed = true
-			log.Printf("Handshake failed. Moving on. Error: %s", err.Error())
+			s.conns = append(s.conns[:k], s.conns[(k+1):]...) // delete s.conns[k]
+			// means we either have a spam node or didn't get a resonse. So we try again
+			handshakeEstablished = append(handshakeEstablished, false)
+			connEstablished = append(connEstablished, false)
+			log.Printf("Handshake failed with node %d. Moving on. Error: %s", k, err.Error())
 			if len(listOfNodes) == 1 { // when the list is empty, error out
 				return fmt.Errorf("Couldn't establish connection with any remote node. Exiting.")
 			}
-			// means we either have a sapm node or didn't get a resonse. So we Try again
-			log.Println("Couldn't establish connection with node. Proceeding to the next one", err)
-			s.conns = s.conns[1:]
-		} else {
-			connEstablished = true
+			continue
 		}
-		if connEstablished { // connection should be established, still checking for safety
-			break
-		}
+		handshakeEstablished = append(handshakeEstablished, true)
+		connEstablished = append(connEstablished, true)
+		// setup streams to receive and send wire messages
+		// one for each connection
+		s.inMsgQueue = make(chan wire.Message)
+		go s.incomingMessageHandler(k)
+		s.outMsgQueue = make(chan wire.Message)
+		go s.outgoingMessageHandler(k)
 	}
-
-	if !handShakeFailed && !connEstablished {
+	if !ConnCheck(connEstablished) && !ConnCheck(handshakeEstablished) {
+		// if no handhsake and connection established
 		// this case happens when user provided node fails to connect
-		return fmt.Errorf("Couldn't establish connection with node. Exiting.")
+		return fmt.Errorf("Couldn't establish connection with any node. Exiting.")
 	}
-	if handShakeFailed && !connEstablished {
-		// this case is when the last node fails and we continue, only to exit the
-		// loop and execute below code, which is unnecessary.
-		return fmt.Errorf("Couldn't establish connection with any remote node after an instance of handshake. Exiting.")
-	}
-	s.inMsgQueue = make(chan wire.Message)
-	go s.incomingMessageHandler()
-	s.outMsgQueue = make(chan wire.Message)
-	go s.outgoingMessageHandler()
+	//log.Println(handshakeEstablished, connEstablished)
+	log.Println("Remote versions of connected nodes:", s.remoteVersion)
 
 	if s.HardMode {
 		s.blockQueue = make(chan HashAndHeight, 32) // queue depth 32 for hardmode.

--- a/uspv/msghandler.go
+++ b/uspv/msghandler.go
@@ -8,9 +8,12 @@ import (
 	"github.com/mit-dci/lit/wire"
 )
 
+// incomingMessageHandler sets up an incoming message stream on which
+// peerIdx's can listen on and decrypt messages that are received from the
+// remote peer
 func (s *SPVCon) incomingMessageHandler(peerIdx int) {
 	for {
-		log.Printf("Received message from peer %d", peerIdx)
+		log.Printf("Received message from peer %d", peerIdx+1)
 		n, xm, _, err := wire.ReadMessageWithEncodingN(s.conns[peerIdx], s.localVersion,
 			wire.BitcoinNet(s.Param.NetMagicBytes), wire.LatestEncoding)
 		if err != nil {
@@ -31,29 +34,29 @@ func (s *SPVCon) incomingMessageHandler(peerIdx int) {
 			log.Printf("got %d addresses.\n", len(m.AddrList))
 		case *wire.MsgPing:
 			// log.Printf("Got a ping message.  We should pong back or they will kick us off.")
-			go s.PongBack(m.Nonce)
+			go s.PongBack(m.Nonce, peerIdx)
 		case *wire.MsgPong:
 			log.Printf("Got a pong response. OK.\n")
 		case *wire.MsgBlock:
 			s.IngestBlock(m)
 		case *wire.MsgMerkleBlock:
-			s.IngestMerkleBlock(m)
+			s.IngestMerkleBlock(m, peerIdx)
 		case *wire.MsgHeaders: // concurrent because we keep asking for blocks
-			go s.HeaderHandler(m)
+			go s.HeaderHandler(m, peerIdx)
 		case *wire.MsgTx: // not concurrent! txs must be in order
 			s.TxHandler(m)
 		case *wire.MsgReject:
 			log.Printf("Rejected! cmd: %s code: %s tx: %s reason: %s",
 				m.Cmd, m.Code.String(), m.Hash.String(), m.Reason)
 		case *wire.MsgInv:
-			s.InvHandler(m)
+			s.InvHandler(m, peerIdx)
 		case *wire.MsgNotFound:
 			log.Printf("Got not found response from remote:")
 			for i, thing := range m.InvList {
 				log.Printf("\t%d) %s: %s", i, thing.Type, thing.Hash)
 			}
 		case *wire.MsgGetData:
-			s.GetDataHandler(m)
+			s.GetDataHandler(m, peerIdx)
 
 		default:
 			if m != nil {
@@ -66,12 +69,12 @@ func (s *SPVCon) incomingMessageHandler(peerIdx int) {
 	return
 }
 
-// this one seems kindof pointless?  could get rid of it and let
-// functions call WriteMessageWithEncodingN themselves...
+// outgoingMessageHandler initializes an outgoing message stream for each
+// peerIdx. each peerIdx can then listen and send messages on its own
 func (s *SPVCon) outgoingMessageHandler(peerIdx int) {
 	for {
-		//log.Printf("Sending message to peer %d", peerIdx)
-		msg := <-s.outMsgQueue
+		log.Printf("Sending message to peer %d", peerIdx)
+		msg := <-s.outMsgQueue[peerIdx]
 		if msg == nil {
 			log.Printf("ERROR: nil message to outgoingMessageHandler\n")
 			continue
@@ -87,7 +90,7 @@ func (s *SPVCon) outgoingMessageHandler(peerIdx int) {
 }
 
 // fPositiveHandler monitors false positives and when it gets enough of them,
-func (s *SPVCon) fPositiveHandler() {
+func (s *SPVCon) fPositiveHandler(peerIdx int) {
 	var fpAccumulator int32
 	for {
 		fpAccumulator += <-s.fPositives // blocks here
@@ -99,7 +102,7 @@ func (s *SPVCon) fPositiveHandler() {
 				return
 			}
 			// send filter
-			s.Refilter(filt)
+			s.Refilter(filt, peerIdx)
 			log.Printf("sent filter %x\n", filt.MsgFilterLoad().Filter)
 
 			// clear the channel
@@ -122,7 +125,10 @@ func (s *SPVCon) fPositiveHandler() {
 
 // REORG TODO: how to detect reorgs and send them up to wallet layer
 
-func (s *SPVCon) HeaderHandler(m *wire.MsgHeaders) {
+// Headerhandler ingests all headers, checks whether we need more headers
+// and if needed, asks the remote node for them. After asking for headers,
+// it also asks for blocks
+func (s *SPVCon) HeaderHandler(m *wire.MsgHeaders, peerIdx int) {
 	moar, err := s.IngestHeaders(m)
 	if err != nil {
 		log.Printf("Header error: %s\n", err.Error())
@@ -130,7 +136,7 @@ func (s *SPVCon) HeaderHandler(m *wire.MsgHeaders) {
 	}
 	// more to get? if so, ask for them and return
 	if moar {
-		err = s.AskForHeaders()
+		err = s.AskForHeaders(peerIdx)
 		if err != nil {
 			log.Printf("AskForHeaders error: %s", err.Error())
 		}
@@ -144,11 +150,11 @@ func (s *SPVCon) HeaderHandler(m *wire.MsgHeaders) {
 			return
 		}
 		// send filter
-		s.SendFilter(filt)
+		s.SendFilter(filt, peerIdx)
 		log.Printf("sent filter %x\n", filt.MsgFilterLoad().Filter)
 	}
 
-	err = s.AskForBlocks()
+	err = s.AskForBlocks(peerIdx)
 	if err != nil {
 		log.Printf("AskForBlocks error: %s", err.Error())
 		return
@@ -198,7 +204,7 @@ func (s *SPVCon) TxHandler(tx *wire.MsgTx) {
 
 // GetDataHandler responds to requests for tx data, which happen after
 // advertising our txs via an inv message
-func (s *SPVCon) GetDataHandler(m *wire.MsgGetData) {
+func (s *SPVCon) GetDataHandler(m *wire.MsgGetData, peerIdx int) {
 	log.Printf("got GetData.  Contains:\n")
 	var sent int32
 	for i, thing := range m.InvList {
@@ -214,7 +220,7 @@ func (s *SPVCon) GetDataHandler(m *wire.MsgGetData) {
 					thing.Hash.String())
 				continue
 			}
-			s.outMsgQueue <- tx
+			s.outMsgQueue[peerIdx] <- tx
 			sent++
 			continue
 		}
@@ -224,7 +230,7 @@ func (s *SPVCon) GetDataHandler(m *wire.MsgGetData) {
 	log.Printf("sent %d of %d requested items", sent, len(m.InvList))
 }
 
-func (s *SPVCon) InvHandler(m *wire.MsgInv) {
+func (s *SPVCon) InvHandler(m *wire.MsgInv, peerIdx int) {
 	log.Printf("got inv.  Contains:\n")
 	for i, thing := range m.InvList {
 		log.Printf("\t%d)%s : %s",
@@ -236,7 +242,7 @@ func (s *SPVCon) InvHandler(m *wire.MsgInv) {
 				// also request if we already have it; might have new witness?
 				// needed for confirmed channels...
 				s.OKTxid(&thing.Hash, 0) // unconfirmed
-				s.AskForTx(thing.Hash)
+				s.AskForTx(thing.Hash, peerIdx)
 			}
 		}
 		if thing.Type == wire.InvTypeBlock { // new block what to do?
@@ -244,7 +250,7 @@ func (s *SPVCon) InvHandler(m *wire.MsgInv) {
 			case <-s.inWaitState:
 				// start getting headers
 				log.Printf("asking for headers due to inv block\n")
-				err := s.AskForHeaders()
+				err := s.AskForHeaders(peerIdx)
 				if err != nil {
 					log.Printf("AskForHeaders error: %s", err.Error())
 				}
@@ -256,15 +262,14 @@ func (s *SPVCon) InvHandler(m *wire.MsgInv) {
 	}
 }
 
-func (s *SPVCon) PongBack(nonce uint64) {
+func (s *SPVCon) PongBack(nonce uint64, peerIdx int) {
 	mpong := wire.NewMsgPong(nonce)
 
-	s.outMsgQueue <- mpong
+	s.outMsgQueue[peerIdx] <- mpong
 	return
 }
 
-func (s *SPVCon) SendFilter(f *bloom.Filter) {
-	s.outMsgQueue <- f.MsgFilterLoad()
-
+func (s *SPVCon) SendFilter(f *bloom.Filter, peerIdx int) {
+	s.outMsgQueue[peerIdx] <- f.MsgFilterLoad()
 	return
 }

--- a/uspv/msghandler.go
+++ b/uspv/msghandler.go
@@ -10,14 +10,14 @@ import (
 
 func (s *SPVCon) incomingMessageHandler() {
 	for {
-		n, xm, _, err := wire.ReadMessageWithEncodingN(s.con, s.localVersion,
+		n, xm, _, err := wire.ReadMessageWithEncodingN(s.conns[0], s.localVersion,
 			wire.BitcoinNet(s.Param.NetMagicBytes), wire.LatestEncoding)
 		if err != nil {
 			log.Printf("ReadMessageWithEncodingN error.  Disconnecting from given peer. %s\n", err.Error())
 			if s.randomNodesOK { // if user wants to connect to localhost, let him do so
 				s.Connect("yes") // really any YupString here
 			} else {
-				s.con.Close()
+				s.conns[0].Close()
 				return
 			}
 		}
@@ -78,7 +78,7 @@ func (s *SPVCon) outgoingMessageHandler() {
 			log.Printf("ERROR: nil message to outgoingMessageHandler\n")
 			continue
 		}
-		n, err := wire.WriteMessageWithEncodingN(s.con, msg, s.localVersion,
+		n, err := wire.WriteMessageWithEncodingN(s.conns[0], msg, s.localVersion,
 			wire.BitcoinNet(s.Param.NetMagicBytes), wire.LatestEncoding)
 
 		if err != nil {

--- a/uspv/spvcon.go
+++ b/uspv/spvcon.go
@@ -44,9 +44,9 @@ type SPVCon struct {
 
 	//[doesn't work without fancy mutexes, nevermind, just use header file]
 	// localHeight   int32  // block height we're on
-	remoteHeight  int32  // block height they're on
+	remoteHeight  []int32  // block height they're on
 	localVersion  uint32 // version we report
-	remoteVersion uint32 // version remote node
+	remoteVersion []uint32 // version remote node
 
 	// what's the point of the input queue? remove? leave for now...
 	inMsgQueue  chan wire.Message // Messages coming in from remote node

--- a/uspv/spvcon.go
+++ b/uspv/spvcon.go
@@ -12,8 +12,9 @@ import (
 )
 
 type SPVCon struct {
-	con net.Conn // the (probably tcp) connection to the node
-
+	// store all open tcp connections to bitcoin nodes
+	// can just drop the connection if it misbehaves
+	conns []net.Conn
 	// Enhanced SPV modes for users who have outgrown easy mode SPV
 	// but have not yet graduated to full nodes.
 	HardMode bool   // hard mode doesn't use filters.

--- a/uspv/spvcon.go
+++ b/uspv/spvcon.go
@@ -15,6 +15,7 @@ type SPVCon struct {
 	// store all open tcp connections to bitcoin nodes
 	// can just drop the connection if it misbehaves
 	conns []net.Conn
+	maxConnections int
 	// Enhanced SPV modes for users who have outgrown easy mode SPV
 	// but have not yet graduated to full nodes.
 	HardMode bool   // hard mode doesn't use filters.

--- a/uspv/spvcon.go
+++ b/uspv/spvcon.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/mit-dci/lit/btcutil/chaincfg/chainhash"
 	"github.com/mit-dci/lit/coinparam"
+	"github.com/mit-dci/lit/consts"
 	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/wire"
 )
@@ -14,7 +15,7 @@ import (
 type SPVCon struct {
 	// store all open tcp connections to bitcoin nodes
 	// can just drop the connection if it misbehaves
-	conns []net.Conn
+	conns          []net.Conn
 	maxConnections int
 	// Enhanced SPV modes for users who have outgrown easy mode SPV
 	// but have not yet graduated to full nodes.
@@ -45,12 +46,16 @@ type SPVCon struct {
 	//[doesn't work without fancy mutexes, nevermind, just use header file]
 	// localHeight   int32  // block height we're on
 	remoteHeight  []int32  // block height they're on
-	localVersion  uint32 // version we report
+	localVersion  uint32   // version we report
 	remoteVersion []uint32 // version remote node
 
 	// what's the point of the input queue? remove? leave for now...
-	inMsgQueue  chan wire.Message // Messages coming in from remote node
-	outMsgQueue chan wire.Message // Messages going out to remote node
+	//inMsgQueue  []chan wire.Message // Messages coming in from remote node
+	// doesn't seem to be used anywhere, so retiring for now
+
+	// outMsgQueue is an array that will hold all outoging channel messages
+	// currently set to consts.MaxConns as per bitcoind config
+	outMsgQueue [consts.MaxConns]chan wire.Message // Messages going out to remote node
 
 	WBytes uint64 // total bytes written
 	RBytes uint64 // total bytes read

--- a/wallit/init.go
+++ b/wallit/init.go
@@ -18,7 +18,7 @@ import (
 
 func NewWallit(
 	rootkey *hdkeychain.ExtendedKey, birthHeight int32, resync bool,
-	spvhost, path string, proxyURL string, p *coinparam.Params) (*Wallit, int, error) {
+	spvhost, path string, proxyURL string, maxConnections int, p *coinparam.Params) (*Wallit, int, error) {
 
 	var w Wallit
 	w.rootPrivKey = rootkey
@@ -65,7 +65,7 @@ func NewWallit(
 	}
 	hookFail := false
 	log.Printf("DB corrected height %d\n", height)
-	incomingTx, incomingBlockheight, err := w.Hook.Start(height, spvhost, wallitpath, proxyURL, p)
+	incomingTx, incomingBlockheight, err := w.Hook.Start(height, spvhost, wallitpath, proxyURL, maxConnections, p)
 	if err != nil {
 		hookFail = true
 		log.Printf("NewWallit Hook.Start crash  %s ", err.Error())


### PR DESCRIPTION
Connect simultaneously to multiple peers and send / receive messages from them. An extension of Batch Connections which had a problem that peers would try to ban us. Default maxConnections value is 5 and the maximum maxConnections value is 120. Works fine as tested, although there may be some stuff I missed out. Nodes also have an additional identifier peerIdx based which the message streams are handled.