### PR TITLE
Fixed peerIdx confusion after reconnecting/restarting nodes, with tests

### DIFF
--- a/db/lnbolt/peerdb.go
+++ b/db/lnbolt/peerdb.go
@@ -5,14 +5,19 @@ import (
 	"fmt"
 	"github.com/boltdb/bolt"
 	"github.com/mit-dci/lit/lncore"
+	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/logging"
 )
 
 var (
-	peersLabel = []byte(`peers`)
-	pdbbuckets = [][]byte{
+	peersLabel    = []byte(`peers`)
+	peerMetaLabel = []byte(`peersmeta`)
+	pdbbuckets    = [][]byte{
 		peersLabel,
+		peerMetaLabel,
 	}
+
+	peerIdxLast = []byte(`lastpeeridx`)
 )
 
 type peerboltdb struct {
@@ -138,6 +143,10 @@ func (pdb *peerboltdb) GetPeerInfos() (map[lncore.LnAddr]lncore.PeerInfo, error)
 }
 
 func (pdb *peerboltdb) AddPeer(addr lncore.LnAddr, pi lncore.PeerInfo) error {
+	return pdb.UpdatePeer(addr, &pi)
+}
+
+func (pdb *peerboltdb) UpdatePeer(addr lncore.LnAddr, pi *lncore.PeerInfo) error {
 
 	var err error
 
@@ -146,6 +155,8 @@ func (pdb *peerboltdb) AddPeer(addr lncore.LnAddr, pi lncore.PeerInfo) error {
 	if err != nil {
 		return err
 	}
+
+	fmt.Printf("%s\n", string(piraw))
 
 	err = pdb.db.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket(peersLabel)
@@ -186,4 +197,39 @@ func (pdb *peerboltdb) DeletePeer(addr lncore.LnAddr) error {
 
 	return nil
 
+}
+
+func (pdb *peerboltdb) GetUniquePeerIdx() (uint32, error) {
+
+	var err error
+	var pidx uint32
+
+	err = pdb.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(peerMetaLabel)
+
+		// Get the last unique peer idx, or create it.
+		v := b.Get(peerIdxLast)
+		if v == nil {
+			x := lnutil.U32tB(1)
+			err2 := b.Put(peerIdxLast, x)
+			if err2 != nil {
+				return err2
+			}
+			v = x
+		}
+		pidx = lnutil.BtU32(v)
+
+		// Increment it.
+		err2 := b.Put(peerIdxLast, lnutil.U32tB(pidx+1))
+		if err2 != nil {
+			return err2
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return 0, err
+	}
+	return pidx, nil
 }

--- a/db/lnbolt/peerdb.go
+++ b/db/lnbolt/peerdb.go
@@ -156,8 +156,6 @@ func (pdb *peerboltdb) UpdatePeer(addr lncore.LnAddr, pi *lncore.PeerInfo) error
 		return err
 	}
 
-	fmt.Printf("%s\n", string(piraw))
-
 	err = pdb.db.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket(peersLabel)
 

--- a/lit.go
+++ b/lit.go
@@ -55,10 +55,10 @@ type litConfig struct { // define a struct for usage with go-flags
 	Rpcport uint16 `short:"p" long:"rpcport" description:"Set RPC port to connect to"`
 	Rpchost string `long:"rpchost" description:"Set RPC host to listen to"`
 	// auto config
-	AutoReconnect                   bool   `long:"autoReconnect" description:"Attempts to automatically reconnect to known peers periodically."`
-	AutoReconnectInterval           int64  `long:"autoReconnectInterval" description:"The interval (in seconds) the reconnect logic should be executed"`
-	AutoReconnectOnlyConnectedCoins bool   `long:"autoReconnectOnlyConnectedCoins" description:"Only reconnect to peers that we have channels with in a coin whose coin daemon is available"`
-	AutoListenPort                  int `long:"autoListenPort" description:"When auto reconnect enabled, starts listening on this port"`
+	AutoReconnect                   bool  `long:"autoReconnect" description:"Attempts to automatically reconnect to known peers periodically."`
+	AutoReconnectInterval           int64 `long:"autoReconnectInterval" description:"The interval (in seconds) the reconnect logic should be executed"`
+	AutoReconnectOnlyConnectedCoins bool  `long:"autoReconnectOnlyConnectedCoins" description:"Only reconnect to peers that we have channels with in a coin whose coin daemon is available"`
+	AutoListenPort                  int   `long:"autoListenPort" description:"When auto reconnect enabled, starts listening on this port"`
 	Params                          *coinparam.Params
 }
 

--- a/lncore/peers.go
+++ b/lncore/peers.go
@@ -9,8 +9,12 @@ type LitPeerStorage interface {
 	GetPeerAddrs() ([]LnAddr, error)
 	GetPeerInfo(addr LnAddr) (*PeerInfo, error)
 	GetPeerInfos() (map[LnAddr]PeerInfo, error)
-	AddPeer(addr LnAddr, pi PeerInfo) error // also updates
+	AddPeer(addr LnAddr, pi PeerInfo) error
+	UpdatePeer(addr LnAddr, pi *PeerInfo) error
 	DeletePeer(addr LnAddr) error
+
+	// TEMP Until we figure this all out.
+	GetUniquePeerIdx() (uint32, error)
 }
 
 // PeerInfo .
@@ -18,4 +22,7 @@ type PeerInfo struct {
 	LnAddr   *LnAddr `json:"lnaddr"`
 	Nickname *string `json:"name"`
 	NetAddr  *string `json:"netaddr"` // ip address, port, I guess
+
+	// TEMP This is again, for adapting to the old system.
+	PeerIdx uint32 `json:"hint_peeridx"`
 }

--- a/lnp2p/peermgr.go
+++ b/lnp2p/peermgr.go
@@ -118,13 +118,11 @@ func computeIdentKeyFromRoot(rootkey *hdkeychain.ExtendedKey) (privkey, error) {
 }
 
 // GetPeerIdx is a convenience function for working with older code.
-func (pm *PeerManager) GetPeerIdx(peer *Peer) int32 {
-	for i, p := range pm.peers {
-		if pm.peerMap[p] == peer {
-			return int32(i)
-		}
+func (pm *PeerManager) GetPeerIdx(peer *Peer) uint32 {
+	if peer.idx == nil {
+		return 0
 	}
-	return 0
+	return *peer.idx
 }
 
 // GetPeer returns the peer with the given lnaddr.

--- a/qln/eventhandlers.go
+++ b/qln/eventhandlers.go
@@ -54,6 +54,7 @@ func makeTmpDisconnectPeerHandler(nd *LitNode) func(eventbus.Event) eventbus.Eve
 
 		nd.RemoteMtx.Lock()
 		delete(nd.RemoteCons, rpeer.Idx)
+		delete(nd.PeerMap, ee.Peer)
 		nd.RemoteMtx.Unlock()
 
 		return eventbus.EHANDLE_OK

--- a/qln/netio.go
+++ b/qln/netio.go
@@ -107,16 +107,18 @@ func (nd *LitNode) tmpSendLitMsg(msg lnutil.LitMsg) {
 
 }
 
+// SimplePeerInfo .
 type SimplePeerInfo struct {
-	PeerNumber int32
+	PeerNumber uint32
 	RemoteHost string
 	Nickname   string
 	LitAdr     string
 }
 
+// GetConnectedPeerList .
 func (nd *LitNode) GetConnectedPeerList() []SimplePeerInfo {
 	peers := make([]SimplePeerInfo, 0)
-	for k, _ := range nd.PeerMap {
+	for k := range nd.PeerMap {
 		spi := SimplePeerInfo{
 			PeerNumber: nd.PeerMan.GetPeerIdx(k),
 			RemoteHost: k.GetRemoteAddr(),

--- a/test/itest_break.py
+++ b/test/itest_break.py
@@ -5,12 +5,12 @@ fee = 20
 initialsend = 200000
 capacity = 1000000
 
-def run_test_forward(env):
+def forward(env):
     lit1 = env.lits[0]
     lit2 = env.lits[1]
     test_combinators.run_break_test(env, lit1, lit2, lit1)
 
-def run_test_reverse(env):
+def reverse(env):
     lit1 = env.lits[0]
     lit2 = env.lits[1]
     test_combinators.run_break_test(env, lit1, lit2, lit1)

--- a/test/itest_close.py
+++ b/test/itest_close.py
@@ -1,12 +1,12 @@
 import testlib
 import test_combinators
 
-def run_test_forward(env):
+def forward(env):
     lit1 = env.lits[0]
     lit2 = env.lits[1]
     test_combinators.run_close_test(env, lit1, lit2, lit1)
 
-def run_test_reverse(env):
+def reverse(env):
     lit1 = env.lits[0]
     lit2 = env.lits[1]
     test_combinators.run_close_test(env, lit1, lit2, lit1)

--- a/test/itest_pushbreak.py
+++ b/test/itest_pushbreak.py
@@ -1,12 +1,12 @@
 import testlib
 import test_combinators
 
-def run_test_forward(env):
+def forward(env):
     lit1 = env.lits[0]
     lit2 = env.lits[1]
     test_combinators.run_pushbreak_test(env, lit1, lit2, lit1)
 
-def run_test_reverse(env):
+def reverse(env):
     lit1 = env.lits[0]
     lit2 = env.lits[1]
     test_combinators.run_pushbreak_test(env, lit1, lit2, lit2)

--- a/test/itest_pushclose.py
+++ b/test/itest_pushclose.py
@@ -1,12 +1,12 @@
 import testlib
 import test_combinators
 
-def run_test_forward(env):
+def forward(env):
     lit1 = env.lits[0]
     lit2 = env.lits[1]
     test_combinators.run_pushclose_test(env, lit1, lit2, lit1)
 
-def run_test_reverse(env):
+def reverse(env):
     lit1 = env.lits[0]
     lit2 = env.lits[1]
     test_combinators.run_pushclose_test(env, lit1, lit2, lit2)

--- a/test/itest_reconnect.py
+++ b/test/itest_reconnect.py
@@ -1,0 +1,34 @@
+
+import testlib
+
+def run_test(env):
+    print('Starting nodes')
+    lit1 = env.new_lit_node()
+    lit2 = env.new_lit_node()
+    print('Connecting nodes...')
+    lit1.connect_to_peer(lit2)
+    print('OK, shutting down node 1...')
+    lit1.shutdown()
+    print('Restarting...')
+    lit1.start()
+    print('Connecting to node 2.')
+    lit1.connect_to_peer(lit2)
+    print('Connected! OK')
+
+def run_test_unordered(env):
+    print('Starting nodes')
+    lit1 = env.new_lit_node()
+    lit2 = env.new_lit_node()
+    lit3 = env.new_lit_node()
+    print('Connecting nodes... (2 then 3)')
+    lit1.connect_to_peer(lit2)
+    lit1.connect_to_peer(lit3)
+    print('OK, shutting down node 1...')
+    lit1.shutdown()
+    print('Restarting...')
+    lit1.start()
+    lit1.resync()
+    print('Connecting nodes again... (3 then 2)')
+    lit1.connect_to_peer(lit3)
+    lit1.connect_to_peer(lit2)
+    print('Connected! OK')

--- a/test/itest_reconnect.py
+++ b/test/itest_reconnect.py
@@ -22,7 +22,7 @@ def simple(env):
     l2p2 = lit1.get_peer_id(lit2)
 
     print('Checking IDs match...')
-    print('Node 2: %s -> %s' % (l2p2, l2p2))
+    print('Node 2: %s -> %s' % (l2p1, l2p2))
     assert l2p1 == l2p2, 'peer IDs on node 1 don\'t match across restarts!'
     print('OK')
 

--- a/test/itest_reconnect.py
+++ b/test/itest_reconnect.py
@@ -7,13 +7,18 @@ def run_test(env):
     lit2 = env.new_lit_node()
     print('Connecting nodes...')
     lit1.connect_to_peer(lit2)
+    l2p1 = lit1.get_peer_id(lit2)
     print('OK, shutting down node 1...')
     lit1.shutdown()
     print('Restarting...')
     lit1.start()
-    print('Connecting to node 2.')
+    print('Connecting to node 2...')
     lit1.connect_to_peer(lit2)
-    print('Connected! OK')
+    l2p2 = lit1.get_peer_id(lit2)
+    print('Checking IDs match...')
+    print('Node 2: %s -> %s' % (l2p2, l2p2))
+    assert l2p1 == l2p2, 'peer IDs on node 1 don\'t match across restarts!'
+    print('OK')
 
 def run_test_unordered(env):
     print('Starting nodes')
@@ -23,6 +28,8 @@ def run_test_unordered(env):
     print('Connecting nodes... (2 then 3)')
     lit1.connect_to_peer(lit2)
     lit1.connect_to_peer(lit3)
+    l2p1 = lit1.get_peer_id(lit2)
+    l3p1 = lit1.get_peer_id(lit3)
     print('OK, shutting down node 1...')
     lit1.shutdown()
     print('Restarting...')
@@ -31,4 +38,11 @@ def run_test_unordered(env):
     print('Connecting nodes again... (3 then 2)')
     lit1.connect_to_peer(lit3)
     lit1.connect_to_peer(lit2)
-    print('Connected! OK')
+    l2p2 = lit1.get_peer_id(lit2)
+    l3p2 = lit1.get_peer_id(lit3)
+    print('Checking IDs match...')
+    print('Node 2: %s -> %s' % (l2p1, l2p2))
+    print('Node 3: %s -> %s' % (l3p1, l3p2))
+    assert l2p1 == l2p2, 'peer IDs on node 1 don\'t match across restarts for node 2!'
+    assert l3p1 == l3p2, 'peer IDs on node 1 don\'t match across restarts for node 3!'
+    print('OK')

--- a/test/itest_reconnect.py
+++ b/test/itest_reconnect.py
@@ -1,7 +1,7 @@
 
 import testlib
 
-def run_test(env):
+def simple(env):
     print('Starting nodes')
     lit1 = env.new_lit_node()
     lit2 = env.new_lit_node()
@@ -20,7 +20,7 @@ def run_test(env):
     assert l2p1 == l2p2, 'peer IDs on node 1 don\'t match across restarts!'
     print('OK')
 
-def run_test_unordered(env):
+def reordered(env):
     print('Starting nodes')
     lit1 = env.new_lit_node()
     lit2 = env.new_lit_node()

--- a/test/itest_reconnect.py
+++ b/test/itest_reconnect.py
@@ -5,16 +5,22 @@ def simple(env):
     print('Starting nodes')
     lit1 = env.new_lit_node()
     lit2 = env.new_lit_node()
+
     print('Connecting nodes...')
     lit1.connect_to_peer(lit2)
+    # lXpY : X == node, Y == peerIdx sample
     l2p1 = lit1.get_peer_id(lit2)
+
     print('OK, shutting down node 1...')
     lit1.shutdown()
+
     print('Restarting...')
     lit1.start()
+
     print('Connecting to node 2...')
     lit1.connect_to_peer(lit2)
     l2p2 = lit1.get_peer_id(lit2)
+
     print('Checking IDs match...')
     print('Node 2: %s -> %s' % (l2p2, l2p2))
     assert l2p1 == l2p2, 'peer IDs on node 1 don\'t match across restarts!'
@@ -25,21 +31,27 @@ def reordered(env):
     lit1 = env.new_lit_node()
     lit2 = env.new_lit_node()
     lit3 = env.new_lit_node()
+
     print('Connecting nodes... (2 then 3)')
     lit1.connect_to_peer(lit2)
     lit1.connect_to_peer(lit3)
+    # lXpY : X == node, Y == peerIdx sample
     l2p1 = lit1.get_peer_id(lit2)
     l3p1 = lit1.get_peer_id(lit3)
+
     print('OK, shutting down node 1...')
     lit1.shutdown()
+
     print('Restarting...')
     lit1.start()
     lit1.resync()
+
     print('Connecting nodes again... (3 then 2)')
     lit1.connect_to_peer(lit3)
     lit1.connect_to_peer(lit2)
     l2p2 = lit1.get_peer_id(lit2)
     l3p2 = lit1.get_peer_id(lit3)
+
     print('Checking IDs match...')
     print('Node 2: %s -> %s' % (l2p1, l2p2))
     print('Node 3: %s -> %s' % (l3p1, l3p2))

--- a/test/itest_reconnect.py
+++ b/test/itest_reconnect.py
@@ -26,6 +26,31 @@ def simple(env):
     assert l2p1 == l2p2, 'peer IDs on node 1 don\'t match across restarts!'
     print('OK')
 
+def inbound(env):
+    print('Starting nodes')
+    lit1 = env.new_lit_node()
+    lit2 = env.new_lit_node()
+
+    print('Connecting nodes...')
+    lit1.connect_to_peer(lit2)
+    # lXpY : X == node, Y == peerIdx sample
+    l2p1 = lit1.get_peer_id(lit2)
+
+    print('OK, shutting down node 1...')
+    lit1.shutdown()
+
+    print('Restarting...')
+    lit1.start()
+
+    print('Connecting to node 2 (inbound)...')
+    lit2.connect_to_peer(lit1)
+    l2p2 = lit1.get_peer_id(lit2)
+
+    print('Checking IDs match...')
+    print('Node 2: %s -> %s' % (l2p1, l2p2))
+    assert l2p1 == l2p2, 'peer IDs on node 1 don\'t match across restarts!'
+    print('OK')
+
 def reordered(env):
     print('Starting nodes')
     lit1 = env.new_lit_node()
@@ -49,6 +74,39 @@ def reordered(env):
     print('Connecting nodes again... (3 then 2)')
     lit1.connect_to_peer(lit3)
     lit1.connect_to_peer(lit2)
+    l2p2 = lit1.get_peer_id(lit2)
+    l3p2 = lit1.get_peer_id(lit3)
+
+    print('Checking IDs match...')
+    print('Node 2: %s -> %s' % (l2p1, l2p2))
+    print('Node 3: %s -> %s' % (l3p1, l3p2))
+    assert l2p1 == l2p2, 'peer IDs on node 1 don\'t match across restarts for node 2!'
+    assert l3p1 == l3p2, 'peer IDs on node 1 don\'t match across restarts for node 3!'
+    print('OK')
+
+def reordered_inbound(env):
+    print('Starting nodes')
+    lit1 = env.new_lit_node()
+    lit2 = env.new_lit_node()
+    lit3 = env.new_lit_node()
+
+    print('Connecting nodes... (2 then 3)')
+    lit1.connect_to_peer(lit2)
+    lit1.connect_to_peer(lit3)
+    # lXpY : X == node, Y == peerIdx sample
+    l2p1 = lit1.get_peer_id(lit2)
+    l3p1 = lit1.get_peer_id(lit3)
+
+    print('OK, shutting down node 1...')
+    lit1.shutdown()
+
+    print('Restarting...')
+    lit1.start()
+    lit1.resync()
+
+    print('Connecting nodes again... (3 then 2, reversed)')
+    lit2.connect_to_peer(lit1)
+    lit3.connect_to_peer(lit1)
     l2p2 = lit1.get_peer_id(lit2)
     l3p2 = lit1.get_peer_id(lit3)
 

--- a/test/runtests.py
+++ b/test/runtests.py
@@ -65,27 +65,29 @@ def load_tests_from_file(path):
             modname = 'testmod_' + tname
             mod = __load_mod_from_file(fname, modname)
             mods[tname] = mod
+        pretty = tname
+        tfn = getattr(mod, t['func_name'])
+        if tfn.__name__ != 'run_test':
+            pretty += ':' + tfn.__name__
         tests.append({
             'name': tname,
-            'test_func': getattr(mod, t['func_name']),
+            'pretty_name': pretty,
+            'test_func': tfn,
             'node_cnt': t['node_cnt']
         })
     return tests
 
 def run_test_list(tests):
     ok = 0
-    fail = 0
+    failed = []
 
     # First, just run the tests.
     for t in tests:
-        name = t['name']
+        pname = t['pretty_name']
 
         print('==============================')
         tfunc = t['test_func']
-        if tfunc.__name__ == 'run_test':
-            print('Running test:', name)
-        else:
-            print('Running test:', name + ':' + tfunc.__name__)
+        print('Running test:', pname)
 
         # Do this before the bottom frame so we have a clue how long startup
         # took and where the fail was.
@@ -104,15 +106,15 @@ def run_test_list(tests):
             tfunc(env)
             env.shutdown()
             print('------------------------------')
-            print('Success:', name)
+            print('Success:', pname)
             ok += 1
             time.sleep(0.1) # Wait for things to exit, just to be sure.
         except BaseException as e:
             env.shutdown()
             print('------------------------------')
-            print('Failure:', name)
+            print('Failure:', pname)
             print('\nError:', e)
-            fail += 1
+            failed.append(t)
             if type(e) is KeyboardInterrupt:
                 break
             # TODO Report failures and why.
@@ -122,8 +124,9 @@ def run_test_list(tests):
     # Collect results.
     res = {
         'ok': ok,
-        'fail': fail,
-        'ignored': len(tests) - ok - fail
+        'fail': len(failed),
+        'ignored': len(tests) - ok - len(failed),
+        'failed': failed
     }
     return res
 
@@ -144,6 +147,9 @@ if __name__ == '__main__':
     print('Failure:', res['fail'])
     print('Ignored:', res['ignored'])
     if res['fail'] > 0:
+        print('\nFailures:')
+        for f in res['failed']:
+            print(' - %s' % f['pretty_name'])
         sys.exit(1)
     else:
         sys.exit(0)

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -113,7 +113,7 @@ class LitNode():
         res = self.rpc.Connect(LNAddr=addr)
         self.update_peers()
         if 'PeerIdx' in res and self.peer_mapping[other.lnid] != res['PeerIdx']:
-            raise AssertError("new peer ID doesn't match reported ID")
+            raise AssertionError("new peer ID doesn't match reported ID (%s vs %s)" % (self.peer_mapping[other.lnid], res['PeerIdx']))
         other.update_peers()
 
     def get_peer_id(self, other):

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -47,10 +47,12 @@ hexchars = "0123456789abcdef"
 
 class LitNode():
     def __init__(self, bcnode):
+        self.bcnode = bcnode
         self.p2p_port = new_port()
         self.rpc_port = new_port()
         self.data_dir = new_data_dir("lit")
         self.peer_mapping = {}
+        self.proc = None
 
         # Write a hexkey to the privkey file
         with open(paths.join(self.data_dir, "privkey.hex"), 'w+') as f:
@@ -59,6 +61,13 @@ class LitNode():
                 s += hexchars[random.randint(0, len(hexchars) - 1)]
             print('Using key:', s)
             f.write(s + "\n")
+
+        # Go and do the initial startup and sync.
+        self.start()
+
+    def start(self):
+        # Sanity check.
+        assert self.proc is None, "tried to start a node that is already started!"
 
         # See if we should print stdout
         outputredir = subprocess.DEVNULL
@@ -71,7 +80,7 @@ class LitNode():
         args = [
             LIT_BIN,
             "-v", "4",
-            "--reg", "127.0.0.1:" + str(bcnode.p2p_port),
+            "--reg", "127.0.0.1:" + str(self.bcnode.p2p_port),
             "--tn3", "", # disable autoconnect
             "--dir", self.data_dir,
             "--unauthrpc",
@@ -91,7 +100,7 @@ class LitNode():
         # Make it listen to P2P connections!
         lres = self.rpc.Listen(Port=self.p2p_port)
         testutil.wait_until_port("localhost", self.p2p_port)
-        self.lnid = lres["Adr"]
+        self.lnid = lres["Adr"] # technically we do this more times than we have to, that's okay
 
     def get_sync_height(self):
         for bal in self.rpc.balance():
@@ -141,6 +150,11 @@ class LitNode():
             InitialSend=initialsend,
             Data=None) # maybe use [0 for _ in range(32)] or something?
         return res['ChanIdx']
+
+    def resync(self):
+        def ck_synced():
+            return self.get_sync_height() == self.bcnode.get_block_height()
+        testutil.wait_until(ck_synced, attempts=40, errmsg="node failing to resync!")
 
     def shutdown(self):
         if self.proc is not None:
@@ -196,6 +210,9 @@ class BitcoinNode():
                 return False
         testutil.wait_until(ck_segwit, errmsg="couldn't activate segwit")
 
+    def get_block_height(self):
+        return self.rpc.getblockchaininfo()['blocks']
+
     def shutdown(self):
         if self.proc is not None:
             self.proc.kill()
@@ -224,13 +241,16 @@ class TestEnv():
             self.shutdown()
         logger.info("nodes synced!")
 
-    def get_height(self):
-        return self.bitcoind.rpc.getblockchaininfo()['blocks']
+    def new_lit_node(self):
+        node = LitNode(self.bitcoind)
+        self.lits.append(node)
+        self.generate_block(count=0) # Force it to wait for sync.
+        return node
 
     def generate_block(self, count=1):
         if count > 0:
             self.bitcoind.rpc.generate(count)
-        h = self.get_height()
+        h = self.bitcoind.get_block_height()
         def ck_lits_synced():
             for l in self.lits:
                 sh = l.get_sync_height()

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -259,6 +259,9 @@ class TestEnv():
             return True
         testutil.wait_until(ck_lits_synced, errmsg="lits aren't syncing to bitcoind")
 
+    def get_height(self):
+        return self.bitcoind.get_block_height()
+
     def shutdown(self):
         for l in self.lits:
             l.shutdown()

--- a/test/tests.txt
+++ b/test/tests.txt
@@ -1,8 +1,8 @@
 # Basic tests
 testlib 1
 connect 2
-reconnect 0
-reconnect 0 run_test_unordered
+reconnect 0 simple
+reconnect 0 reordered
 setgetfee 1
 
 # Tx operations
@@ -12,13 +12,13 @@ send2 2
 
 # Simple channel operations
 fund 2
-close 2 run_test_forward
-close 2 run_test_reverse
+close 2 forward
+close 2 reverse
 # Disabled these to tests until we support breaking right after funding (we don't)
-break 2 run_test_forward
-break 2 run_test_reverse
+break 2 forward
+break 2 reverse
 push 2
-pushbreak 2 run_test_forward
-pushbreak 2 run_test_reverse
-pushclose 2 run_test_forward
-pushclose 2 run_test_reverse
+pushbreak 2 forward
+pushbreak 2 reverse
+pushclose 2 forward
+pushclose 2 reverse

--- a/test/tests.txt
+++ b/test/tests.txt
@@ -3,6 +3,8 @@ testlib 1
 connect 2
 reconnect 0 simple
 reconnect 0 reordered
+reconnect 0 inbound
+reconnect 0 reordered_inbound
 setgetfee 1
 
 # Tx operations

--- a/test/tests.txt
+++ b/test/tests.txt
@@ -1,6 +1,8 @@
 # Basic tests
 testlib 1
 connect 2
+reconnect 0
+reconnect 0 run_test_unordered
 setgetfee 1
 
 # Tx operations


### PR DESCRIPTION
I don't think that I need to restart the node that's reconnecting to the other nodes, but that was the simplest idea I had to make sure that the nodes would actually disconnect.

I also had to refactor a bit of the testlib code to get it to support dynamically starting/shutting down nodes on demand.