### PR TITLE
Change logging scheme

### DIFF
--- a/lit.go
+++ b/lit.go
@@ -45,8 +45,9 @@ type config struct { // define a struct for usage with go-flags
 	Tower  bool `long:"tower" description:"Watchtower: Run a watching node"`
 	Hard   bool `short:"t" long:"hard" description:"Flag to set networks."`
 
-	// logging, bool because that's how the tool works
-	LogLevel []bool `short:"v" long:"verbose" description:"Set verbosity level from 0 to 5 (most to least)"`
+	// logging and debug parameters
+	LogLevel []bool `short:"v" description:"Set verbosity level to verbose (-v) or very verbose (-vv)"`
+	Debug bool `short:"d" long:"debug" description:"Set debug mode (highest verbosity level)"`
 
 	// rpc server config
 	Rpcport uint16 `short:"p" long:"rpcport" description:"Set RPC port to connect to"`
@@ -71,7 +72,7 @@ var (
 	defaultAutoListenPort                  = ":2448"
 	defaultAutoReconnectInterval           = int64(60)
 	defaultUpnPFlag                        = false
-	defaultLogLevel                        = 3 // reasons
+	defaultLogLevel                        = 0
 	defaultAutoReconnectOnlyConnectedCoins = false
 	defaultUnauthRPC                       = false
 )
@@ -172,7 +173,6 @@ func main() {
 		AutoListenPort:                  defaultAutoListenPort,
 		AutoReconnectInterval:           defaultAutoReconnectInterval,
 		AutoReconnectOnlyConnectedCoins: defaultAutoReconnectOnlyConnectedCoins,
-		LogLevel:                        []bool{}, // reasons
 		UnauthRPC:                       defaultUnauthRPC,
 	}
 
@@ -182,7 +182,7 @@ func main() {
 		conf.ChainProxyURL = conf.ProxyURL
 	}
 
-	// SIGQUIT hander for debugging
+	// SIGQUIT handler for debugging
 	go func() {
 		sigs := make(chan os.Signal, 1)
 		signal.Notify(sigs, syscall.SIGQUIT)

--- a/lit.go
+++ b/lit.go
@@ -46,8 +46,7 @@ type config struct { // define a struct for usage with go-flags
 	Hard   bool `short:"t" long:"hard" description:"Flag to set networks."`
 
 	// logging and debug parameters
-	LogLevel []bool `short:"v" description:"Set verbosity level to verbose (-v) or very verbose (-vv)"`
-	Debug bool `short:"d" long:"debug" description:"Set debug mode (highest verbosity level)"`
+	LogLevel []bool `short:"v" description:"Set verbosity level to verbose (-v), very verbose (-vv) or very very verbose (-vvv)"`
 
 	// rpc server config
 	Rpcport uint16 `short:"p" long:"rpcport" description:"Set RPC port to connect to"`

--- a/litinit.go
+++ b/litinit.go
@@ -126,8 +126,7 @@ func litSetup(conf *config) *[32]byte {
 		logLevel = 1
 	} else if len(conf.LogLevel) == 2 { // -vv
 		logLevel = 2
-	}
-	if conf.Debug { // -d
+	} else if len(conf.LogLevel) >= 3 {
 		logLevel = 3
 	}
 	logging.SetLogLevel(logLevel)

--- a/litinit.go
+++ b/litinit.go
@@ -54,6 +54,8 @@ func litSetup(conf *config) *[32]byte {
 	// Load config from file and parse
 	parser := newConfigParser(conf, flags.Default)
 
+	// set default log level here
+	logging.SetLogLevel(defaultLogLevel)
 	// create home directory
 	_, err = os.Stat(preconf.LitHomeDir)
 	if err != nil {
@@ -119,13 +121,16 @@ func litSetup(conf *config) *[32]byte {
 	// TODO ... what's this do?
 	defer logFile.Close()
 
-	// special handling for this one.
-	ll := len(conf.LogLevel)
-	if ll > 0 {
-		logging.SetLogLevel(len(conf.LogLevel))
-	} else {
-		logging.SetLogLevel(defaultLogLevel)
+	logLevel := -1
+	if len(conf.LogLevel) == 1 { // -v
+		logLevel = 1
+	} else if len(conf.LogLevel) == 2 { // -vv
+		logLevel = 2
 	}
+	if conf.Debug { // -d
+		logLevel = 3
+	}
+	logging.SetLogLevel(logLevel)
 
 	// Allow node with no linked wallets, for testing.
 	// TODO Should update tests and disallow nodes without wallets later.

--- a/logging/log.go
+++ b/logging/log.go
@@ -10,14 +10,13 @@ import (
 type LogLevel int
 
 const (
-	LogLevelPanicOrFatal LogLevel = 0
-	LogLevelError        LogLevel = 1
-	LogLevelWarning      LogLevel = 2
-	LogLevelInfo         LogLevel = 3
-	LogLevelDebug        LogLevel = 4
+	LogLevelError        LogLevel = 0
+	LogLevelWarning      LogLevel = 1
+	LogLevelInfo         LogLevel = 2
+	LogLevelDebug        LogLevel = 3
 )
 
-var logLevel = LogLevelPanicOrFatal
+var logLevel = LogLevelError
 
 func SetLogLevel(newLevel int) {
 	logLevel = LogLevel(newLevel)


### PR DESCRIPTION
Instead of `-v`, `-vv`, `-vvv`, `-vvvv` and `-vvvvv`, we now make `LogLevelError` as default (which makes sense because you shouldn't ideally ignore any errors) and then have `LogLevelWarning` as `-v`, `LogLevelInfo` as `-vv` and `LogLevelDebug` as `-d` or `--debug`.