### PR TITLE
[WIP] Event bus system, replacing ad-hoc channel-based notification systems

### DIFF
--- a/eventbus/bus.go
+++ b/eventbus/bus.go
@@ -1,0 +1,143 @@
+package eventbus
+
+import "sync"
+import "fmt"
+
+// An EventBus takes events and forwards them to event handlers matched by name.
+type EventBus struct {
+	handlers map[string][]*eventhandler
+	mutex    *sync.Mutex
+}
+
+// NewEventBus creates a new event bus without any event handlers.
+func NewEventBus() EventBus {
+	return EventBus{
+		handlers: map[string][]*eventhandler{},
+		mutex:    &sync.Mutex{},
+	}
+}
+
+const (
+
+	// EHANDLE_OK means that the event should not be cancelled.
+	EHANDLE_OK = 0
+
+	// EHANDLE_CANCEL means that the event should be cancelled.
+	EHANDLE_CANCEL = 1
+)
+
+// EventHandleResult is a flag field to represent certain things.
+type EventHandleResult uint8
+
+type eventhandler struct {
+	handleFunc func(Event) EventHandleResult
+}
+
+// RegisterHandler registers an event handler function by name
+func (b *EventBus) RegisterHandler(eventName string, hFunc func(Event) EventHandleResult) {
+
+	b.mutex.Lock()
+
+	h := &eventhandler{
+		handleFunc: hFunc,
+	}
+
+	// We might need to make a new array of handlers.
+	if _, ok := b.handlers[eventName]; !ok {
+		b.handlers[eventName] = make([]*eventhandler, 0)
+	}
+
+	b.handlers[eventName] = append(b.handlers[eventName], h)
+
+	b.mutex.Unlock()
+
+}
+
+// CountHandlers is a convenience function.
+func (b *EventBus) CountHandlers(name string) int {
+	if _, ok := b.handlers[name]; !ok {
+		return 0
+	}
+	return len(b.handlers[name])
+}
+
+// Publish sends an event to the relevant event handlers.
+func (b *EventBus) Publish(event Event) (bool, error) {
+
+	ck := checkEventSanity(event)
+	if ck != nil {
+		return true, ck
+	}
+
+	name := event.Name()
+
+	// Make a copy of the handler list so we don't block for longer than we need to.
+	b.mutex.Lock()
+	src := b.handlers[name]
+	hs := make([]*eventhandler, len(src))
+	copy(hs, src)
+	b.mutex.Unlock()
+
+	// Figure out the flags.
+	f := event.Flags()
+	async := (f & EFLAG_ASYNC_UNSAFE) != 0
+	uncan := (f & EFLAG_UNCANCELLABLE) != 0
+
+	// Actually iterate over all the handlers and make them run.
+	ok := true
+	for _, h := range hs {
+
+		if async {
+
+			// If it's an async event, spawn a goroutine for it.  Ignore results.
+			go callEventHandler(h, event)
+
+		} else {
+
+			// Since it's not async we might cancel it.
+			res, err := callEventHandler(h, event)
+			if err != nil {
+				// TODO Error handling.
+			}
+
+			if res == EHANDLE_CANCEL && !uncan {
+				ok = false
+			}
+
+		}
+
+	}
+
+	return ok, nil
+
+}
+
+// PublishNonblocking sends async events off to the relevant handlers witout blocking.
+func (b *EventBus) PublishNonblocking(event Event) error {
+
+	// Make sure it's async, if it is then we can't do it nonblockingly.
+	async := (event.Flags() & EFLAG_ASYNC_UNSAFE) != 0
+	if !async {
+		return fmt.Errorf("event %s not async but called on function that needs async", event.Name())
+	}
+
+	// This is the lazy way of spawning it.
+	go b.Publish(event)
+	return nil
+
+}
+
+func callEventHandler(handler *eventhandler, event Event) (EventHandleResult, error) {
+	r := handler.handleFunc(event)
+	return r, nil // TODO Catch panics.
+}
+
+func checkEventSanity(e Event) error {
+	f := e.Flags()
+
+	// If it's async then the caller will return before the event handler can know if it wants to cancel the event.
+	if (f&EFLAG_ASYNC_UNSAFE) != 0 && (f&EFLAG_UNCANCELLABLE) == 0 {
+		return fmt.Errorf("event of type %s flagged as async but isn't cancellable, is it using EFLAG_ASYNC_UNSAFE instead of EFLAG_ASYNC?", e.Name())
+	}
+	return nil
+}

--- a/eventbus/bus.go
+++ b/eventbus/bus.go
@@ -80,7 +80,11 @@ func (b *EventBus) Publish(event Event) (bool, error) {
 
 	// Make a copy of the handler list so we don't block for longer than we need to.
 	b.mutex.Lock()
-	b.eventMutexes[name].Lock()
+	eventMutex, present := b.eventMutexes[name]
+	if !present {
+		return true, nil
+	}
+	eventMutex.Lock()
 	src := b.handlers[name]
 	hs := make([]*eventhandler, len(src))
 	copy(hs, src)
@@ -116,7 +120,7 @@ func (b *EventBus) Publish(event Event) (bool, error) {
 
 	}
 
-	b.eventMutexes[name].Unlock()
+	eventMutex.Unlock()
 	return ok, nil
 
 }

--- a/eventbus/bus_test.go
+++ b/eventbus/bus_test.go
@@ -1,8 +1,10 @@
 package eventbus
 
-import "testing"
-import "fmt"
-import "time"
+import (
+	"fmt"
+	"testing"
+	"time"
+)
 
 func TestBusSimple(t *testing.T) {
 	bus := NewEventBus()

--- a/eventbus/bus_test.go
+++ b/eventbus/bus_test.go
@@ -1,0 +1,78 @@
+package eventbus
+
+import "testing"
+import "fmt"
+import "time"
+
+func TestBusSimple(t *testing.T) {
+	bus := NewEventBus()
+	m := "Hello, World!"
+	x := ""
+
+	// Register the handler.
+	bus.RegisterHandler("foo", func(e Event) EventHandleResult {
+		println("normal event handler invoked")
+		e2 := e.(FooEvent)
+		x = e2.msg
+		return EHANDLE_OK
+	})
+	if bus.CountHandlers("foo") != 1 {
+		t.Fail()
+	}
+
+	// Publish an event to the handler.
+	bus.Publish(FooEvent{
+		msg:   m,
+		async: false,
+	})
+	if x != m {
+		t.Fail()
+	}
+}
+
+func TestBusAsync(t *testing.T) {
+
+	bus := NewEventBus()
+	c := make(chan uint8, 2)
+
+	// Register the handler.
+	bus.RegisterHandler("foo", func(e Event) EventHandleResult {
+		println("async event handler invoked")
+		c <- 42
+		return EHANDLE_OK
+	})
+
+	// Escape if we don't work out.
+	go (func() {
+		time.Sleep(1000 * time.Millisecond)
+		t.FailNow()
+	})()
+
+	// Publish an event to the handler.
+	bus.Publish(FooEvent{
+		msg:   "asdf",
+		async: true,
+	})
+
+	r := <-c
+	fmt.Printf("got result: %d\n", r)
+	return
+
+}
+
+type FooEvent struct {
+	msg   string
+	async bool
+}
+
+func (FooEvent) Name() string {
+	return "foo"
+}
+
+func (e FooEvent) Flags() uint8 {
+	if e.async {
+		return EFLAG_ASYNC
+	} else {
+		return EFLAG_NORMAL
+	}
+}

--- a/eventbus/bus_test.go
+++ b/eventbus/bus_test.go
@@ -58,6 +58,20 @@ func TestBusAsync(t *testing.T) {
 
 	r := <-c
 	fmt.Printf("got result: %d\n", r)
+
+}
+
+func TestBusNoHandlers(t *testing.T) {
+
+	bus := NewEventBus()
+
+	bus.Publish(FooEvent{
+		msg:   "lol",
+		async: false,
+	})
+
+	println("event fired with no handlers ok")
+
 	return
 
 }

--- a/eventbus/event.go
+++ b/eventbus/event.go
@@ -1,0 +1,22 @@
+package eventbus
+
+// An Event is a description of "something" that has taken place.
+type Event interface {
+	Name() string
+	Flags() uint8
+}
+
+const (
+
+	// EFLAG_NORMAL means this is a normal sync event.
+	EFLAG_NORMAL = 0
+
+	// EFLAG_UNCANCELLABLE means that the event cannot be cancelled.
+	EFLAG_UNCANCELLABLE = 1 << 0
+
+	// EFLAG_ASYNC_UNSAFE means that the event is an async event.  Don't use declaritvely.
+	EFLAG_ASYNC_UNSAFE = 1 << 1 // Don't use this directly!
+
+	// EFLAG_ASYNC means thtat the event will be processed asychronously.
+	EFLAG_ASYNC = EFLAG_ASYNC_UNSAFE | EFLAG_UNCANCELLABLE
+)

--- a/qln/events.go
+++ b/qln/events.go
@@ -1,0 +1,24 @@
+package qln
+
+import (
+	"github.com/mit-dci/lit/eventbus"
+)
+
+type ChannelStateUpdateEvent struct {
+
+	// Because a lot of these update events are similar, we can use the same
+	// structure for all of them and have a dynamic name, which you wouldn't
+	// normally do.
+	action string
+
+	chanIdx uint32
+	state   *StatCom
+}
+
+func (e ChannelStateUpdateEvent) Name() string {
+	return "qln.chanupdate." + e.action
+}
+
+func (e ChannelStateUpdateEvent) Flags() uint8 {
+	return eventbus.EFLAG_ASYNC
+}

--- a/qln/init.go
+++ b/qln/init.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mit-dci/lit/btcutil/hdkeychain"
 	"github.com/mit-dci/lit/coinparam"
 	"github.com/mit-dci/lit/dlc"
+	"github.com/mit-dci/lit/eventbus"
 	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/portxo"
 	"github.com/mit-dci/lit/wallit"
@@ -22,6 +23,7 @@ func NewLitNode(privKey *[32]byte, path string, trackerURL string, proxyURL stri
 
 	nd := new(LitNode)
 	nd.LitFolder = path
+	nd.EventSystem = eventbus.NewEventBus()
 
 	litdbpath := filepath.Join(nd.LitFolder, "ln.db")
 	err := nd.OpenDB(litdbpath)

--- a/qln/lndb.go
+++ b/qln/lndb.go
@@ -7,11 +7,12 @@ import (
 	"time"
 
 	"github.com/boltdb/bolt"
-	"github.com/mit-dci/lit/lndc"
 	"github.com/mit-dci/lit/btcutil"
 	"github.com/mit-dci/lit/btcutil/btcec"
 	"github.com/mit-dci/lit/dlc"
 	"github.com/mit-dci/lit/elkrem"
+	"github.com/mit-dci/lit/eventbus"
+	"github.com/mit-dci/lit/lndc"
 	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/watchtower"
 	"github.com/mit-dci/lit/wire"
@@ -89,6 +90,9 @@ type LitNode struct {
 	LitFolder string // path to save stuff
 
 	IdentityKey *btcec.PrivateKey
+
+	// event bus
+	Events eventbus.EventBus
 
 	// all nodes have a watchtower.  but could have a tower without a node
 	Tower watchtower.Watcher


### PR DESCRIPTION
I've noticed in some places we're basing triggering certain actions around sending a message to a channel.  This works, but it's not very extensible and it leads to some bad habits.

This kind of event bus is just a simple design that uses strings as event names and an interface for the overall "`Event`" type.  Events be handled synchronously or asynchronously on a per-event basis, and there's logic to "cancel" and even if-needed.  There isn't a "handler priority" system but that shouldn't be too difficult to develop.

The next steps for this is just porting over old code to use this event bus system and adding events for different kinds of actions.