### PR TITLE
Allow connecting to coindaemon peers by hostname, not just localhost

### DIFF
--- a/uspv/init.go
+++ b/uspv/init.go
@@ -27,15 +27,7 @@ func IP4(ipAddress string) bool {
 func (s *SPVCon) parseRemoteNode(remoteNode string) (string, string, error) {
 	colonCount := strings.Count(remoteNode, ":")
 	var conMode string
-	if colonCount == 0 {
-		if IP4(remoteNode) || remoteNode == "localhost" { // need this to connect to locahost
-			remoteNode = remoteNode + ":" + s.Param.DefaultPort
-		}
-		// only ipv4 clears this since ipv6 has colons
-		conMode = "tcp4"
-		return remoteNode, conMode, nil
-	} else if colonCount == 1 && IP4(strings.Split(remoteNode, ":")[0]) {
-		// custom port on ipv4
+	if colonCount <= 1 {
 		return remoteNode, "tcp4", nil
 	} else if colonCount >= 5 {
 		// ipv6 without remote port

--- a/uspv/init.go
+++ b/uspv/init.go
@@ -28,6 +28,9 @@ func (s *SPVCon) parseRemoteNode(remoteNode string) (string, string, error) {
 	colonCount := strings.Count(remoteNode, ":")
 	var conMode string
 	if colonCount <= 1 {
+		if colonCount == 0 {
+			remoteNode = remoteNode + ":" + s.Param.DefaultPort
+		}
 		return remoteNode, "tcp4", nil
 	} else if colonCount >= 5 {
 		// ipv6 without remote port


### PR DESCRIPTION
This allows you to connect to coindaemons not just by IP or `localhost` but also hostname. So i could use `reg=someserver:18444`