### PR TITLE
Fixes difficulty adjustment for dummy USD regtest (there is none)

### DIFF
--- a/coinparam/dummyusd.go
+++ b/coinparam/dummyusd.go
@@ -20,10 +20,9 @@ var DummyUsdNetParams = Params{
 	PoWFunction: func(b []byte, height int32) chainhash.Hash {
 		return chainhash.DoubleHashH(b)
 	},
-	DiffCalcFunction: diffBitcoin,
-	//	func(r io.ReadSeeker, height, startheight int32, p *Params) (uint32, error) {
-	//		return diffBTC(r, height, startheight, p, false)
-	//	},
+	DiffCalcFunction: func(headers []*wire.BlockHeader, height int32, p *Params) (uint32, error) {
+		return p.PowLimitBits, nil
+	},
 	FeePerByte:               80,
 	PowLimit:                 regressionPowLimit,
 	PowLimitBits:             0x207fffff,


### PR DESCRIPTION
The difficulty adjustment for dummy USD is non-existent. It's always the minimum since it's a regtest copy. Without this it won't sync past block 2015