### PR TITLE
Fix for (de)serialization error

### DIFF
--- a/lndc/noise_test.go
+++ b/lndc/noise_test.go
@@ -3,15 +3,15 @@ package lndc
 import (
 	"bytes"
 	"encoding/hex"
-	"github.com/mit-dci/lit/btcutil/koblitz"
-	"github.com/mit-dci/lit/crypto/koblitz"
-	"github.com/mit-dci/lit/lnutil"
-	"github.com/mit-dci/lit/logging"
 	"io"
 	"math"
 	"net"
 	"sync"
 	"testing"
+
+	"github.com/mit-dci/lit/crypto/koblitz"
+	"github.com/mit-dci/lit/lnutil"
+	"github.com/mit-dci/lit/logging"
 )
 
 type maybeNetConn struct {

--- a/qln/lndb.go
+++ b/qln/lndb.go
@@ -600,7 +600,7 @@ func (nd *LitNode) ReloadQchanState(q *Qchan) error {
 		if txoBytes == nil {
 			return fmt.Errorf("utxo value empty")
 		}
-		u, err := portxo.PorTxoFromBytes(txoBytes[99:])
+		u, err := portxo.PorTxoFromBytes(txoBytes[107:])
 		if err != nil {
 			return err
 		}

--- a/qln/multihop.go
+++ b/qln/multihop.go
@@ -5,9 +5,9 @@ import (
 	"crypto/rand"
 	"fmt"
 
-	"github.com/adiabat/bech32"
-	"github.com/btcsuite/fastsha256"
+	"github.com/mit-dci/lit/bech32"
 	"github.com/mit-dci/lit/consts"
+	"github.com/mit-dci/lit/crypto/fastsha256"
 	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/logging"
 )

--- a/shortaddr/shortadr.go
+++ b/shortaddr/shortadr.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 
-	"github.com/btcsuite/fastsha256"
+	"github.com/mit-dci/lit/crypto/fastsha256"
 )
 
 /*


### PR DESCRIPTION
This fixes the `Not connected to cointype 5` issue in one of the tests. 

Magic numbers...

Also added a few import changes that were causing the build to fail. Wrong packages were imported.