### PR TITLE
Use tracker to lookup nodes (new p2p code)

### DIFF
--- a/lnp2p/peermgr.go
+++ b/lnp2p/peermgr.go
@@ -4,18 +4,20 @@ package lnp2p
 import (
 	"crypto/ecdsa"
 	"fmt"
+	"net"
+	"strconv"
+	"sync"
+	"time"
+
 	"github.com/mit-dci/lit/btcutil/hdkeychain"
 	"github.com/mit-dci/lit/crypto/koblitz"
 	"github.com/mit-dci/lit/eventbus"
 	"github.com/mit-dci/lit/lncore"
 	"github.com/mit-dci/lit/lndc"
+	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/logging"
 	"github.com/mit-dci/lit/nat"
 	"github.com/mit-dci/lit/portxo"
-	"net"
-	"strconv"
-	"sync"
-	"time"
 )
 
 type privkey *koblitz.PrivateKey
@@ -41,6 +43,9 @@ type PeerManager struct {
 	sending  bool
 	outqueue chan outgoingmsg
 
+	// Tracker
+	trackerURL string
+
 	// Sync.
 	mtx *sync.Mutex
 }
@@ -57,7 +62,7 @@ type NetSettings struct {
 }
 
 // NewPeerManager creates a peer manager from a root key
-func NewPeerManager(rootkey *hdkeychain.ExtendedKey, pdb lncore.LitPeerStorage, bus *eventbus.EventBus) (*PeerManager, error) {
+func NewPeerManager(rootkey *hdkeychain.ExtendedKey, pdb lncore.LitPeerStorage, trackerURL string, bus *eventbus.EventBus) (*PeerManager, error) {
 	k, err := computeIdentKeyFromRoot(rootkey)
 	if err != nil {
 		return nil, err
@@ -72,6 +77,7 @@ func NewPeerManager(rootkey *hdkeychain.ExtendedKey, pdb lncore.LitPeerStorage, 
 		peerMap:        map[lncore.LnAddr]*Peer{},
 		listeningPorts: map[string]*listeningthread{},
 		sending:        false,
+		trackerURL:     trackerURL,
 		outqueue:       make(chan outgoingmsg, outgoingbuf),
 		mtx:            &sync.Mutex{},
 	}
@@ -141,7 +147,11 @@ func (pm *PeerManager) TryConnectAddress(addr string, settings *NetSettings) (*P
 	// Figure out who we're trying to connect to.
 	who, where := splitAdrString(addr)
 	if where == "" {
-		// TODO Do lookup.
+		ipv4, _, err := lnutil.Lookup(addr, pm.trackerURL, "")
+		if err != nil {
+			return nil, err
+		}
+		where = ipv4
 	}
 
 	lnwho := lncore.LnAddr(who)

--- a/lnp2p/peermgr.go
+++ b/lnp2p/peermgr.go
@@ -151,7 +151,7 @@ func (pm *PeerManager) TryConnectAddress(addr string, settings *NetSettings) (*P
 		if err != nil {
 			return nil, err
 		}
-		where = ipv4
+		where = fmt.Sprintf("%s:2448", ipv4)
 	}
 
 	lnwho := lncore.LnAddr(who)

--- a/qln/init.go
+++ b/qln/init.go
@@ -2,6 +2,9 @@ package qln
 
 import (
 	"fmt"
+	"path/filepath"
+	"sync"
+
 	"github.com/boltdb/bolt"
 	"github.com/mit-dci/lit/btcutil"
 	"github.com/mit-dci/lit/btcutil/hdkeychain"
@@ -15,8 +18,6 @@ import (
 	"github.com/mit-dci/lit/portxo"
 	"github.com/mit-dci/lit/wallit"
 	"github.com/mit-dci/lit/watchtower"
-	"path/filepath"
-	"sync"
 )
 
 // NewLitNode starts up a lit node.  Needs priv key, and a path.
@@ -59,7 +60,7 @@ func NewLitNode(privKey *[32]byte, path string, trackerURL string, proxyURL stri
 	nd.Events = &ebus
 
 	// Peer manager
-	nd.PeerMan, err = lnp2p.NewPeerManager(rootPrivKey, nd.NewLitDB.GetPeerDB(), &ebus)
+	nd.PeerMan, err = lnp2p.NewPeerManager(rootPrivKey, nd.NewLitDB.GetPeerDB(), trackerURL, &ebus)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The new peer-to-peer code was missing the ability to lookup node addresses via the tracker. I've added that in this PR. Needed also for convenient multihop payments, otherwise you have to manually connect to the nodes you want to pay beforehand.