### PR TITLE
Just remove obsolete logging statements. Elkrem not needed for break

### DIFF
--- a/qln/break.go
+++ b/qln/break.go
@@ -28,16 +28,6 @@ func (nd *LitNode) BreakChannel(q *Qchan) error {
 	}
 
 	logging.Infof("breaking (%d,%d)\n", q.Peer(), q.Idx())
-	z, err := q.ElkSnd.AtIndex(0)
-	if err != nil {
-		return err
-	}
-	logging.Infof("elk send 0: %s\n", z.String())
-	z, err = q.ElkRcv.AtIndex(0)
-	if err != nil {
-		return err
-	}
-	logging.Infof("elk recv 0: %s\n", z.String())
 
 	// set delta to 0... needed for break
 	q.State.Delta = 0

--- a/test/tests.txt
+++ b/test/tests.txt
@@ -13,8 +13,8 @@ fund 2
 close 2 run_test_forward
 close 2 run_test_reverse
 # Disabled these to tests until we support breaking right after funding (we don't)
-# break 2 run_test_forward
-# break 2 run_test_reverse
+break 2 run_test_forward
+break 2 run_test_reverse
 push 2
 pushbreak 2 run_test_forward
 pushbreak 2 run_test_reverse


### PR DESCRIPTION
This fixes the failing two tests breaking right after fund. The elkrem is empty, but also not needed to break. Elkrem is needed for justice - at state 2 or higher.

Return value of ElkRcv is not used, but it used to crash this section.

Re-enabled the two tests