### PR TITLE
Mismatch between peer.Idx and msg.Peer() after refactor

### DIFF
--- a/qln/remotecontrol.go
+++ b/qln/remotecontrol.go
@@ -77,7 +77,7 @@ func (nd *LitNode) RemoteControlRequestHandler(msg lnutil.RemoteControlRpcReques
 		if err != nil {
 			return err
 		}
-		outMsg := lnutil.NewRemoteControlRpcResponseMsg(msg.Peer(), msg.Idx, false, resp)
+		outMsg := lnutil.NewRemoteControlRpcResponseMsg(peer.Idx, msg.Idx, false, resp)
 		nd.tmpSendLitMsg(outMsg)
 		return nil
 	}
@@ -88,7 +88,7 @@ func (nd *LitNode) RemoteControlRequestHandler(msg lnutil.RemoteControlRpcReques
 		err = fmt.Errorf("Received remote control request from unauthorized peer: %x", pubKey)
 		logging.Errorf(err.Error())
 
-		outMsg := lnutil.NewRemoteControlRpcResponseMsg(msg.Peer(), msg.Idx, true, []byte("Unauthorized"))
+		outMsg := lnutil.NewRemoteControlRpcResponseMsg(peer.Idx, msg.Idx, true, []byte("Unauthorized"))
 		nd.tmpSendLitMsg(outMsg)
 
 		return err
@@ -199,7 +199,7 @@ func (nd *LitNode) RemoteControlRequestHandler(msg lnutil.RemoteControlRpcReques
 					}
 				}
 
-				outMsg := lnutil.NewRemoteControlRpcResponseMsg(msg.Peer(), msg.Idx, replyIsError, reply)
+				outMsg := lnutil.NewRemoteControlRpcResponseMsg(peer.Idx, msg.Idx, replyIsError, reply)
 				nd.tmpSendLitMsg(outMsg)
 			}
 		}
@@ -213,7 +213,7 @@ func (nd *LitNode) RemoteControlRequestHandler(msg lnutil.RemoteControlRpcReques
 // two regular lit nodes do not talk to each other using remote control. But
 // just in case someone sends us one, we print it out here.
 func (nd *LitNode) RemoteControlResponseHandler(msg lnutil.RemoteControlRpcResponseMsg, peer *RemotePeer) error {
-	logging.Debugf("Received remote control reply from peer %d:\n%s", msg.Peer(), string(msg.Result))
+	logging.Debugf("Received remote control reply from peer %d:\n%s", peer.Idx, string(msg.Result))
 	return nil
 }
 


### PR DESCRIPTION
The refactored peer-to-peer code uses a different indexing for the peers. It does contain logic to translate to the old indexing, but message handlers receive two indexes:

- `msg.Peer()` (this is the "new" index)
- `peer.Idx` (this is the "old" index)

`peer` is the second parameter to a message handler (of type `RemotePeer`). This index can also be used as index to `nd.RemoteCons`.

The problem is, that when sending a message, the `nd.tmpSendLitMsg` expects the message.Peer() to be an _old_ index. So if you pass that `msg.Peer()` it will _only_ work when the old and new indexes are the same. 

This manifests itself when a peer reconnects to you. It will receive a new index in the new system, but reuse its old index in the old system. 

By switching to the old indexing (using the `peer.Idx`) in these message handlers, the functionality works also when you reconnect. 

But this is a widespread issue in other message handlers including channel funding.