### PR TITLE
Fixed typing and local variable definitions in Lit-AF

### DIFF
--- a/cmd/lit-af/netcmds.go
+++ b/cmd/lit-af/netcmds.go
@@ -75,6 +75,8 @@ func (lc *litAfClient) Graph(textArgs []string) error {
 
 // Lis starts listening.  Takes args of port to listen on.
 func (lc *litAfClient) Lis(textArgs []string) error {
+	var err error
+
 	if len(textArgs) > 0 && textArgs[0] == "-h" {
 		fmt.Fprintf(color.Output, lisCommand.Format)
 		fmt.Fprintf(color.Output, lisCommand.Description)
@@ -92,7 +94,7 @@ func (lc *litAfClient) Lis(textArgs []string) error {
 		}
 	}
 
-	err := lc.Call("LitRPC.Listen", args, reply)
+	err = lc.Call("LitRPC.Listen", args, reply)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Something weird happened when @Varunram changed ports to be numerical that caused things to not compile.  But it works fine now, I think.