### PR TITLE
Fixed the way the test framework supplied ports to Lit to use the new port formatting

### DIFF
--- a/test/runtests.py
+++ b/test/runtests.py
@@ -105,6 +105,7 @@ def run_test_list(tests):
             print('------------------------------')
             print('Success:', name)
             ok += 1
+            time.sleep(0.1) # Wait for things to exit, just to be sure.
         except BaseException as e:
             env.shutdown()
             print('------------------------------')

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -76,8 +76,8 @@ class LitNode():
             "--dir", self.data_dir,
             "--unauthrpc",
             "--rpcport=" + str(self.rpc_port),
-            "--autoReconnect",
-            "--autoListenPort=" + str(self.p2p_port)
+            #"--autoReconnect",
+            #"--autoListenPort=" + str(self.p2p_port)
         ]
         self.proc = subprocess.Popen(args,
             stdin=subprocess.DEVNULL,
@@ -89,7 +89,7 @@ class LitNode():
         self.rpc = litrpc.LitClient("localhost", str(self.rpc_port))
 
         # Make it listen to P2P connections!
-        lres = self.rpc.Listen(Port=":" + str(self.p2p_port))
+        lres = self.rpc.Listen(Port=self.p2p_port)
         testutil.wait_until_port("localhost", self.p2p_port)
         self.lnid = lres["Adr"]
 


### PR DESCRIPTION
Probably should have had this in the last PR, oops!