### PR TITLE
Allow closing LNDC RPC client

### DIFF
--- a/litrpc/lndcrpcclient.go
+++ b/litrpc/lndcrpcclient.go
@@ -142,6 +142,10 @@ func NewLndcRpcClient(address string, key *koblitz.PrivateKey) (*LndcRpcClient, 
 	return cli, nil
 }
 
+func (cli *LndcRpcClient) Close() error {
+	return cli.lnconn.Close()
+}
+
 func (cli *LndcRpcClient) Call(serviceMethod string, args interface{}, reply interface{}) error {
 	var err error
 


### PR DESCRIPTION
When you use an LndcRpcClient, you can't close the connection. While building some utilities that interface with lit this becomes kind of problematic.