### PR TITLE
Format lit-af help output

### DIFF
--- a/cmd/lit-af/chancmds.go
+++ b/cmd/lit-af/chancmds.go
@@ -91,7 +91,7 @@ var breakCommand = &Command{
 }
 
 var historyCommand = &Command{
-	Format:           lnutil.White("history"),
+	Format:           fmt.Sprintf("%s\n", lnutil.White("history")),
 	Description:      "Show all the metadata for justice txs",
 	ShortDescription: "Show all the metadata for justice txs.\n",
 }

--- a/cmd/lit-af/netcmds.go
+++ b/cmd/lit-af/netcmds.go
@@ -41,16 +41,16 @@ var graphCommand = &Command{
 }
 
 var rcAuthCommand = &Command{
-	Format:           fmt.Sprintf("%s %s\n", lnutil.White("rcauth"), lnutil.ReqColor("pub", "auth (true|false)")),
+	Format:           fmt.Sprintf("%s%s\n", lnutil.White("rcauth"), lnutil.ReqColor("pub", "auth (true|false)")),
 	Description:      "Authorizes a remote peer by pubkey for sending remote control commands over LNDC\n",
-	ShortDescription: "Manages authorization for remote control",
+	ShortDescription: "Manages authorization for remote control\n",
 }
 
 // Request remote control access
 var rcRequestCommand = &Command{
 	Format:           fmt.Sprintf("%s\n", lnutil.White("rcreq")),
 	Description:      "If this lit-af key has not been authorized on the server, this command will let the server know you want access. Another client that is privileged can authorize you then.\n",
-	ShortDescription: "Requests remote control authorization",
+	ShortDescription: "Requests remote control authorization\n",
 }
 
 // graph gets the channel map


### PR DESCRIPTION
Was earlier
```
rcauth <pub> <auth (true|false)>
	Manages authorization for remote controlrcreq
	Requests remote control authorizationhistory
	Show all the metadata for justice txs.
off	Shut down the lit node.
```
now is 
```
rcauth <pub> <auth (true|false)>
	Manages authorization for remote control
rcreq
	Requests remote control authorization
history
	Show all the metadata for justice txs.
```