### PR TITLE
Added more graceful handling to some errors on startup

### DIFF
--- a/lit.go
+++ b/lit.go
@@ -59,6 +59,7 @@ type litConfig struct { // define a struct for usage with go-flags
 	AutoReconnectInterval           int64 `long:"autoReconnectInterval" description:"The interval (in seconds) the reconnect logic should be executed"`
 	AutoReconnectOnlyConnectedCoins bool  `long:"autoReconnectOnlyConnectedCoins" description:"Only reconnect to peers that we have channels with in a coin whose coin daemon is available"`
 	AutoListenPort                  int   `long:"autoListenPort" description:"When auto reconnect enabled, starts listening on this port"`
+	NoAutoListen                    bool  `long:"noautolisten" description:"Don't automatically listen on any ports."`
 	Params                          *coinparam.Params
 }
 
@@ -71,6 +72,7 @@ var (
 	defaultRpcport                         = uint16(8001)
 	defaultRpchost                         = "localhost"
 	defaultAutoReconnect                   = true
+	defaultNoAutoListen                    = false
 	defaultAutoListenPort                  = 2448
 	defaultAutoReconnectInterval           = int64(60)
 	defaultUpnPFlag                        = false
@@ -253,6 +255,7 @@ func main() {
 		Rpchost:                         defaultRpchost,
 		TrackerURL:                      defaultTrackerURL,
 		AutoReconnect:                   defaultAutoReconnect,
+		NoAutoListen:                    defaultNoAutoListen,
 		AutoListenPort:                  defaultAutoListenPort,
 		AutoReconnectInterval:           defaultAutoReconnectInterval,
 		AutoReconnectOnlyConnectedCoins: defaultAutoReconnectOnlyConnectedCoins,
@@ -300,7 +303,7 @@ func main() {
 		go litrpc.RPCListen(rpcl, conf.Rpchost, conf.Rpcport)
 	}
 
-	if conf.AutoReconnect {
+	if conf.AutoReconnect && !conf.NoAutoListen {
 		node.AutoReconnect(conf.AutoListenPort, conf.AutoReconnectInterval, conf.AutoReconnectOnlyConnectedCoins)
 	}
 

--- a/litinit.go
+++ b/litinit.go
@@ -71,11 +71,8 @@ func litSetup(conf *litConfig) *[32]byte {
 		}
 	}
 
-	if _, err := os.Stat(filepath.Join(filepath.Join(conf.LitHomeDir), "lit.conf")); os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(conf.LitHomeDir, "lit.conf")); os.IsNotExist(err) {
 		// if there is no config file found over at the directory, create one
-		if err != nil {
-			fmt.Println(err)
-		}
 		logging.Infof("Creating a new config file")
 		err := createDefaultConfigFile(filepath.Join(conf.LitHomeDir)) // Source of error
 		if err != nil {
@@ -83,7 +80,7 @@ func litSetup(conf *litConfig) *[32]byte {
 		}
 	}
 
-	conf.ConfigFile = filepath.Join(filepath.Join(conf.LitHomeDir), "lit.conf")
+	conf.ConfigFile = filepath.Join(conf.LitHomeDir, "lit.conf")
 	// lets parse the config file provided, if any
 	err = flags.NewIniParser(parser).ParseFile(conf.ConfigFile)
 	if err != nil {

--- a/lnutil/keyfile.go
+++ b/lnutil/keyfile.go
@@ -60,9 +60,12 @@ func LoadKeyFromFileArg(filename string, pass []byte) (*[32]byte, error) {
 	}
 
 	if len(enckey) == 32 { // UNencrypted key, length 32
-		logging.Warnf("WARNING!! Key file not encrypted!!\n")
-		logging.Warnf("Anyone who can read the key file can take everything!\n")
-		logging.Warnf("You should start over and use a good passphrase!\n")
+		v, p := os.LookupEnv("LIT_KEYFILE_WARN")
+		if !p || v != "0" {
+			logging.Warnf("WARNING!! Key file not encrypted!!\n")
+			logging.Warnf("Anyone who can read the key file can take everything!\n")
+			logging.Warnf("You should start over and use a good passphrase!\n")
+		}
 		copy(priv32[:], enckey[:])
 		return priv32, nil
 	}

--- a/lnutil/keyfile.go
+++ b/lnutil/keyfile.go
@@ -61,11 +61,12 @@ func LoadKeyFromFileArg(filename string, pass []byte) (*[32]byte, error) {
 
 	if len(enckey) == 32 { // UNencrypted key, length 32
 		v, p := os.LookupEnv("LIT_KEYFILE_WARN")
-		if !p || v != "0" {
+		if !p || (p && v != "0") {
 			logging.Warnf("WARNING!! Key file not encrypted!!\n")
 			logging.Warnf("Anyone who can read the key file can take everything!\n")
 			logging.Warnf("You should start over and use a good passphrase!\n")
 		}
+
 		copy(priv32[:], enckey[:])
 		return priv32, nil
 	}

--- a/qln/routing.go
+++ b/qln/routing.go
@@ -576,7 +576,11 @@ func (nd *LitNode) PopulateRates() error {
 
 	jsonFile, err := os.Open(ratesPath)
 	if err != nil {
-		return err
+		if !os.IsNotExist(err) {
+			return err
+		}
+		logging.Infof("Rates file not found.")
+		return nil
 	}
 	defer jsonFile.Close()
 

--- a/qln/routing.go
+++ b/qln/routing.go
@@ -29,7 +29,10 @@ func (nd *LitNode) InitRouting() {
 
 	err := nd.PopulateRates()
 	if err != nil {
-		logging.Errorf("failure loading exchange rates: %s", err.Error())
+		if os.IsNotExist(err) {
+			logging.Infof("Rates file not found.")
+		}
+		logging.Warnf("failure loading exchange rates: %s", err.Error())
 	}
 
 	nd.AdvTimeout = time.NewTicker(15 * time.Second)
@@ -576,11 +579,7 @@ func (nd *LitNode) PopulateRates() error {
 
 	jsonFile, err := os.Open(ratesPath)
 	if err != nil {
-		if !os.IsNotExist(err) {
-			return err
-		}
-		logging.Infof("Rates file not found.")
-		return nil
+		return err
 	}
 	defer jsonFile.Close()
 

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -97,7 +97,9 @@ class LitNode():
             "--noautolisten"
         ]
         penv = os.environ.copy()
-        penv['LIT_KEYFILE_WARN'] = '0'
+        lkw = 'LIT_KEYFILE_WARN'
+        if lkw not in penv:
+            penv[lkw] = '0'
         self.proc = subprocess.Popen(args,
             stdin=subprocess.DEVNULL,
             stdout=outputredir,

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -94,8 +94,7 @@ class LitNode():
             "--dir", self.data_dir,
             "--unauthrpc",
             "--rpcport=" + str(self.rpc_port),
-            #"--autoReconnect",
-            #"--autoListenPort=" + str(self.p2p_port)
+            "--noautolisten"
         ]
         self.proc = subprocess.Popen(args,
             stdin=subprocess.DEVNULL,

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -96,10 +96,13 @@ class LitNode():
             "--rpcport=" + str(self.rpc_port),
             "--noautolisten"
         ]
+        penv = os.environ.copy()
+        penv['LIT_KEYFILE_WARN'] = '0'
         self.proc = subprocess.Popen(args,
             stdin=subprocess.DEVNULL,
             stdout=outputredir,
-            stderr=outputredir)
+            stderr=outputredir,
+            env=penv)
 
         # Make the RPC client for future use, too.
         testutil.wait_until_port("localhost", self.rpc_port)


### PR DESCRIPTION
We don't complain about perfectly normal things now, like not finding the config file.  I also added an envvar called `LIT_KEYFILE_WARN` that if `0` will suppress the warning about having an unencrypted `privkey.hex`.