### PR TITLE
Re-disabled tests for break right after fund, since it's not supported

### DIFF
--- a/test/tests.txt
+++ b/test/tests.txt
@@ -12,8 +12,9 @@ send2 2
 fund 2
 close 2 run_test_forward
 close 2 run_test_reverse
-break 2 run_test_forward
-break 2 run_test_reverse
+# Disabled these to tests until we support breaking right after funding (we don't)
+# break 2 run_test_forward
+# break 2 run_test_reverse
 push 2
 pushbreak 2 run_test_forward
 pushbreak 2 run_test_reverse


### PR DESCRIPTION
These two tests should not run until there's a fix for allowing to break a channel right after funding.