### PR TITLE
Fix test failure

### DIFF
--- a/cmd/lit-af/shell.go
+++ b/cmd/lit-af/shell.go
@@ -18,7 +18,7 @@ import (
 
 var lsCommand = &Command{
 	Format: fmt.Sprintf("%s%s\n", lnutil.White("ls"), lnutil.ReqColor(("topic"))),
-	Description: fmt.Sprintf("%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s",
+	Description: fmt.Sprintf("%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s",
 		"Show various information about our current state, such as connections, addresses, UTXO's, balances, etc.",
 		fmt.Sprintf("%s %s",
 			lnutil.White("topic"),


### PR DESCRIPTION
This fixes failure in `go test`:

```
# github.com/mit-dci/lit/cmd/lit-af
cmd/lit-af/shell.go:21: Sprintf call needs 9 args but has 10 args
```