### PR TITLE
Allow lit node to run even if no daemon is running

### DIFF
--- a/lit.go
+++ b/lit.go
@@ -106,6 +106,7 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *litConfig) error {
 		p := &coinparam.RegressionNetParams
 		logging.Infof("reg: %s\n", conf.Reghost)
 		resync := false
+		conf.Tip = consts.BitcoinRegtestBHeight
 		if conf.Resync == "reg" {
 			if conf.Tip < consts.BitcoinRegtestBHeight {
 				conf.Tip = consts.BitcoinRegtestBHeight
@@ -122,6 +123,7 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *litConfig) error {
 	if !lnutil.NopeString(conf.Tn3host) {
 		p := &coinparam.TestNet3Params
 		resync := false
+		conf.Tip = consts.BitcoinTestnet3BHeight
 		if conf.Resync == "tn3" {
 			if conf.Tip < consts.BitcoinTestnet3BHeight {
 				conf.Tip = consts.BitcoinTestnet3BHeight
@@ -139,6 +141,7 @@ func linkWallets(node *qln.LitNode, key *[32]byte, conf *litConfig) error {
 	if !lnutil.NopeString(conf.Litereghost) {
 		p := &coinparam.LiteRegNetParams
 		resync := false
+		conf.Tip = consts.BitcoinRegtestBHeight
 		if conf.Resync == "ltcreg" {
 			if conf.Tip < consts.BitcoinRegtestBHeight {
 				conf.Tip = consts.BitcoinRegtestBHeight // birth heights are the same for btc and ltc regtests
@@ -284,7 +287,8 @@ func main() {
 	// node is up; link wallets based on args
 	err = linkWallets(node, key, &conf)
 	if err != nil {
-		logging.Fatal(err)
+		// if we don't link wallet, we can still continue, no worries.
+		logging.Error(err)
 	}
 
 	rpcl := new(litrpc.LitRPC)

--- a/qln/remotecontrol.go
+++ b/qln/remotecontrol.go
@@ -77,7 +77,7 @@ func (nd *LitNode) RemoteControlRequestHandler(msg lnutil.RemoteControlRpcReques
 		if err != nil {
 			return err
 		}
-		outMsg := lnutil.NewRemoteControlRpcResponseMsg(msg.Peer(), msg.Idx, false, resp)
+		outMsg := lnutil.NewRemoteControlRpcResponseMsg(peer.Idx, msg.Idx, false, resp)
 		nd.tmpSendLitMsg(outMsg)
 		return nil
 	}
@@ -88,7 +88,7 @@ func (nd *LitNode) RemoteControlRequestHandler(msg lnutil.RemoteControlRpcReques
 		err = fmt.Errorf("Received remote control request from unauthorized peer: %x", pubKey)
 		logging.Errorf(err.Error())
 
-		outMsg := lnutil.NewRemoteControlRpcResponseMsg(msg.Peer(), msg.Idx, true, []byte("Unauthorized"))
+		outMsg := lnutil.NewRemoteControlRpcResponseMsg(peer.Idx, msg.Idx, true, []byte("Unauthorized"))
 		nd.tmpSendLitMsg(outMsg)
 
 		return err
@@ -199,7 +199,7 @@ func (nd *LitNode) RemoteControlRequestHandler(msg lnutil.RemoteControlRpcReques
 					}
 				}
 
-				outMsg := lnutil.NewRemoteControlRpcResponseMsg(msg.Peer(), msg.Idx, replyIsError, reply)
+				outMsg := lnutil.NewRemoteControlRpcResponseMsg(peer.Idx, msg.Idx, replyIsError, reply)
 				nd.tmpSendLitMsg(outMsg)
 			}
 		}
@@ -213,7 +213,7 @@ func (nd *LitNode) RemoteControlRequestHandler(msg lnutil.RemoteControlRpcReques
 // two regular lit nodes do not talk to each other using remote control. But
 // just in case someone sends us one, we print it out here.
 func (nd *LitNode) RemoteControlResponseHandler(msg lnutil.RemoteControlRpcResponseMsg, peer *RemotePeer) error {
-	logging.Debugf("Received remote control reply from peer %d:\n%s", msg.Peer(), string(msg.Result))
+	logging.Debugf("Received remote control reply from peer %d:\n%s", peer.Idx, string(msg.Result))
 	return nil
 }
 

--- a/uspv/chainhook.go
+++ b/uspv/chainhook.go
@@ -89,7 +89,6 @@ type ChainHook interface {
 
 // --- implementation of ChainHook interface ----
 
-// Start ...
 func (s *SPVCon) Start(
 	startHeight int32, host, path string, proxyURL string, params *coinparam.Params) (
 	chan lnutil.TxAndHeight, chan int32, error) {
@@ -101,6 +100,8 @@ func (s *SPVCon) Start(
 
 	s.Param = params
 
+	s.inMsgQueue = make(chan wire.Message)
+	s.outMsgQueue = make(chan wire.Message)
 	s.TrackingAdrs = make(map[[20]byte]bool)
 	s.TrackingOPs = make(map[wire.OutPoint]bool)
 
@@ -123,7 +124,6 @@ func (s *SPVCon) Start(
 	err = s.Connect(host)
 	if err != nil {
 		logging.Errorf("Can't connect to host %s\n", host)
-		logging.Error(err)
 		return nil, nil, err
 	}
 

--- a/uspv/eight333.go
+++ b/uspv/eight333.go
@@ -326,7 +326,9 @@ func (s *SPVCon) AskForHeaders() error {
 	logging.Infof("get headers message has %d header hashes, first one is %s\n",
 		len(ghdr.BlockLocatorHashes), ghdr.BlockLocatorHashes[0].String())
 
+	logging.Errorf("DOES IT COME HERE?")
 	s.outMsgQueue <- ghdr
+	logging.Errorf("2 YEAH")
 	return nil
 }
 

--- a/uspv/eight333.go
+++ b/uspv/eight333.go
@@ -326,9 +326,7 @@ func (s *SPVCon) AskForHeaders() error {
 	logging.Infof("get headers message has %d header hashes, first one is %s\n",
 		len(ghdr.BlockLocatorHashes), ghdr.BlockLocatorHashes[0].String())
 
-	logging.Errorf("DOES IT COME HERE?")
 	s.outMsgQueue <- ghdr
-	logging.Errorf("2 YEAH")
 	return nil
 }
 


### PR DESCRIPTION
This was the default behaviour before recent PRs. This PR also adds a timeout for connecting to external peers instead of waiting indefinitely for non proxy connections. This also closes a bug with testnet start heights which earlier would have produced:
```
testnet3 birth height give as 0, but parameters start at 1255968
```
but now stands corrected. 