### PR TITLE
Refactor Qchan serialization to store data as flat JSON

### DIFF
--- a/elkrem/elkrem_test.go
+++ b/elkrem/elkrem_test.go
@@ -22,9 +22,9 @@ func TestElkremBig(t *testing.T) {
 		}
 		if n%1000 == 999 {
 			t.Logf("stack with %d received hashes\n", n+1)
-			for i, n := range rcv.s {
+			for i, n := range rcv.Nodes {
 				t.Logf("Stack element %d: index %d height %d %s\n",
-					i, n.i, n.h, n.sha.String())
+					i, n.I, n.H, n.Sha.String())
 			}
 		}
 	}
@@ -54,9 +54,9 @@ func TestElkremLess(t *testing.T) {
 		}
 		if n%1000 == 999 {
 			t.Logf("stack with %d received hashes\n", n+1)
-			for i, n := range rcv.s {
+			for i, n := range rcv.Nodes {
 				t.Logf("Stack element %d: index %d height %d %s\n",
-					i, n.i, n.h, n.sha.String())
+					i, n.I, n.H, n.Sha.String())
 			}
 		}
 	}

--- a/elkrem/serdes_test.go
+++ b/elkrem/serdes_test.go
@@ -10,14 +10,14 @@ func ReceiverSerdesTest(t *testing.T, rcv *ElkremReceiver) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Logf("rcv2 has len %d\n", len(rcv.s))
+	t.Logf("rcv2 has len %d\n", len(rcv.Nodes))
 	t.Logf("Serialized receiver; %d bytes, hex:\n%x\n", len(b), b)
 
 	rcv2, err := ElkremReceiverFromBytes(b)
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Logf("rcv2 has len %d\n", len(rcv2.s))
+	t.Logf("rcv2 has len %d\n", len(rcv2.Nodes))
 	b2, err := rcv2.ToBytes()
 	if err != nil {
 		t.Fatal(err)

--- a/litrpc/chancmds.go
+++ b/litrpc/chancmds.go
@@ -392,6 +392,7 @@ func (r *LitRPC) Push(args PushArgs, reply *PushReply) error {
 
 	err = r.Node.PushChannel(qc, uint32(args.Amt), args.Data)
 	if err != nil {
+		logging.Errorf("Push error: %s\n", err.Error())
 		return err
 	}
 

--- a/qln/close.go
+++ b/qln/close.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/mit-dci/lit/crypto/koblitz"
 	"github.com/mit-dci/lit/btcutil/chaincfg/chainhash"
 	"github.com/mit-dci/lit/btcutil/txscript"
 	"github.com/mit-dci/lit/crypto/fastsha256"
+	"github.com/mit-dci/lit/crypto/koblitz"
 	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/logging"
 	"github.com/mit-dci/lit/portxo"
@@ -82,8 +82,8 @@ func (nd *LitNode) CoopClose(q *Qchan) error {
 	// we don't accept payments on this channel anymore.
 
 	outMsg := lnutil.NewCloseReqMsg(q.Peer(), q.Op, signature)
-
 	nd.tmpSendLitMsg(outMsg)
+
 	return nil
 }
 

--- a/qln/init.go
+++ b/qln/init.go
@@ -230,7 +230,7 @@ func (nd *LitNode) OpenDB(filename string) error {
 	}
 	// create buckets if they're not already there
 	err = nd.LitDB.Update(func(btx *bolt.Tx) error {
-		_, err := btx.CreateBucketIfNotExists(BKTChannel)
+		_, err := btx.CreateBucketIfNotExists(BKTChannelData)
 		if err != nil {
 			return err
 		}

--- a/qln/justicetx.go
+++ b/qln/justicetx.go
@@ -165,6 +165,7 @@ func (nd *LitNode) BuildJusticeSig(q *Qchan) error {
 
 	jtxid := justiceTx.TxHash()
 	logging.Infof("made justice tx %s\n", jtxid.String())
+
 	// get hashcache for signing
 	hCache := txscript.NewTxSigHashes(justiceTx)
 

--- a/qln/lnchannels.go
+++ b/qln/lnchannels.go
@@ -96,7 +96,7 @@ type StatCom struct {
 	NextElkPoint [33]byte `json:"elkp1"` // Point stored for next state
 	N2ElkPoint   [33]byte `json:"elkp2"` // Point for state after next (in case of collision)
 
-	sig [64]byte `json:"sig"` // Counterparty's signature for current state
+	Sig [64]byte `json:"sig"` // Counterparty's signature for current state
 	// don't write to sig directly; only overwrite via fn() call
 
 	// note sig can be nil during channel creation. if stateIdx isn't 0,

--- a/qln/lnchannels.go
+++ b/qln/lnchannels.go
@@ -10,8 +10,8 @@ import (
 	"github.com/mit-dci/lit/logging"
 	"github.com/mit-dci/lit/portxo"
 
-	"github.com/mit-dci/lit/crypto/koblitz"
 	"github.com/mit-dci/lit/btcutil/chaincfg/chainhash"
+	"github.com/mit-dci/lit/crypto/koblitz"
 )
 
 // Uhh, quick channel.  For now.  Once you get greater spire it upgrades to
@@ -52,51 +52,51 @@ type Qchan struct {
 
 // 4 + 1 + 8 + 32 + 4 + 33 + 33 + 1 + 5 + 32 + 64 = 217 bytes
 type HTLC struct {
-	Idx uint32
+	Idx uint32 `json:"idx"`
 
-	Incoming bool
-	Amt      int64
-	RHash    [32]byte
-	Locktime uint32
+	Incoming bool     `json:"incoming"`
+	Amt      int64    `json:"amt"`
+	RHash    [32]byte `json:"hash"`
+	Locktime uint32   `json:"locktime"`
 
-	MyHTLCBase    [33]byte
-	TheirHTLCBase [33]byte
+	MyHTLCBase    [33]byte `json:"mhtlcbase"`
+	TheirHTLCBase [33]byte `json:"rhtlcbase"`
 
-	KeyGen portxo.KeyGen
+	KeyGen portxo.KeyGen `json:"keygen"`
 
-	Sig [64]byte
+	Sig [64]byte `json:"sig"`
 
-	R              [16]byte
-	Clearing       bool
-	Cleared        bool
-	ClearedOnChain bool // To keep track of what HTLCs we claimed on-chain
+	R              [16]byte `json:"preimage"`
+	Clearing       bool     `json:"clearing"`
+	Cleared        bool     `json:"cleared"`
+	ClearedOnChain bool     `json:"clearedoc"` // To keep track of what HTLCs we claimed on-chain
 }
 
 // StatComs are State Commitments.
 // all elements are saved to the db.
 type StatCom struct {
-	StateIdx uint64 // this is the n'th state commitment
+	StateIdx uint64 `json:"idx"` // this is the n'th state commitment
 
-	WatchUpTo uint64 // have sent out to watchtowers up to this state  ( < stateidx)
+	WatchUpTo uint64 `json:"watchupto"` // have sent out to watchtowers up to this state  ( < stateidx)
 
-	MyAmt int64 // my channel allocation
+	MyAmt int64 `json:"amt"` // my channel allocation
 
-	Fee int64 // symmetric fee in absolute satoshis
+	Fee int64 `json:"fee"` // symmetric fee in absolute satoshis
 
-	Data [32]byte
+	Data [32]byte `json:"miscdata"`
 
 	// their Amt is the utxo.Value minus this
-	Delta int32 // fund amount in-transit; is negative for the pusher
+	Delta int32 `json:"delta"` // fund amount in-transit; is negative for the pusher
 	// Delta for when the channel is in a collision state which needs to be resolved
-	Collision int32
+	Collision int32 `json:"collision"`
 
 	// Elkrem point from counterparty, used to make
 	// Homomorphic Adversarial Key Derivation public keys (HAKD)
-	ElkPoint     [33]byte // saved to disk, current revealable point
-	NextElkPoint [33]byte // Point stored for next state
-	N2ElkPoint   [33]byte // Point for state after next (in case of collision)
+	ElkPoint     [33]byte `json:"elkp0"` // saved to disk, current revealable point
+	NextElkPoint [33]byte `json:"elkp1"` // Point stored for next state
+	N2ElkPoint   [33]byte `json:"elkp2"` // Point for state after next (in case of collision)
 
-	sig [64]byte // Counterparty's signature for current state
+	sig [64]byte `json:"sig"` // Counterparty's signature for current state
 	// don't write to sig directly; only overwrite via fn() call
 
 	// note sig can be nil during channel creation. if stateIdx isn't 0,
@@ -104,26 +104,26 @@ type StatCom struct {
 	// only one sig is ever stored, to prevent broadcasting the wrong tx.
 	// could add a mutex here... maybe will later.
 
-	HTLCIdx       uint32
-	InProgHTLC    *HTLC // Current in progress HTLC
-	CollidingHTLC *HTLC // HTLC for when the channel is colliding
+	HTLCIdx       uint32 `json:"htlcidx"`
+	InProgHTLC    *HTLC  `json:"iphtlc"`   // Current in progress HTLC
+	CollidingHTLC *HTLC  `json:"collhtlc"` // HTLC for when the channel is colliding
 
-	CollidingHashDelta     bool // True when colliding between a DeltaSig and HashSig/PreImageSig
-	CollidingHashPreimage  bool // True when colliding between HashSig and PreimageSig
-	CollidingPreimages     bool // True when colliding between PreimageSig and PreimageSig
-	CollidingPreimageDelta bool // True when colliding between a DeltaSig and HashSig/PreImageSig
+	CollidingHashDelta     bool `json:"colhd"` // True when colliding between a DeltaSig and HashSig/PreImageSig
+	CollidingHashPreimage  bool `json:"colhp"` // True when colliding between HashSig and PreimageSig
+	CollidingPreimages     bool `json:"colpp"` // True when colliding between PreimageSig and PreimageSig
+	CollidingPreimageDelta bool `json:"colpd"` // True when colliding between a DeltaSig and HashSig/PreImageSig
 
 	// Analogous to the ElkPoints above but used for generating their pubkey for the HTLC
-	NextHTLCBase [33]byte
-	N2HTLCBase   [33]byte
+	NextHTLCBase [33]byte `json:"rnexthtlcbase"`
+	N2HTLCBase   [33]byte `json:"rnexthtlcbase2"`
 
-	MyNextHTLCBase [33]byte
-	MyN2HTLCBase   [33]byte
+	MyNextHTLCBase [33]byte `json:"mnexthtlcbase"`
+	MyN2HTLCBase   [33]byte `json:"mnexthtlcbase2"`
 
 	// Any HTLCs associated with this channel state (can be nil)
-	HTLCs []HTLC
+	HTLCs []HTLC `json:"htlcs"`
 
-	Failed bool // S there was a fatal error with the channel
+	Failed bool `json:"failed"` // S there was a fatal error with the channel
 	// meaning it cannot be used safely
 }
 
@@ -136,9 +136,9 @@ type StatCom struct {
 type QCloseData struct {
 	// 3 txid / height pairs are stored.  All 3 only are used in the
 	// case where you grab their invalid close.
-	CloseTxid   chainhash.Hash
-	CloseHeight int32
-	Closed      bool // if channel is closed; if CloseTxid != -1
+	CloseTxid   chainhash.Hash `json:"txid"`
+	CloseHeight int32          `json:"height"`
+	Closed      bool           `json:"closed"` // if channel is closed; if CloseTxid != -1
 }
 
 // ChannelInfo prints info about a channel.

--- a/qln/lndb.go
+++ b/qln/lndb.go
@@ -354,7 +354,7 @@ func (nd *LitNode) SaveNicknameForPeerIdx(nickname string, idx uint32) error {
 	return err // same as if err != nil { return err } ; return nil
 }
 
-// SaveQchanUtxoData saves utxo data such as outpoint and close tx / status
+// SaveQchanUtxoData saves utxo data such as outpoint and close tx / status.
 func (nd *LitNode) SaveQchanUtxoData(q *Qchan) error {
 	logging.Warnln("someone tried to SaveQchanUtxoData, doing some hacks to make it save only parts of it")
 
@@ -366,6 +366,11 @@ func (nd *LitNode) SaveQchanUtxoData(q *Qchan) error {
 		return nil
 	}
 	fq.PorTxo = q.PorTxo
+
+	// we also quietly save close data when we call this function
+	if q.CloseData.Closed {
+		fq.CloseData = q.CloseData
+	}
 
 	return nd.SaveQChan(fq)
 }

--- a/qln/lndb.go
+++ b/qln/lndb.go
@@ -10,16 +10,13 @@ import (
 	"github.com/mit-dci/lit/logging"
 
 	"github.com/boltdb/bolt"
-	"github.com/mit-dci/lit/btcutil"
 	"github.com/mit-dci/lit/crypto/koblitz"
 	"github.com/mit-dci/lit/dlc"
-	"github.com/mit-dci/lit/elkrem"
 	"github.com/mit-dci/lit/eventbus"
 	"github.com/mit-dci/lit/lncore"
 	"github.com/mit-dci/lit/lndc"
 	"github.com/mit-dci/lit/lnp2p"
 	"github.com/mit-dci/lit/lnutil"
-	"github.com/mit-dci/lit/portxo"
 	"github.com/mit-dci/lit/watchtower"
 	"github.com/mit-dci/lit/wire"
 )
@@ -369,39 +366,18 @@ func (nd *LitNode) SaveNicknameForPeerIdx(nickname string, idx uint32) error {
 
 // SaveQchanUtxoData saves utxo data such as outpoint and close tx / status
 func (nd *LitNode) SaveQchanUtxoData(q *Qchan) error {
-	return nd.LitDB.Update(func(btx *bolt.Tx) error {
-		cbk := btx.Bucket(BKTChannel)
-		if cbk == nil {
-			return fmt.Errorf("no peers")
-		}
+	logging.Warnln("someone tried to SaveQchanUtxoData, doing some hacks to make it save only parts of it")
 
-		opArr := lnutil.OutPointToBytes(q.Op)
+	// XXX This is a horrible hack and we need to change other code to not be
+	// dependent on the way this data is saved/loaded.
+	opArr := lnutil.OutPointToBytes(q.Op)
+	fq, err := nd.GetQchan(opArr)
+	if err != nil {
+		return nil
+	}
+	fq.PorTxo = q.PorTxo
 
-		qcBucket := cbk.Bucket(opArr[:])
-		if qcBucket == nil {
-			return fmt.Errorf("outpoint %s not in db ", q.Op.String())
-		}
-
-		if q.CloseData.Closed {
-			closeBytes, err := q.CloseData.ToBytes()
-			if err != nil {
-				return err
-			}
-			err = qcBucket.Put(KEYqclose, closeBytes)
-			if err != nil {
-				return err
-			}
-		}
-
-		// serialize channel
-		qcBytes, err := q.ToBytes()
-		if err != nil {
-			return err
-		}
-
-		// save qchannel
-		return qcBucket.Put(KEYutxo, qcBytes)
-	})
+	return nd.SaveQChan(fq)
 }
 
 // register a new Qchan in the db
@@ -410,73 +386,16 @@ func (nd *LitNode) SaveQChan(q *Qchan) error {
 		return fmt.Errorf("SaveQChan: nil qchan")
 	}
 
+	opArr := lnutil.OutPointToBytes(q.Op)
+	qdata := nd.QchanSerializeToBytes(q)
+
 	// save channel to db.  It has no state, and has no outpoint yet
 	err := nd.LitDB.Update(func(btx *bolt.Tx) error {
-
-		qOPArr := lnutil.OutPointToBytes(q.Op)
-
-		// make mapping of index to outpoint
-		cmp := btx.Bucket(BKTChanMap)
-		if cmp == nil {
-			return fmt.Errorf("SaveQChan: no channel map bucket")
+		b := btx.Bucket(BKTChannelData)
+		if b == nil {
+			return fmt.Errorf("channel data bucket not found")
 		}
-
-		// save index : outpoint
-		err := cmp.Put(lnutil.U32tB(q.Idx()), qOPArr[:])
-		if err != nil {
-			return err
-		}
-		logging.Infof("saved %d : %s mapping in db\n", q.Idx(), q.Op.String())
-
-		cbk := btx.Bucket(BKTChannel) // go into bucket for all peers
-		if cbk == nil {
-			return fmt.Errorf("SaveQChan: no channel bucket")
-		}
-
-		// make bucket for this channel
-
-		qcBucket, err := cbk.CreateBucket(qOPArr[:])
-		if qcBucket == nil || err != nil {
-			return fmt.Errorf("SaveQChan: can't make channel bucket")
-		}
-
-		// serialize channel
-		qcBytes, err := q.ToBytes()
-		if err != nil {
-			return err
-		}
-
-		// save qchannel in the bucket
-		err = qcBucket.Put(KEYutxo, qcBytes)
-		if err != nil {
-			return err
-		}
-
-		// also save all state; maybe there isn't any ..?
-		// serialize elkrem receiver if it exists
-
-		if q.ElkRcv != nil {
-			logging.Infof("--- elk rcv exists, saving\n")
-
-			eb, err := q.ElkRcv.ToBytes()
-			if err != nil {
-				return err
-			}
-			// save elkrem
-			err = qcBucket.Put(KEYElkRecv, eb)
-			if err != nil {
-				return err
-			}
-		}
-
-		// serialize state
-		b, err := q.State.ToBytes()
-		if err != nil {
-			return err
-		}
-		// save state
-		logging.Infof("writing %d byte state to bucket\n", len(b))
-		return qcBucket.Put(KEYState, b)
+		return b.Put(opArr[:], qdata)
 	})
 	if err != nil {
 		return err
@@ -485,168 +404,23 @@ func (nd *LitNode) SaveQChan(q *Qchan) error {
 	return nil
 }
 
-// RestoreQchanFromBucket loads the full qchan into memory from the
-// bucket where it's stored.  Loads the channel info, the elkrems,
-// and the current state.
-// restore happens all at once, but saving to the db can happen
-// incrementally (updating states)
-// This should populate everything int he Qchan struct: the elkrems and the states.
-// Elkrem sender always works; is derived from local key data.
-// Elkrem receiver can be "empty" with nothing in it (no data in db)
-func (nd *LitNode) RestoreQchanFromBucket(bkt *bolt.Bucket) (*Qchan, error) {
-	if bkt == nil { // can't do anything without a bucket
-		return nil, fmt.Errorf("empty qchan bucket ")
-	}
-
-	// load the serialized channel base description
-	qc, err := QchanFromBytes(bkt.Get(KEYutxo))
-	if err != nil {
-		logging.Errorf("Error decoding Qchan: %s", err.Error())
-		return nil, err
-	}
-	qc.CloseData, err = QCloseFromBytes(bkt.Get(KEYqclose))
-	if err != nil {
-		logging.Errorf("Error decoding QClose: %s", err.Error())
-		return nil, err
-	}
-
-	// get my channel pubkey
-	qc.MyPub, _ = nd.GetUsePub(qc.KeyGen, UseChannelFund)
-
-	// derive my refund / base point from index
-	qc.MyRefundPub, _ = nd.GetUsePub(qc.KeyGen, UseChannelRefund)
-	qc.MyHAKDBase, _ = nd.GetUsePub(qc.KeyGen, UseChannelHAKDBase)
-
-	// derive my watchtower refund PKH
-	watchRefundPub, _ := nd.GetUsePub(qc.KeyGen, UseChannelWatchRefund)
-	watchRefundPKHslice := btcutil.Hash160(watchRefundPub[:])
-	copy(qc.WatchRefundAdr[:], watchRefundPKHslice)
-
-	qc.State = new(StatCom)
-
-	// load state.  If it exists.
-	// if it doesn't, leave as empty state, will fill in
-	stBytes := bkt.Get(KEYState)
-	if stBytes != nil {
-		qc.State, err = StatComFromBytes(stBytes)
-		if err != nil {
-			logging.Errorf("Error loading StatCom: %s", err.Error())
-			return nil, err
-		}
-	}
-
-	// load elkrem from elkrem bucket.
-	// shouldn't error even if nil.  So shouldn't error, ever.  Right?
-	// ignore error?
-	qc.ElkRcv, err = elkrem.ElkremReceiverFromBytes(bkt.Get(KEYElkRecv))
-	if err != nil {
-		return nil, err
-	}
-	if qc.ElkRcv != nil {
-		// logging.Infof("loaded elkrem receiver at state %d\n", qc.ElkRcv.UpTo())
-	}
-
-	// derive elkrem sender root from HD keychain
-	r, _ := nd.GetElkremRoot(qc.KeyGen)
-	// set sender
-	qc.ElkSnd = elkrem.NewElkremSender(r)
-
-	// make the clear to send chan
-	qc.ClearToSend = make(chan bool, 1)
-	// set it to true (all qchannels start as clear to send in ram
-	// maybe they shouldn't be...?
-	qc.ClearToSend <- true
-
-	return &qc, nil
-}
-
 // ReloadQchan loads updated data from the db into the qchan.  Loads elkrem
 // and state, but does not change qchan info itself.  Faster than GetQchan()
 // also reload the channel close state
-func (nd *LitNode) ReloadQchanState(q *Qchan) error {
-	var err error
-	opArr := lnutil.OutPointToBytes(q.Op)
+func (nd *LitNode) ReloadQchanState(qc *Qchan) error {
+	opArr := lnutil.OutPointToBytes(qc.Op)
 
 	return nd.LitDB.View(func(btx *bolt.Tx) error {
-		cbk := btx.Bucket(BKTChannel)
-		if cbk == nil {
-			return fmt.Errorf("no channels")
+		b := btx.Bucket(BKTChannelData)
+		if b == nil {
+			return fmt.Errorf("channel data bucket not found")
 		}
 
-		qcBucket := cbk.Bucket(opArr[:])
-		if qcBucket == nil {
-			return fmt.Errorf("outpoint %s not in db", q.Op.String())
+		buf := b.Get(opArr[:])
+		if buf == nil {
+			return fmt.Errorf("channel not found in DB")
 		}
-
-		// load state and update
-		// if it doesn't, leave as empty state, will fill in
-		stBytes := qcBucket.Get(KEYState)
-		if stBytes == nil {
-			return fmt.Errorf("state value empty")
-		}
-		nd.RemoteMtx.Lock()
-		q.State, err = StatComFromBytes(stBytes)
-		nd.RemoteMtx.Unlock()
-		if err != nil {
-			return err
-		}
-
-		q.CloseData, err = QCloseFromBytes(qcBucket.Get(KEYqclose))
-		if err != nil {
-			return err
-		}
-
-		txoBytes := qcBucket.Get(KEYutxo)
-		if txoBytes == nil {
-			return fmt.Errorf("utxo value empty")
-		}
-		u, err := portxo.PorTxoFromBytes(txoBytes[107:])
-		if err != nil {
-			return err
-		}
-
-		q.PorTxo = *u // assign the utxo
-
-		// load elkrem from elkrem bucket.
-		q.ElkRcv, err = elkrem.ElkremReceiverFromBytes(qcBucket.Get(KEYElkRecv))
-		if err != nil {
-			return err
-		}
-		return nil
-	})
-}
-
-// SetQchanRefund overwrites "theirrefund" and "theirHAKDbase" in a qchan.
-//   This is needed after getting a chanACK.
-func (nd *LitNode) SetQchanRefund(q *Qchan, refund, hakdBase [33]byte) error {
-	return nd.LitDB.Update(func(btx *bolt.Tx) error {
-		cbk := btx.Bucket(BKTChannel)
-		if cbk == nil {
-			return fmt.Errorf("no channels")
-		}
-
-		opArr := lnutil.OutPointToBytes(q.Op)
-		qcBucket := cbk.Bucket(opArr[:])
-		if qcBucket == nil {
-			return fmt.Errorf("outpoint %s not in db ", q.Op.String())
-		}
-
-		// load the serialized channel base description
-		qc, err := QchanFromBytes(qcBucket.Get(KEYutxo))
-		if err != nil {
-			return err
-		}
-		// modify their refund
-		qc.TheirRefundPub = refund
-		// modify their HAKDbase
-		qc.TheirHAKDBase = hakdBase
-		// re -serialize
-		qcBytes, err := qc.ToBytes()
-		if err != nil {
-			return err
-		}
-		// save/overwrite
-		return qcBucket.Put(KEYutxo, qcBytes)
+		return nd.QchanUpdateFromBytes(qc, buf)
 	})
 }
 
@@ -655,63 +429,36 @@ func (nd *LitNode) SetQchanRefund(q *Qchan, refund, hakdBase [33]byte) error {
 // if we can make that it's own function.  Get channel bucket maybe?  But then
 // you have to close it...
 func (nd *LitNode) SaveQchanState(q *Qchan) error {
-	return nd.LitDB.Update(func(btx *bolt.Tx) error {
-		cbk := btx.Bucket(BKTChannel)
-		if cbk == nil {
-			return fmt.Errorf("no channels")
-		}
+	logging.Warnln("someone called SaveQchanState, but this is deprecated.  doing some hacks to make it save just that.")
 
-		opArr := lnutil.OutPointToBytes(q.Op)
-		qcBucket := cbk.Bucket(opArr[:])
-		if qcBucket == nil {
-			return fmt.Errorf("outpoint %s not in db ", q.Op.String())
-		}
-		// serialize elkrem receiver
-		eb, err := q.ElkRcv.ToBytes()
-		if err != nil {
-			return err
-		}
-		// save elkrem
-		err = qcBucket.Put(KEYElkRecv, eb)
-		if err != nil {
-			return err
-		}
-		// serialize state
-		b, err := q.State.ToBytes()
-		if err != nil {
-			return err
-		}
-		// save state
-		logging.Infof("writing %d byte state to bucket\n", len(b))
-		return qcBucket.Put(KEYState, b)
-	})
+	// XXX This is a horrible hack and we need to change other code to not be
+	// dependent on the way this data is saved/loaded.
+	opArr := lnutil.OutPointToBytes(q.Op)
+	fq, err := nd.GetQchan(opArr)
+	if err != nil {
+		return nil
+	}
+	fq.State = q.State
+
+	return nd.SaveQChan(fq)
 }
 
 // GetAllQchans returns a slice of all channels. empty slice is OK.
 func (nd *LitNode) GetAllQchans() ([]*Qchan, error) {
 	var qChans []*Qchan
 	err := nd.LitDB.View(func(btx *bolt.Tx) error {
-		cbk := btx.Bucket(BKTChannel)
-		if cbk == nil {
-			return fmt.Errorf("no channels")
+		b := btx.Bucket(BKTChannelData)
+		if b == nil {
+			return fmt.Errorf("channel data bucket not found")
 		}
-		return cbk.ForEach(func(op, nothin []byte) error {
-			if nothin != nil {
-				return nil // non-bucket
-			}
-			qcBucket := cbk.Bucket(op)
-			if qcBucket == nil {
-				return nil // nothing stored
-			}
-			newQc, err := nd.RestoreQchanFromBucket(qcBucket)
+		return b.ForEach(func(_, buf []byte) error {
+			newQc, err := nd.QchanDeserializeFromBytes(buf)
 			if err != nil {
-				return err
+				return err // should we not return this?
 			}
 
-			// add to slice
 			qChans = append(qChans, newQc)
 			return nil
-
 		})
 	})
 	if err != nil {
@@ -724,24 +471,28 @@ func (nd *LitNode) GetAllQchans() ([]*Qchan, error) {
 // pubkey and outpoint bytes.
 func (nd *LitNode) GetQchan(opArr [36]byte) (*Qchan, error) {
 
-	qc := new(Qchan)
+	var qc *Qchan
 	var err error
-	op := lnutil.OutPointFromBytes(opArr)
 	err = nd.LitDB.View(func(btx *bolt.Tx) error {
-		cbk := btx.Bucket(BKTChannel)
-		if cbk == nil {
-			return fmt.Errorf("no channels")
+
+		var err error
+
+		b := btx.Bucket(BKTChannelData)
+		if b == nil {
+			return fmt.Errorf("channel data bucket not found")
 		}
 
-		qcBucket := cbk.Bucket(opArr[:])
-		if qcBucket == nil {
-			return fmt.Errorf("outpoint %s not in db", op.String())
+		buf := b.Get(opArr[:])
+		if buf == nil {
+			return fmt.Errorf("channel not found in DB")
 		}
 
-		qc, err = nd.RestoreQchanFromBucket(qcBucket)
+		// Go has weird scoping rules, I hope this doesn't break things.
+		qc, err = nd.QchanDeserializeFromBytes(buf)
 		if err != nil {
 			return err
 		}
+
 		return nil
 	})
 	if err != nil {

--- a/qln/lndb.go
+++ b/qln/lndb.go
@@ -27,16 +27,6 @@ first there's the peer bucket.
 
 Here's the structure:
 
-Channels
-|
-|-channelID (36 byte outpoint)
-	|
-	|- portxo data (includes peer id, channel ID)
-	|
-	|- Watchtower: watchtower data
-	|
-	|- State: state data
-
 Peers
 |
 |- peerID (33 byte pubkey)

--- a/qln/magicnums.go
+++ b/qln/magicnums.go
@@ -34,7 +34,9 @@ const (
 )
 
 var (
-	BKTChannel  = []byte("chn") // all channel data is in this bucket.
+	BKTChannelData = []byte("channels")
+
+	//BKTChannel  = []byte("chn") // all channel data is in this bucket.
 	BKTPeers    = []byte("pir") // all peer data is in this bucket.
 	BKTPeerMap  = []byte("pmp") // map of peer index to pubkey
 	BKTChanMap  = []byte("cmp") // map of channel index to outpoint

--- a/qln/pushpull.go
+++ b/qln/pushpull.go
@@ -121,6 +121,8 @@ func (nd *LitNode) PushChannel(qc *Qchan, amt uint32, data [32]byte) error {
 		return fmt.Errorf("have to send non-zero amount")
 	}
 
+	logging.Infof("started push on channel %d of %d\n", qc.Idx(), amt)
+
 	// see if channel is busy
 	// lock this channel
 	cts := false

--- a/qln/serdes.go
+++ b/qln/serdes.go
@@ -1,15 +1,11 @@
 package qln
 
 import (
-	"bytes"
-	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"sync"
 
-	"github.com/mit-dci/lit/btcutil/chaincfg/chainhash"
 	"github.com/mit-dci/lit/elkrem"
-	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/portxo"
 
 	"github.com/getlantern/deepcopy"
@@ -17,29 +13,6 @@ import (
 
 /*----- serialization for StatCom ------- */
 /*
-bytes   desc   ends at
-8	StateIdx		8
-8	MyAmt		16
-4	Delta		20
-33	ElkPoint		53
-33	N1ElkPoint	86
-33	N2ElkPoint
-1	Collision
-64	Sig
-32  Data
-
-4   HTLCIdx
-1   InProgHTLC?
-(250 InProgHTLC)
-
-33   NextHTLCBase
-33   N2HTLCBase
-33   MyNextHTLCBase
-33   MyN2HTLCBase
-
-4    nHTLCs
-(n*250 HTLC)
-
 
 note that sigs are truncated and don't have the sighash type byte at the end.
 
@@ -47,328 +20,6 @@ their rev hash can be derived from the elkrem sender
 and the stateidx.  hash160(elkremsend(sIdx)[:16])
 
 */
-
-// ToBytes turns a StatCom into 192ish bytes
-func (s *StatCom) ToBytes() ([]byte, error) {
-	var buf bytes.Buffer
-	var err error
-
-	// write 8 byte state index
-	err = binary.Write(&buf, binary.BigEndian, s.StateIdx)
-	if err != nil {
-		return nil, err
-	}
-	// write 8 byte watch up to state index
-	err = binary.Write(&buf, binary.BigEndian, s.WatchUpTo)
-	if err != nil {
-		return nil, err
-	}
-
-	// write 8 byte amount of my allocation in the channel
-	err = binary.Write(&buf, binary.BigEndian, s.MyAmt)
-	if err != nil {
-		return nil, err
-	}
-	// write 8 byte absolute fee
-	err = binary.Write(&buf, binary.BigEndian, s.Fee)
-	if err != nil {
-		return nil, err
-	}
-
-	// write 4 byte delta.  At steady state it's 0.
-	err = binary.Write(&buf, binary.BigEndian, s.Delta)
-	if err != nil {
-		return nil, err
-	}
-	// write 4 byte collision.  Only non zero briefly on collision
-	err = binary.Write(&buf, binary.BigEndian, s.Collision)
-	if err != nil {
-		return nil, err
-	}
-
-	// write 33 byte my elk point
-	_, err = buf.Write(s.ElkPoint[:])
-	if err != nil {
-		return nil, err
-	}
-	// write 33 byte Next elk point
-	_, err = buf.Write(s.NextElkPoint[:])
-	if err != nil {
-		return nil, err
-	}
-	// write 33 byte Next elk point
-	_, err = buf.Write(s.N2ElkPoint[:])
-	if err != nil {
-		return nil, err
-	}
-
-	// write their sig
-	_, err = buf.Write(s.sig[:])
-	if err != nil {
-		return nil, err
-	}
-
-	// write their data
-	_, err = buf.Write(s.Data[:])
-	if err != nil {
-		return nil, err
-	}
-
-	err = binary.Write(&buf, binary.BigEndian, s.HTLCIdx)
-	if err != nil {
-		return nil, err
-	}
-
-	err = binary.Write(&buf, binary.BigEndian, s.CollidingHashDelta)
-	if err != nil {
-		return nil, err
-	}
-
-	err = binary.Write(&buf, binary.BigEndian, s.CollidingHashPreimage)
-	if err != nil {
-		return nil, err
-	}
-
-	err = binary.Write(&buf, binary.BigEndian, s.CollidingPreimages)
-	if err != nil {
-		return nil, err
-	}
-
-	err = binary.Write(&buf, binary.BigEndian, s.CollidingPreimageDelta)
-	if err != nil {
-		return nil, err
-	}
-
-	if s.InProgHTLC != nil {
-		err = binary.Write(&buf, binary.BigEndian, true)
-		if err != nil {
-			return nil, err
-		}
-
-		HTLCBytes, err := s.InProgHTLC.Bytes()
-		if err != nil {
-			return nil, err
-		}
-
-		_, err = buf.Write(HTLCBytes)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		err = binary.Write(&buf, binary.BigEndian, false)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if s.CollidingHTLC != nil {
-		err = binary.Write(&buf, binary.BigEndian, true)
-		if err != nil {
-			return nil, err
-		}
-
-		HTLCBytes, err := s.CollidingHTLC.Bytes()
-		if err != nil {
-			return nil, err
-		}
-
-		_, err = buf.Write(HTLCBytes)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		err = binary.Write(&buf, binary.BigEndian, false)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	_, err = buf.Write(s.NextHTLCBase[:])
-	if err != nil {
-		return nil, err
-	}
-
-	_, err = buf.Write(s.N2HTLCBase[:])
-	if err != nil {
-		return nil, err
-	}
-
-	_, err = buf.Write(s.MyNextHTLCBase[:])
-	if err != nil {
-		return nil, err
-	}
-
-	_, err = buf.Write(s.MyN2HTLCBase[:])
-	if err != nil {
-		return nil, err
-	}
-
-	nHTLCs := uint32(len(s.HTLCs))
-	err = binary.Write(&buf, binary.BigEndian, nHTLCs)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, h := range s.HTLCs {
-		HTLCBytes, err := h.Bytes()
-		if err != nil {
-			return nil, err
-		}
-
-		_, err = buf.Write(HTLCBytes)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	err = binary.Write(&buf, binary.BigEndian, s.Failed)
-	if err != nil {
-		return nil, err
-	}
-
-	return buf.Bytes(), nil
-}
-
-// StatComFromBytes turns at least 357 bytes into a StatCom
-func StatComFromBytes(b []byte) (*StatCom, error) {
-	var s StatCom
-	if len(b) < 357 {
-		return nil, fmt.Errorf("StatComFromBytes got %d bytes, expect at least 357",
-			len(b))
-	}
-	buf := bytes.NewBuffer(b)
-	// read 8 byte state index
-	err := binary.Read(buf, binary.BigEndian, &s.StateIdx)
-	if err != nil {
-		return nil, err
-	}
-	// read 8 byte WatchUpTo index
-	err = binary.Read(buf, binary.BigEndian, &s.WatchUpTo)
-	if err != nil {
-		return nil, err
-	}
-
-	// read 8 byte amount of my allocation in the channel
-	err = binary.Read(buf, binary.BigEndian, &s.MyAmt)
-	if err != nil {
-		return nil, err
-	}
-	// read 8 byte absolute fee
-	err = binary.Read(buf, binary.BigEndian, &s.Fee)
-	if err != nil {
-		return nil, err
-	}
-	// read 4 byte delta.
-	err = binary.Read(buf, binary.BigEndian, &s.Delta)
-	if err != nil {
-		return nil, err
-	}
-	// read 4 byte collision.
-	err = binary.Read(buf, binary.BigEndian, &s.Collision)
-	if err != nil {
-		return nil, err
-	}
-	// read 33 byte elk point
-	copy(s.ElkPoint[:], buf.Next(33))
-	// read 33 byte next elk point
-	copy(s.NextElkPoint[:], buf.Next(33))
-	// read 33 byte n+2 elk point
-	copy(s.N2ElkPoint[:], buf.Next(33))
-
-	// the rest is their sig
-	copy(s.sig[:], buf.Next(64))
-
-	// copy data
-	copy(s.Data[:], buf.Next(32))
-
-	err = binary.Read(buf, binary.BigEndian, &s.HTLCIdx)
-	if err != nil {
-		return nil, err
-	}
-
-	err = binary.Read(buf, binary.BigEndian, &s.CollidingHashDelta)
-	if err != nil {
-		return nil, err
-	}
-
-	err = binary.Read(buf, binary.BigEndian, &s.CollidingHashPreimage)
-	if err != nil {
-		return nil, err
-	}
-
-	err = binary.Read(buf, binary.BigEndian, &s.CollidingPreimages)
-	if err != nil {
-		return nil, err
-	}
-
-	err = binary.Read(buf, binary.BigEndian, &s.CollidingPreimageDelta)
-	if err != nil {
-		return nil, err
-	}
-
-	var inProg bool
-	err = binary.Read(buf, binary.BigEndian, &inProg)
-	if err != nil {
-		return nil, err
-	}
-
-	if inProg {
-		HTLCBytes := buf.Next(251)
-
-		h, err := HTLCFromBytes(HTLCBytes)
-		if err != nil {
-			return nil, err
-		}
-
-		s.InProgHTLC = &h
-	}
-
-	var collidingHtlc bool
-	err = binary.Read(buf, binary.BigEndian, &collidingHtlc)
-	if err != nil {
-		return nil, err
-	}
-
-	if collidingHtlc {
-		HTLCBytes := buf.Next(251)
-
-		h, err := HTLCFromBytes(HTLCBytes)
-		if err != nil {
-			return nil, err
-		}
-
-		s.CollidingHTLC = &h
-	}
-
-	copy(s.NextHTLCBase[:], buf.Next(33))
-	copy(s.N2HTLCBase[:], buf.Next(33))
-	copy(s.MyNextHTLCBase[:], buf.Next(33))
-	copy(s.MyN2HTLCBase[:], buf.Next(33))
-
-	var nHTLCs uint32
-	err = binary.Read(buf, binary.BigEndian, &nHTLCs)
-	if err != nil {
-		return nil, err
-	}
-
-	for i := uint32(0); i < nHTLCs; i++ {
-		HTLCBytes := buf.Next(251)
-
-		h, err := HTLCFromBytes(HTLCBytes)
-		if err != nil {
-			return nil, err
-		}
-
-		s.HTLCs = append(s.HTLCs, h)
-	}
-
-	err = binary.Read(buf, binary.BigEndian, &s.Failed)
-	if err != nil {
-		return nil, err
-	}
-
-	return &s, nil
-}
 
 // ChanData is a struct used as a surrogate for going between Qchan and the JSON
 // representation stored on disk.  There's an annoying layer in between that
@@ -390,11 +41,10 @@ type ChanData struct {
 
 func (nd *LitNode) NewQchanFromChanData(data *ChanData) (*Qchan, error) {
 
-	var erecv elkrem.ElkremReceiver
-	deepcopy.Copy(erecv, *data.ElkRcv)
-
-	var sc StatCom
-	deepcopy.Copy(sc, *data.State)
+	erecv := new(elkrem.ElkremReceiver)
+	deepcopy.Copy(erecv, data.ElkRcv)
+	sc := new(StatCom)
+	deepcopy.Copy(sc, data.State)
 
 	// I don't know if these errors are supposed to be ignored but that's what
 	// other code does so I'm just copying that.
@@ -415,11 +65,11 @@ func (nd *LitNode) NewQchanFromChanData(data *ChanData) (*Qchan, error) {
 		TheirHAKDBase:  data.TheirHAKDBase,
 
 		ElkSnd: elkrem.NewElkremSender(elkroot),
-		ElkRcv: &erecv,
+		ElkRcv: erecv,
 
 		Delay: 5, // This is defined to just be 5.
 
-		State: &sc,
+		State: sc,
 
 		ClearToSend: make(chan bool),
 		ChanMtx:     sync.Mutex{},
@@ -434,10 +84,10 @@ func (nd *LitNode) NewQchanFromChanData(data *ChanData) (*Qchan, error) {
 func (nd *LitNode) NewChanDataFromQchan(qc *Qchan) *ChanData {
 
 	// We have to make copies of some thing because it's weird.
-	var er elkrem.ElkremReceiver
-	deepcopy.Copy(er, *qc.ElkRcv)
-	var sc StatCom
-	deepcopy.Copy(sc, *qc.State)
+	er := new(elkrem.ElkremReceiver)
+	deepcopy.Copy(er, qc.ElkRcv)
+	sc := new(StatCom)
+	deepcopy.Copy(sc, qc.State)
 
 	cd := &ChanData{
 		Txo:            qc.PorTxo,
@@ -445,8 +95,8 @@ func (nd *LitNode) NewChanDataFromQchan(qc *Qchan) *ChanData {
 		TheirPub:       qc.TheirPub,
 		TheirRefundPub: qc.TheirRefundPub,
 		TheirHAKDBase:  qc.TheirHAKDBase,
-		ElkRcv:         &er,
-		State:          &sc,
+		ElkRcv:         er,
+		State:          sc,
 		LastUpdate:     qc.LastUpdate,
 	}
 
@@ -481,275 +131,13 @@ func (nd *LitNode) ApplyChanDataToQchan(data *ChanData, qc *Qchan) error {
 
 }
 
-/*----- serialization for QChannels ------- */
-
-/* Qchan serialization:
-bytes   desc   at offset
-
-60	utxo		0
-33	nonce	60
-33	thrref	93
-
-length 126
-
-peeridx is inferred from position in db.
-
-^^^ a lot of this data is outdated, just read the code below!
-
-*/
 //TODO !!! don't store the outpoint!  it's redundant!!!!!
 // it's just a nonce and a refund, that's it! 40 bytes!
-
-func (q *Qchan) ToBytes() ([]byte, error) {
-	var buf bytes.Buffer
-
-	// write their channel pubkey
-	_, err := buf.Write(q.TheirPub[:])
-	if err != nil {
-		return nil, err
-	}
-
-	// write their refund pubkey
-	_, err = buf.Write(q.TheirRefundPub[:])
-	if err != nil {
-		return nil, err
-	}
-	// write their HAKD base
-	_, err = buf.Write(q.TheirHAKDBase[:])
-	if err != nil {
-		return nil, err
-	}
-
-	// write the timestamp data
-	lubuf := make([]byte, 8)
-	binary.BigEndian.PutUint64(lubuf, q.LastUpdate)
-	buf.Write(lubuf)
-
-	// then serialize the utxo part
-	uBytes, err := q.PorTxo.Bytes()
-	if err != nil {
-		return nil, err
-	}
-
-	// and write that into the buffer
-	_, err = buf.Write(uBytes)
-	if err != nil {
-		return nil, err
-	}
-
-	// done
-	return buf.Bytes(), nil
-}
-
-// QchanFromBytes turns bytes into a Qchan.
-// the first 99 bytes are the 3 pubkeys: channel, refund, HAKD base
-// then 8 bytes for a timestamp
-// then 8 bytes for the DH mask
-// the rest is the utxo
-func QchanFromBytes(b []byte) (Qchan, error) {
-	var q Qchan
-
-	if len(b) < 213 {
-		return q, fmt.Errorf("Got %d bytes for qchan, expect 213+", len(b))
-	}
-
-	copy(q.TheirPub[:], b[:33])
-	copy(q.TheirRefundPub[:], b[33:66])
-	copy(q.TheirHAKDBase[:], b[66:99])
-
-	tsbuf := make([]byte, 8)
-	copy(tsbuf, b[99:107])
-	q.LastUpdate = binary.BigEndian.Uint64(tsbuf)
-
-	u, err := portxo.PorTxoFromBytes(b[107:])
-	if err != nil {
-		return q, err
-	}
-
-	q.PorTxo = *u // assign the utxo
-	// hard-coded.  save this soon, it's easy
-	q.Delay = 5
-
-	// pls werk
-	q.LastUpdate = binary.BigEndian.Uint64(b[len(b)-8 : len(b)])
-
-	return q, nil
-}
-
-/*----- serialization for CloseTXOs -------
-
-  serialization:
-closetxid	32
-closeheight	4
-
-only closeTxid needed, I think
-
-*/
-
-func (c *QCloseData) ToBytes() ([]byte, error) {
-	if c == nil {
-		return nil, fmt.Errorf("nil qclose")
-	}
-	b := make([]byte, 36)
-	copy(b[:32], c.CloseTxid.CloneBytes())
-	copy(b[32:], lnutil.I32tB(c.CloseHeight))
-	return b, nil
-}
-
-// QCloseFromBytes deserializes a Qclose.  Note that a nil slice
-// gives an empty / non closed qclose.
-func QCloseFromBytes(b []byte) (QCloseData, error) {
-	var c QCloseData
-	if len(b) == 0 { // empty is OK
-		return c, nil
-
-	}
-	if len(b) < 36 {
-		return c, fmt.Errorf("close data %d bytes, expect 36", len(b))
-	}
-	var empty chainhash.Hash
-	c.CloseTxid.SetBytes(b[:32])
-	if !c.CloseTxid.IsEqual(&empty) {
-		c.Closed = true
-	}
-	c.CloseHeight = lnutil.BtI32(b[32:36])
-
-	return c, nil
-}
-
-// Bytes turns an HTLC into a slice of
-// 4 + 1 + 8 + 32 + 4 + 33 + 33 + 53 + 64 + 16 + 1 + 1 + 1
-// = 251 bytes
-func (h *HTLC) Bytes() ([]byte, error) {
-	var buf bytes.Buffer
-	var err error
-
-	err = binary.Write(&buf, binary.BigEndian, h.Idx)
-	if err != nil {
-		return nil, err
-	}
-
-	err = binary.Write(&buf, binary.BigEndian, h.Incoming)
-	if err != nil {
-		return nil, err
-	}
-
-	err = binary.Write(&buf, binary.BigEndian, h.Amt)
-	if err != nil {
-		return nil, err
-	}
-
-	_, err = buf.Write(h.RHash[:])
-	if err != nil {
-		return nil, err
-	}
-
-	err = binary.Write(&buf, binary.BigEndian, h.Locktime)
-	if err != nil {
-		return nil, err
-	}
-
-	_, err = buf.Write(h.MyHTLCBase[:])
-	if err != nil {
-		return nil, err
-	}
-
-	_, err = buf.Write(h.TheirHTLCBase[:])
-	if err != nil {
-		return nil, err
-	}
-
-	_, err = buf.Write(h.KeyGen.Bytes())
-	if err != nil {
-		return nil, err
-	}
-
-	_, err = buf.Write(h.Sig[:])
-	if err != nil {
-		return nil, err
-	}
-
-	_, err = buf.Write(h.R[:])
-	if err != nil {
-		return nil, err
-	}
-
-	err = binary.Write(&buf, binary.BigEndian, h.Clearing)
-	if err != nil {
-		return nil, err
-	}
-
-	err = binary.Write(&buf, binary.BigEndian, h.Cleared)
-	if err != nil {
-		return nil, err
-	}
-
-	err = binary.Write(&buf, binary.BigEndian, h.ClearedOnChain)
-	if err != nil {
-		return nil, err
-	}
-
-	return buf.Bytes(), nil
-}
-
-func HTLCFromBytes(b []byte) (HTLC, error) {
-	var h HTLC
-
-	buf := bytes.NewBuffer(b)
-	err := binary.Read(buf, binary.BigEndian, &h.Idx)
-	if err != nil {
-		return h, err
-	}
-
-	err = binary.Read(buf, binary.BigEndian, &h.Incoming)
-	if err != nil {
-		return h, err
-	}
-
-	err = binary.Read(buf, binary.BigEndian, &h.Amt)
-	if err != nil {
-		return h, err
-	}
-
-	copy(h.RHash[:], buf.Next(32))
-
-	err = binary.Read(buf, binary.BigEndian, &h.Locktime)
-	if err != nil {
-		return h, err
-	}
-
-	copy(h.MyHTLCBase[:], buf.Next(33))
-	copy(h.TheirHTLCBase[:], buf.Next(33))
-
-	var keyGenBytes [53]byte
-	copy(keyGenBytes[:], buf.Next(53))
-	h.KeyGen = portxo.KeyGenFromBytes(keyGenBytes)
-
-	copy(h.Sig[:], buf.Next(64))
-
-	copy(h.R[:], buf.Next(16))
-
-	err = binary.Read(buf, binary.BigEndian, &h.Clearing)
-	if err != nil {
-		return h, err
-	}
-
-	err = binary.Read(buf, binary.BigEndian, &h.Cleared)
-	if err != nil {
-		return h, err
-	}
-
-	err = binary.Read(buf, binary.BigEndian, &h.ClearedOnChain)
-	if err != nil {
-		return h, err
-	}
-
-	return h, nil
-}
 
 func (nd *LitNode) QchanSerializeToBytes(qc *Qchan) []byte {
 	cd := nd.NewChanDataFromQchan(qc)
 	data, _ := json.Marshal(cd)
+	fmt.Printf("QCHAN JSON: %v\n", string(data))
 	return data
 }
 

--- a/qln/serdes.go
+++ b/qln/serdes.go
@@ -4,11 +4,14 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"sync"
 
 	"github.com/mit-dci/lit/btcutil/chaincfg/chainhash"
 	"github.com/mit-dci/lit/elkrem"
 	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/portxo"
+
+	"github.com/getlantern/deepcopy"
 )
 
 /*----- serialization for StatCom ------- */
@@ -43,21 +46,6 @@ their rev hash can be derived from the elkrem sender
 and the stateidx.  hash160(elkremsend(sIdx)[:16])
 
 */
-
-type ChanData struct {
-	Txo       portxo.PorTxo `json:"txo"`
-	CloseData QCloseData    `json:"closedata"`
-
-	TheirPub       [33]byte `json:"rpub"`
-	TheirRefundPub [33]byte `json:"rrefpub"`
-	TheirHAKDBase  [33]byte `json:"rhakdbase"`
-
-	ElkRcv *elkrem.ElkremReceiver `json:"elkrecv"`
-
-	State *StatCom `json:"state"`
-
-	LastUpdate uint64 `json:"updateunix"`
-}
 
 // ToBytes turns a StatCom into 192ish bytes
 func (s *StatCom) ToBytes() ([]byte, error) {
@@ -379,6 +367,117 @@ func StatComFromBytes(b []byte) (*StatCom, error) {
 	}
 
 	return &s, nil
+}
+
+// ChanData is a struct used as a surrogate for going between Qchan and the JSON
+// representation stored on disk.  There's an annoying layer in between that
+// make it all work out with hopefully little friction.
+type ChanData struct {
+	Txo       portxo.PorTxo `json:"txo"`
+	CloseData QCloseData    `json:"closedata"`
+
+	TheirPub       [33]byte `json:"rpub"`
+	TheirRefundPub [33]byte `json:"rrefpub"`
+	TheirHAKDBase  [33]byte `json:"rhakdbase"`
+
+	ElkRcv *elkrem.ElkremReceiver `json:"elkrecv"`
+
+	State *StatCom `json:"state"`
+
+	LastUpdate uint64 `json:"updateunix"`
+}
+
+func (nd *LitNode) NewQchanFromChanData(data *ChanData) (*Qchan, error) {
+
+	var erecv elkrem.ElkremReceiver
+	deepcopy.Copy(erecv, *data.ElkRcv)
+
+	var sc StatCom
+	deepcopy.Copy(sc, *data.State)
+
+	// I don't know if these errors are supposed to be ignored but that's what
+	// other code does so I'm just copying that.
+	mp, _ := nd.GetUsePub(data.Txo.KeyGen, UseChannelFund)
+	mrp, _ := nd.GetUsePub(data.Txo.KeyGen, UseChannelRefund)
+	mhb, _ := nd.GetUsePub(data.Txo.KeyGen, UseChannelHAKDBase)
+	elkroot, _ := nd.GetElkremRoot(data.Txo.KeyGen)
+
+	qc := &Qchan{
+		PorTxo:    data.Txo,
+		CloseData: data.CloseData,
+
+		MyPub:          mp,
+		TheirPub:       data.TheirPub,
+		MyRefundPub:    mrp,
+		TheirRefundPub: data.TheirRefundPub,
+		MyHAKDBase:     mhb,
+		TheirHAKDBase:  data.TheirHAKDBase,
+
+		ElkSnd: elkrem.NewElkremSender(elkroot),
+		ElkRcv: &erecv,
+
+		Delay: 5, // This is defined to just be 5.
+
+		State: &sc,
+
+		ClearToSend: make(chan bool),
+		ChanMtx:     sync.Mutex{},
+
+		LastUpdate: data.LastUpdate,
+	}
+
+	return qc, nil
+
+}
+
+func (nd *LitNode) NewChanDataFromQchan(qc *Qchan) *ChanData {
+
+	// We have to make copies of some thing because it's weird.
+	var er elkrem.ElkremReceiver
+	deepcopy.Copy(er, *qc.ElkRcv)
+	var sc StatCom
+	deepcopy.Copy(sc, *qc.State)
+
+	cd := &ChanData{
+		Txo:            qc.PorTxo,
+		CloseData:      qc.CloseData,
+		TheirPub:       qc.TheirPub,
+		TheirRefundPub: qc.TheirRefundPub,
+		TheirHAKDBase:  qc.TheirHAKDBase,
+		ElkRcv:         &er,
+		State:          &sc,
+		LastUpdate:     qc.LastUpdate,
+	}
+
+	return cd
+
+}
+
+func (nd *LitNode) ApplyChanDataToQchan(data *ChanData, qc *Qchan) error {
+
+	fake, err := nd.NewQchanFromChanData(data)
+	if err != nil {
+		return err
+	}
+
+	// now just copy them over.  this is bad but it should work well enough.
+	qc.PorTxo = fake.PorTxo
+	qc.CloseData = fake.CloseData
+	qc.MyPub = fake.MyPub
+	qc.TheirPub = fake.TheirPub
+	qc.MyRefundPub = fake.MyRefundPub
+	qc.TheirRefundPub = fake.TheirRefundPub
+	qc.MyHAKDBase = fake.MyHAKDBase
+	qc.TheirHAKDBase = fake.TheirHAKDBase
+	qc.WatchRefundAdr = fake.WatchRefundAdr
+	qc.ElkSnd = fake.ElkSnd
+	qc.ElkRcv = fake.ElkRcv
+	qc.Delay = fake.Delay
+	qc.State = fake.State
+	qc.LastUpdate = fake.LastUpdate
+
+	return nil
+
 }
 
 /*----- serialization for QChannels ------- */

--- a/qln/serdes.go
+++ b/qln/serdes.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/mit-dci/lit/btcutil/chaincfg/chainhash"
+	"github.com/mit-dci/lit/elkrem"
 	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/portxo"
 )
@@ -42,6 +43,21 @@ their rev hash can be derived from the elkrem sender
 and the stateidx.  hash160(elkremsend(sIdx)[:16])
 
 */
+
+type ChanData struct {
+	Txo       portxo.PorTxo `json:"txo"`
+	CloseData QCloseData    `json:"closedata"`
+
+	TheirPub       [33]byte `json:"rpub"`
+	TheirRefundPub [33]byte `json:"rrefpub"`
+	TheirHAKDBase  [33]byte `json:"rhakdbase"`
+
+	ElkRcv *elkrem.ElkremReceiver `json:"elkrecv"`
+
+	State *StatCom `json:"state"`
+
+	LastUpdate uint64 `json:"updateunix"`
+}
 
 // ToBytes turns a StatCom into 192ish bytes
 func (s *StatCom) ToBytes() ([]byte, error) {

--- a/qln/serdes.go
+++ b/qln/serdes.go
@@ -71,11 +71,16 @@ func (nd *LitNode) NewQchanFromChanData(data *ChanData) (*Qchan, error) {
 
 		State: sc,
 
-		ClearToSend: make(chan bool),
+		ClearToSend: make(chan bool, 1),
 		ChanMtx:     sync.Mutex{},
 
 		LastUpdate: data.LastUpdate,
 	}
+
+	// I think this might fix the problem?
+	go (func() {
+		qc.ClearToSend <- true
+	})()
 
 	return qc, nil
 

--- a/qln/serdes.go
+++ b/qln/serdes.go
@@ -3,6 +3,7 @@ package qln
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"sync"
 
@@ -744,4 +745,45 @@ func HTLCFromBytes(b []byte) (HTLC, error) {
 	}
 
 	return h, nil
+}
+
+func (nd *LitNode) QchanSerializeToBytes(qc *Qchan) []byte {
+	cd := nd.NewChanDataFromQchan(qc)
+	data, _ := json.Marshal(cd)
+	return data
+}
+
+func (nd *LitNode) QchanDeserializeFromBytes(buf []byte) (*Qchan, error) {
+
+	var cd ChanData
+	err := json.Unmarshal(buf, &cd)
+	if err != nil {
+		return nil, err
+	}
+
+	qc, err := nd.NewQchanFromChanData(&cd)
+	if err != nil {
+		return nil, err
+	}
+
+	return qc, nil
+
+}
+
+func (nd *LitNode) QchanUpdateFromBytes(qc *Qchan, buf []byte) error {
+
+	var err error
+	var cd ChanData
+	err = json.Unmarshal(buf, &cd)
+	if err != nil {
+		return err
+	}
+
+	err = nd.ApplyChanDataToQchan(&cd, qc)
+	if err != nil {
+		return err
+	}
+
+	return nil
+
 }

--- a/qln/serdes.go
+++ b/qln/serdes.go
@@ -2,7 +2,6 @@ package qln
 
 import (
 	"encoding/json"
-	"fmt"
 	"sync"
 
 	"github.com/mit-dci/lit/elkrem"
@@ -142,7 +141,6 @@ func (nd *LitNode) ApplyChanDataToQchan(data *ChanData, qc *Qchan) error {
 func (nd *LitNode) QchanSerializeToBytes(qc *Qchan) []byte {
 	cd := nd.NewChanDataFromQchan(qc)
 	data, _ := json.Marshal(cd)
-	fmt.Printf("QCHAN JSON: %v\n", string(data))
 	return data
 }
 

--- a/qln/serdes.go
+++ b/qln/serdes.go
@@ -31,17 +31,14 @@ type ChanData struct {
 	TheirRefundPub [33]byte `json:"rrefpub"`
 	TheirHAKDBase  [33]byte `json:"rhakdbase"`
 
-	ElkRcv *elkrem.ElkremReceiver `json:"elkrecv"`
-
 	State *StatCom `json:"state"`
 
 	LastUpdate uint64 `json:"updateunix"`
 }
 
+// NewQchanFromChanData creates a new qchan from a chandata.
 func (nd *LitNode) NewQchanFromChanData(data *ChanData) (*Qchan, error) {
 
-	erecv := new(elkrem.ElkremReceiver)
-	deepcopy.Copy(erecv, data.ElkRcv)
 	sc := new(StatCom)
 	deepcopy.Copy(sc, data.State)
 
@@ -64,7 +61,7 @@ func (nd *LitNode) NewQchanFromChanData(data *ChanData) (*Qchan, error) {
 		TheirHAKDBase:  data.TheirHAKDBase,
 
 		ElkSnd: elkrem.NewElkremSender(elkroot),
-		ElkRcv: erecv,
+		ElkRcv: elkrem.NewElkremReceiver(),
 
 		Delay: 5, // This is defined to just be 5.
 
@@ -85,11 +82,10 @@ func (nd *LitNode) NewQchanFromChanData(data *ChanData) (*Qchan, error) {
 
 }
 
+// NewChanDataFromQchan extracts the chandata from the qchan.
 func (nd *LitNode) NewChanDataFromQchan(qc *Qchan) *ChanData {
 
 	// We have to make copies of some thing because it's weird.
-	er := new(elkrem.ElkremReceiver)
-	deepcopy.Copy(er, qc.ElkRcv)
 	sc := new(StatCom)
 	deepcopy.Copy(sc, qc.State)
 
@@ -99,7 +95,6 @@ func (nd *LitNode) NewChanDataFromQchan(qc *Qchan) *ChanData {
 		TheirPub:       qc.TheirPub,
 		TheirRefundPub: qc.TheirRefundPub,
 		TheirHAKDBase:  qc.TheirHAKDBase,
-		ElkRcv:         er,
 		State:          sc,
 		LastUpdate:     qc.LastUpdate,
 	}
@@ -108,6 +103,7 @@ func (nd *LitNode) NewChanDataFromQchan(qc *Qchan) *ChanData {
 
 }
 
+// ApplyChanDataToQchan applies the chandata to the qchan without destroying it.
 func (nd *LitNode) ApplyChanDataToQchan(data *ChanData, qc *Qchan) error {
 
 	fake, err := nd.NewQchanFromChanData(data)

--- a/qln/serdes.go
+++ b/qln/serdes.go
@@ -10,14 +10,14 @@ import (
 	"github.com/getlantern/deepcopy"
 )
 
-/*----- serialization for StatCom ------- */
 /*
-
 note that sigs are truncated and don't have the sighash type byte at the end.
 
 their rev hash can be derived from the elkrem sender
 and the stateidx.  hash160(elkremsend(sIdx)[:16])
 
+TODO Does it make sense to move this comment somewhere else?  It's not really
+relevant here anymore.
 */
 
 // ChanData is a struct used as a surrogate for going between Qchan and the JSON
@@ -134,9 +134,6 @@ func (nd *LitNode) ApplyChanDataToQchan(data *ChanData, qc *Qchan) error {
 	return nil
 
 }
-
-//TODO !!! don't store the outpoint!  it's redundant!!!!!
-// it's just a nonce and a refund, that's it! 40 bytes!
 
 func (nd *LitNode) QchanSerializeToBytes(qc *Qchan) []byte {
 	cd := nd.NewChanDataFromQchan(qc)

--- a/qln/signtx.go
+++ b/qln/signtx.go
@@ -42,7 +42,7 @@ func (nd *LitNode) SignBreakTx(q *Qchan) (*wire.MsgTx, error) {
 		return nil, err
 	}
 
-	theirSig := sig64.SigDecompress(q.State.sig)
+	theirSig := sig64.SigDecompress(q.State.Sig)
 	// put the sighash all byte on the end of their signature
 	theirSig = append(theirSig, byte(txscript.SigHashAll))
 
@@ -455,7 +455,7 @@ func (q *Qchan) VerifySigs(sig [64]byte, HTLCSigs [][64]byte) error {
 	}
 
 	// copy signature, overwriting old signature.
-	q.State.sig = sig
+	q.State.Sig = sig
 
 	// copy HTLC-success/failure signatures
 	for i, s := range sigIndex {

--- a/test/test_combinators.py
+++ b/test/test_combinators.py
@@ -68,7 +68,7 @@ def run_pushclose_test(env, initiator, target, closer):
     assert tt1 == tt0 + initialsend + pushsend - 200, "final balance doesn't match"
 
     # 200 = Fee() * consts.QcStateFee
-    
+
 def run_pushbreak_test(env, initiator, target, breaker):
     bc = env.bitcoind
 

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -70,7 +70,7 @@ class LitNode():
         # Now figure out the args to use and then start Lit.
         args = [
             LIT_BIN,
-            "-v", "4",
+            "-vv",
             "--reg", "127.0.0.1:" + str(bcnode.p2p_port),
             "--tn3", "", # disable autoconnect
             "--dir", self.data_dir,

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -45,8 +45,17 @@ def new_data_dir(name):
 
 hexchars = "0123456789abcdef"
 
+# FIXME This doesn't work as expected anymore since IDs are global.
+next_id = 0
+def get_new_id():
+    global next_id
+    id = next_id
+    next_id += 1
+    return id
+
 class LitNode():
     def __init__(self, bcnode):
+        self.id = get_new_id()
         self.p2p_port = new_port()
         self.rpc_port = new_port()
         self.data_dir = new_data_dir("lit")

--- a/test/tests.txt
+++ b/test/tests.txt
@@ -12,7 +12,6 @@ send2 2
 fund 2
 close 2 run_test_forward
 close 2 run_test_reverse
-# Disabled these to tests until we support breaking right after funding (we don't)
 break 2 run_test_forward
 break 2 run_test_reverse
 push 2


### PR DESCRIPTION
This is a preliminary step towards the new storage layer and channel management code.  It *also* makes channel serialization a lot simpler and less prone to breakage, and in the process I removed a few hundred lines of very scary code.