### PR TITLE
Autolisten fixes

### DIFF
--- a/lit.go
+++ b/lit.go
@@ -62,7 +62,7 @@ var (
 	defaultHomeDir                         = os.Getenv("HOME")
 	defaultRpcport                         = uint16(8001)
 	defaultRpchost                         = "localhost"
-	defaultAutoReconnect                   = false
+	defaultAutoReconnect                   = true
 	defaultAutoListenPort                  = ":2448"
 	defaultAutoReconnectInterval           = int64(60)
 	defaultUpnPFlag                        = false

--- a/qln/autoconnect.go
+++ b/qln/autoconnect.go
@@ -26,7 +26,12 @@ func removeDuplicates(inputArr []uint32) []uint32 {
 // previously known peers attached with the coin daemons running.
 func (nd *LitNode) AutoReconnect(listenPort string, interval int64, connectedCoinOnly bool) {
 	// Listen myself after a timeout
-	nd.TCPListener(listenPort)
+	_, err := nd.TCPListener(listenPort)
+	if err != nil {
+		logging.Errorf("Could not start listening automatically: %s", err.Error())
+		return
+	}
+
 	// Reconnect to other nodes after an interval
 	ticker := time.NewTicker(time.Duration(interval) * time.Second)
 	qcs, _ := nd.GetAllQchans() // get all chan data


### PR DESCRIPTION
Autolisten is needed for lit-af now we're talking to lit over LNDC. So autoReconnect should be on by default (which will also initiate listening).

Also added some logging in case something goes wrong, because now it's not obvious.