### PR TITLE
Added support for p2p function calls

### DIFF
--- a/litrpc/netcmds.go
+++ b/litrpc/netcmds.go
@@ -294,3 +294,33 @@ func (r *LitRPC) ListPendingRemoteControlAuthRequests(args NoArgs, reply *RCPend
 	return nil
 
 }
+
+type PingPeerArgs struct {
+	peerIdx int32
+	msg     string
+}
+
+type PingPeerReply struct {
+	resp string
+	err  string
+}
+
+func (r *LitRPC) PingPeer(args PingPeerArgs, reply *PingPeerReply) error {
+
+	var pm *lnp2p.PeerManager = r.Node.PeerMan
+
+	peer := pm.GetPeerByIdx(args.peerIdx)
+
+	m := lnp2p.NewPingMsg([]byte(args.msg))
+	resp, err := peer.InvokeBlockingCall(m, 5000)
+
+	if err != nil {
+		reply.err = err.Error()
+		return nil
+	}
+
+	pong := resp.(lnp2p.PcPong)
+	reply.resp = string(pong.GetBody())
+	return nil
+
+}

--- a/litrpc/netcmds.go
+++ b/litrpc/netcmds.go
@@ -296,31 +296,31 @@ func (r *LitRPC) ListPendingRemoteControlAuthRequests(args NoArgs, reply *RCPend
 }
 
 type PingPeerArgs struct {
-	peerIdx int32
-	msg     string
+	PeerIdx int32
+	Msg     string
 }
 
 type PingPeerReply struct {
-	resp string
-	err  string
+	Resp string
+	Err  string
 }
 
 func (r *LitRPC) PingPeer(args PingPeerArgs, reply *PingPeerReply) error {
 
 	var pm *lnp2p.PeerManager = r.Node.PeerMan
 
-	peer := pm.GetPeerByIdx(args.peerIdx)
+	peer := pm.GetPeerByIdx(args.PeerIdx)
 
-	m := lnp2p.NewPingMsg([]byte(args.msg))
+	m := lnp2p.NewPingMsg([]byte(args.Msg))
 	resp, err := peer.InvokeBlockingCall(m, 5000)
 
 	if err != nil {
-		reply.err = err.Error()
+		reply.Err = err.Error()
 		return nil
 	}
 
 	pong := resp.(lnp2p.PcPong)
-	reply.resp = string(pong.GetBody())
+	reply.Resp = string(pong.GetBody())
 	return nil
 
 }

--- a/lnp2p/call.go
+++ b/lnp2p/call.go
@@ -78,7 +78,7 @@ type callinprogress struct {
 	messageParser func([]byte) (PeerCallMessage, error)
 
 	// what we pass the parsed message to
-	// if the bool in the reponse is false, then don't consider the call "complete"
+	// TODO if the bool in the reponse is false, then don't consider the call "complete" (impl not complete yet, value ignored)
 	callback PeerCallback
 
 	// if we exceed the timeout and haven't been sent any messages then run this before removing the entry

--- a/lnp2p/call.go
+++ b/lnp2p/call.go
@@ -152,8 +152,8 @@ func (cr *CallRouter) processCall(peer *Peer, msg Message) error {
 	if !ok {
 		logging.Warnf("callrouter: peer %s tried to call a function we don't know %4x\n", peer.GetPrettyName(), id)
 		peer.SendQueuedMessage(errmsg{
-			id:     id,
-			errmsg: "function ID not found",
+			id:  id,
+			msg: "function ID not found",
 		})
 		return fmt.Errorf("unknown message ID")
 	}
@@ -161,8 +161,8 @@ func (cr *CallRouter) processCall(peer *Peer, msg Message) error {
 	m, err := fnh.parser(cmsg.body)
 	if err != nil {
 		peer.SendQueuedMessage(errmsg{
-			id:     id,
-			errmsg: fmt.Sprintf("parse error: %s", err.Error()),
+			id:  id,
+			msg: fmt.Sprintf("parse error: %s", err.Error()),
 		})
 		return err
 	}
@@ -172,8 +172,8 @@ func (cr *CallRouter) processCall(peer *Peer, msg Message) error {
 		if err != nil {
 			// There was an error, just return it as a string.
 			peer.SendQueuedMessage(errmsg{
-				id:     id,
-				errmsg: err.Error(),
+				id:  id,
+				msg: err.Error(),
 			})
 			return
 		}
@@ -249,8 +249,8 @@ func (cr *CallRouter) processErrorResponse(peer *Peer, emsg errmsg) error {
 	ip.ok <- true
 
 	// Now actually invoke the call.
-	logging.Warnf("callrouter: error on call %d to remote peer: %s\n", emsg.id, emsg.errmsg)
-	_, err := ip.callback(nil, fmt.Errorf(emsg.errmsg)) // TODO support repeated returns later
+	logging.Warnf("callrouter: error on call %d to remote peer: %s\n", emsg.id, emsg.msg)
+	_, err := ip.callback(nil, fmt.Errorf(emsg.msg)) // TODO support repeated returns later
 	if err != nil {
 		logging.Warnf("callrouter: problem when processing (error) callback to %d: %s\n", emsg.id, err.Error())
 	}

--- a/lnp2p/call.go
+++ b/lnp2p/call.go
@@ -182,7 +182,7 @@ func (cr *CallRouter) processCall(peer *Peer, msg Message) error {
 		}
 
 		// We're not supposed to have responses have a type of a regular fnid, but just warn on it.
-		if res.FuncID() >= 0x00f0 && res.FuncID() != 0xffff {
+		if res.FuncID() >= 0x0010 && res.FuncID() != 0xffff {
 			logging.Warnf("callrouter: response to %s returning with response fnid out of normal range (%4x)\n", fnh.name, res.FuncID())
 		}
 
@@ -273,7 +273,7 @@ func (cr *CallRouter) DefineFunction(fnid uint16, name string, mparser PcParser,
 	cr.mtx.Lock()
 	defer cr.mtx.Unlock()
 
-	if fnid < 0x00f0 || fnid == 0xffff {
+	if fnid < 0x0010 || fnid == 0xffff {
 		return fmt.Errorf("function ID must be >=0x00f0 and !=0xffff, special values are used for signalling")
 	}
 

--- a/lnp2p/call.go
+++ b/lnp2p/call.go
@@ -1,0 +1,282 @@
+package lnp2p
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/mit-dci/lit/logging"
+)
+
+const (
+
+	// MsgidCall is the id for calling.
+	MsgidCall = 0xC0
+
+	// MsgidResponse is the id for responses.
+	MsgidResponse = 0xC1
+)
+
+// PeerCallMessage is a serialized version of what the remote peer send.
+type PeerCallMessage interface {
+	Bytes() []byte
+	FuncID() uint16
+}
+
+// PcParser is a function that parses P2P message call bodies.
+type PcParser func([]byte) (PeerCallMessage, error)
+
+// PcFunction is the implementation of a P2P call.
+// (inbound message) -> (outbound message, error)
+type PcFunction func(*Peer, PeerCallMessage) (PeerCallMessage, error) // should we make the result have a different type?
+
+type peercallhandlerdef struct {
+	parser       PcParser
+	callFunction PcFunction
+}
+
+// CallRouter is the thing that handles doing p2p calls.
+type CallRouter struct {
+
+	// handlers
+	fnhandlers map[uint16]peercallhandlerdef
+
+	// ID of the next call to be invoked.  Starts counting at 0.
+	currentMsgID uint32
+
+	// the in-progress calls
+	inprog map[uint32]callinprogress
+
+	// mutex for everything, not needed for everything though
+	mtx sync.Mutex
+}
+
+// NewCallRouter creates a new empty CallRouter with default settings.
+func NewCallRouter() CallRouter {
+	return CallRouter{
+		currentMsgID: 0,
+		inprog:       make(map[uint32]callinprogress),
+		mtx:          sync.Mutex{},
+	}
+}
+
+type callmsg struct {
+	id     uint32
+	funcID uint16
+	body   []byte
+}
+
+func (m callmsg) Bytes() []byte {
+
+	w := bytes.Buffer{}
+
+	// Write the call ID and message type
+	binary.Write(&w, binary.BigEndian, m.id)
+	binary.Write(&w, binary.BigEndian, m.funcID)
+
+	// Write the body len
+	blen := uint32(len(m.body))
+	binary.Write(&w, binary.BigEndian, blen)
+
+	// Write the body.
+	w.Write(m.body)
+
+	return w.Bytes()
+
+}
+
+func (callmsg) Type() uint8 {
+	return MsgidCall
+}
+
+type respmsg struct {
+	id   uint32
+	body []byte
+}
+
+func (m respmsg) Bytes() []byte {
+
+	w := bytes.Buffer{}
+
+	// Write the call ID
+	binary.Write(&w, binary.BigEndian, m.id)
+
+	// Write the body len
+	blen := uint32(len(m.body))
+	binary.Write(&w, binary.BigEndian, blen)
+
+	// Write the body.
+	w.Write(m.body)
+
+	return w.Bytes()
+
+}
+
+func (respmsg) Type() uint8 {
+	return MsgidResponse
+}
+
+// PeerCallback is the function that's called when we got a response to a messsage.
+type PeerCallback func(PeerCallMessage, error, error) (bool, error)
+
+// PeerTimeoutHandler is the function called when we timed out.
+type PeerTimeoutHandler func()
+
+type callinprogress struct {
+
+	// millis time for when it started
+	started uint64
+
+	// how many millis to wait until giving up
+	timeout uint64
+
+	// if a true is sent on this channel then we don't have to invoke the timeout handler
+	ok chan bool
+
+	// parses the bytes from the remote peer
+	messageParser func([]byte) (PeerCallMessage, error)
+
+	// what we pass the parsed message to
+	// if the bool in the reponse is false, then don't consider the call "complete"
+	// (inbound message, parse error, network error) -> (delete, processing error)
+	callback PeerCallback
+
+	// if we exceed the timeout and haven't been sent any messages then run this before removing the entry
+	timeoutHandler PeerTimeoutHandler
+}
+
+func makeTimestamp() uint64 {
+	return uint64(time.Now().UnixNano()) / uint64(time.Millisecond)
+}
+
+func (cr *CallRouter) initInvokeCall(peer *Peer, timeout uint64, call PeerCallMessage, cb PeerCallback, toh PeerTimeoutHandler) error {
+
+	cr.mtx.Lock()
+	cid := cr.currentMsgID
+	cr.currentMsgID++
+	cr.mtx.Unlock()
+
+	// Create the record for the in-progres call.
+	cip := callinprogress{
+		started:        makeTimestamp(),
+		timeout:        timeout,
+		ok:             make(chan bool),
+		messageParser:  nil, // TODO
+		callback:       cb,
+		timeoutHandler: toh,
+	}
+
+	// Create the actual message to send off to the remote peer.
+	m := callmsg{
+		id:     cid,
+		funcID: call.FuncID(), // TODO
+		body:   call.Bytes(),
+	}
+
+	// Install the call record.
+	cr.mtx.Lock()
+	cr.inprog[cid] = cip
+	cr.mtx.Unlock()
+
+	// Spin off a thread to wait for the timeout.
+	if toh != nil {
+		go (func() {
+			select {
+			case ok := <-cip.ok:
+				if !ok {
+					logging.Warnf("something bad happened!") // TODO more detials
+				}
+			case <-time.After(time.Duration(cip.timeout) * time.Millisecond):
+				toh()
+			}
+		})()
+	}
+
+	// Now actually send the message and return.
+	return peer.SendQueuedMessage(m)
+
+}
+
+func (cr *CallRouter) processCall(peer *Peer, msg Message) error {
+
+	cmsg, ok := msg.(callmsg)
+	if !ok {
+		return fmt.Errorf("bad message type") // is this really necessary?
+	}
+
+	id := cmsg.id
+
+	// Figure out which function handler to use.
+	cr.mtx.Lock()
+	fnh, ok := cr.fnhandlers[cmsg.funcID]
+	cr.mtx.Unlock()
+
+	// Check that we actually found one.
+	if !ok {
+		// TODO Figure out what to do if we don't have a handler set up.
+	}
+
+	m, err := fnh.parser(cmsg.body)
+	if err != nil {
+		return err // TODO Better error handling for this.
+	}
+
+	go (func() {
+		res, err := fnh.callFunction(peer, m)
+		if err != nil {
+			// TODO
+		}
+
+		if res.FuncID() < 0x00f0 || res.FuncID() == 0xffff {
+			// Actually send off the response here.
+			peer.SendQueuedMessage(respmsg{
+				id:   id,
+				body: res.Bytes(),
+			})
+		} else {
+			// It thinks it's some other call, that's wrong.
+			// TODO
+		}
+	})()
+
+	return nil
+}
+
+func (cr *CallRouter) processResponse(peer *Peer, msg Message) error {
+
+	cmsg, ok := msg.(respmsg)
+	if !ok {
+		return fmt.Errorf("bad message type")
+	}
+
+	cr.mtx.Lock()
+	_, ok = cr.inprog[cmsg.id]
+	if !ok {
+		return fmt.Errorf("message ID doesn't match any in-progress call")
+	}
+	cr.mtx.Unlock()
+
+	// TODO the rest of the handling
+
+	return nil
+}
+
+// DefineFunction sets up implementation for some P2P call.
+func (cr *CallRouter) DefineFunction(fnid uint16, mparser PcParser, impl PcFunction) error {
+	cr.mtx.Lock()
+	defer cr.mtx.Unlock()
+
+	if fnid < 0x00f0 || fnid == 0xffff {
+		return fmt.Errorf("function ID must be >=0x00f0 and !=0xffff, special values are used for signalling")
+	}
+
+	// Just add it to the table, pretty easy.
+	cr.fnhandlers[fnid] = peercallhandlerdef{
+		parser:       mparser,
+		callFunction: impl,
+	}
+
+	return nil
+}

--- a/lnp2p/callmsgs.go
+++ b/lnp2p/callmsgs.go
@@ -1,0 +1,100 @@
+package lnp2p
+
+import (
+	"bytes"
+	"encoding/binary"
+)
+
+const (
+
+	// MsgidCall is the id for calling.
+	MsgidCall = 0xC0
+
+	// MsgidResponse is the id for responses.
+	MsgidResponse = 0xC1
+
+	// MsgidError is for when there was an error processing the call.
+	MsgidError = 0xC2
+)
+
+type callmsg struct {
+	id     uint32
+	funcID uint16
+	body   []byte
+}
+
+func (m callmsg) Bytes() []byte {
+
+	w := bytes.Buffer{}
+
+	// Write the call ID and message type
+	binary.Write(&w, binary.BigEndian, m.id)
+	binary.Write(&w, binary.BigEndian, m.funcID)
+
+	// Write the body len
+	blen := uint32(len(m.body))
+	binary.Write(&w, binary.BigEndian, blen)
+
+	// Write the body.
+	w.Write(m.body)
+
+	return w.Bytes()
+
+}
+
+func (callmsg) Type() uint8 {
+	return MsgidCall
+}
+
+type respmsg struct {
+	id   uint32
+	body []byte
+}
+
+func (m respmsg) Bytes() []byte {
+
+	w := bytes.Buffer{}
+
+	// Write the call ID
+	binary.Write(&w, binary.BigEndian, m.id)
+
+	// Write the body len
+	blen := uint32(len(m.body))
+	binary.Write(&w, binary.BigEndian, blen)
+
+	// Write the body.
+	w.Write(m.body)
+
+	return w.Bytes()
+
+}
+
+func (respmsg) Type() uint8 {
+	return MsgidResponse
+}
+
+type errmsg struct {
+	id     uint32
+	errmsg string // maybe this should be richer?  does it matter?
+}
+
+func (m errmsg) Bytes() []byte {
+
+	w := bytes.Buffer{}
+
+	// Write the call ID
+	binary.Write(&w, binary.BigEndian, m.id)
+
+	// Write the message len.
+	binary.Write(&w, binary.BigEndian, uint16(len(m.errmsg)))
+
+	// Write the message.
+	w.WriteString(m.errmsg)
+
+	return w.Bytes()
+
+}
+
+func (errmsg) Type() uint8 {
+	return MsgidError
+}

--- a/lnp2p/callmsgs.go
+++ b/lnp2p/callmsgs.go
@@ -213,3 +213,51 @@ func ParseErrMessage(buf []byte) (Message, error) {
 func (errmsg) Type() uint8 {
 	return MsgidError
 }
+
+// PcPing .
+type PcPing struct {
+	buf []byte
+}
+
+func NewPingMsg(buf []byte) PcPing {
+	return PcPing{buf}
+}
+
+// Bytes .
+func (p PcPing) Bytes() []byte {
+	return p.buf
+}
+
+// FuncID .
+func (PcPing) FuncID() uint16 {
+	return 0xff00
+}
+
+// PcPong .
+type PcPong struct {
+	buf []byte
+}
+
+// Bytes .
+func (p PcPong) Bytes() []byte {
+	return p.buf
+}
+
+// FuncID .
+func (PcPong) FuncID() uint16 {
+	return 0xffff
+}
+
+func (p PcPong) GetBody() []byte {
+	return p.buf
+}
+
+// ParsePing is for deserializing a buffer into a ping message.
+func ParsePing(buf []byte) (PeerCallMessage, error) {
+	return PcPing{buf}, nil
+}
+
+// ParsePong is for deserializing a buffer into a pong message.
+func ParsePong(buf []byte) (PeerCallMessage, error) {
+	return PcPong{buf}, nil
+}

--- a/lnp2p/callmsgs.go
+++ b/lnp2p/callmsgs.go
@@ -76,7 +76,7 @@ func ParseCallMessage(buf []byte) (Message, error) {
 	}
 
 	if n != int(blen) {
-		return nil, fmt.Errorf("unexpected EOF")
+		return nil, fmt.Errorf("unexpected EOF (parse call)")
 	}
 
 	res.body = body
@@ -139,7 +139,7 @@ func ParseRespMessage(buf []byte) (Message, error) {
 	}
 
 	if n != int(blen) {
-		return nil, fmt.Errorf("unexpected EOF")
+		return nil, fmt.Errorf("unexpected EOF (parse resp)")
 	}
 
 	res.body = body
@@ -188,7 +188,7 @@ func ParseErrMessage(buf []byte) (Message, error) {
 	}
 
 	// More magic to read the error message.
-	var mlen uint32
+	var mlen uint16
 	err = binary.Read(r, binary.BigEndian, &mlen)
 	if err != nil {
 		return nil, err
@@ -201,7 +201,7 @@ func ParseErrMessage(buf []byte) (Message, error) {
 	}
 
 	if n != int(mlen) {
-		return nil, fmt.Errorf("unexpected EOF")
+		return nil, fmt.Errorf("unexpected EOF (parse err)")
 	}
 
 	res.msg = string(body) // apparently this "just werks"

--- a/lnp2p/msgproc.go
+++ b/lnp2p/msgproc.go
@@ -79,13 +79,13 @@ func (mp *MessageProcessor) HandleMessage(peer *Peer, buf []byte) error {
 	mtype := buf[0]
 	h := mp.handlers[mtype]
 	if h == nil {
-		return fmt.Errorf("no handler found for messasge of type %x", mtype)
+		return fmt.Errorf("no handler found for messasge of type %X", mtype)
 	}
 
 	// Parse the message.
 	parsed, err := h.parseFunc(buf[1:])
 	if err != nil {
-		logging.Warnf("msgproc: Malformed message of type %x from peer %s\n", mtype, peer.GetPrettyName())
+		logging.Warnf("msgproc: Malformed message of type %X from peer %s len %d\n", mtype, peer.GetPrettyName(), len(buf[1:]))
 		return err
 	}
 

--- a/lnp2p/peermgr.go
+++ b/lnp2p/peermgr.go
@@ -232,7 +232,7 @@ func (pm *PeerManager) tryConnectPeer(netaddr string, lnaddr *lncore.LnAddr, set
 	}
 
 	pnick := ""
-	if pi != nil {
+	if pi != nil && pi.Nickname != nil {
 		pnick = *pi.Nickname
 	}
 
@@ -449,16 +449,16 @@ func (pm *PeerManager) SetupFunctionalMessageHandling() {
 	mp.DefineMessage(MsgidResponse, ParseRespMessage, func(p *Peer, m Message) error {
 		rm, ok := m.(respmsg)
 		if !ok {
-			return fmt.Errorf("bad message type")
+			return fmt.Errorf("bad peercall message type (resp)")
 		}
 		return pm.crouter.processReturnResponse(p, rm)
 	})
 
 	// Register error handling.
-	mp.DefineMessage(MsgidResponse, ParseRespMessage, func(p *Peer, m Message) error {
+	mp.DefineMessage(MsgidError, ParseErrMessage, func(p *Peer, m Message) error {
 		em, ok := m.(errmsg)
 		if !ok {
-			return fmt.Errorf("bad message type")
+			return fmt.Errorf("bad peercall message type (err)")
 		}
 		return pm.crouter.processErrorResponse(p, em)
 	})

--- a/lnp2p/peermgr.go
+++ b/lnp2p/peermgr.go
@@ -27,10 +27,11 @@ type pubkey *koblitz.PublicKey
 type PeerManager struct {
 
 	// Biographical.
-	idkey  privkey
-	peerdb lncore.LitPeerStorage
-	ebus   *eventbus.EventBus
-	mproc  MessageProcessor
+	idkey   privkey
+	peerdb  lncore.LitPeerStorage
+	ebus    *eventbus.EventBus
+	mproc   MessageProcessor
+	crouter CallRouter
 
 	// Peer tracking.
 	peers   []lncore.LnAddr // compatibility
@@ -73,6 +74,7 @@ func NewPeerManager(rootkey *hdkeychain.ExtendedKey, pdb lncore.LitPeerStorage, 
 		peerdb:         pdb,
 		ebus:           bus,
 		mproc:          NewMessageProcessor(),
+		crouter:        NewCallRouter(),
 		peers:          make([]lncore.LnAddr, 1),
 		peerMap:        map[lncore.LnAddr]*Peer{},
 		listeningPorts: map[int]*listeningthread{},

--- a/lnp2p/peermgr.go
+++ b/lnp2p/peermgr.go
@@ -87,9 +87,17 @@ func NewPeerManager(rootkey *hdkeychain.ExtendedKey, pdb lncore.LitPeerStorage, 
 	return pm, nil
 }
 
-// GetMessageProcessor gets the message processor for this peer manager that's passed incoming messasges from peers.
+// GetMessageProcessor gets the message processor for this peer manager that's
+// passed incoming messasges from peers.
 func (pm *PeerManager) GetMessageProcessor() *MessageProcessor {
 	return &pm.mproc
+}
+
+// GetCallRouter returns the functional p2p call router for the peer manager.
+// But you must call pm.SetupFunctionalMessageHandling() first for it to be
+// useful though.
+func (pm *PeerManager) GetCallRouter() *CallRouter {
+	return &pm.crouter
 }
 
 // GetExternalAddress returns the human-readable LN address

--- a/lnp2p/peermgr.go
+++ b/lnp2p/peermgr.go
@@ -463,4 +463,19 @@ func (pm *PeerManager) SetupFunctionalMessageHandling() {
 		return pm.crouter.processErrorResponse(p, em)
 	})
 
+	cr := pm.GetCallRouter()
+
+	// Set up a "ping" message.
+	cr.DefineFunction(0xff00, "pingpong", ParsePing, ParsePong, func(p *Peer, m PeerCallMessage) (PeerCallMessage, error) {
+		ping := m.(PcPing)
+
+		// If it's long, then we can use this as a test to for error handling.
+		if len(ping.buf) > 255 {
+			return nil, fmt.Errorf("ping body too long")
+		}
+
+		logging.Infof("Received ping call from peer %s: %v\n", p.GetPrettyName(), ping.buf)
+		return PcPong{ping.buf}, nil
+	})
+
 }

--- a/qln/init.go
+++ b/qln/init.go
@@ -76,6 +76,7 @@ func NewLitNode(privKey *[32]byte, path string, trackerURL string, proxyURL stri
 
 	// Sets up handlers for all the messages we need to handle.
 	nd.registerHandlers()
+	nd.PeerMan.SetupFunctionalMessageHandling()
 
 	var kg portxo.KeyGen
 	kg.Depth = 5

--- a/test/itest_peercall.py
+++ b/test/itest_peercall.py
@@ -1,0 +1,23 @@
+import testlib
+
+okmsg = 'Hello, world!'
+
+def succeed(env):
+    lit1 = env.lits[0]
+    lit2 = env.lits[1]
+    lit1.connect_to_peer(lit2)
+    l2idx = lit1.get_peer_id(lit2)
+
+    res = lit1.rpc.PingPeer(PeerIdx=l2idx, Msg=okmsg)
+    assert res['Resp'] == okmsg, 'response message not same as call message'
+    assert res['Err'] == '', 'response Err field non-null'
+
+def fail(env):
+    lit1 = env.lits[0]
+    lit2 = env.lits[1]
+    lit1.connect_to_peer(lit2)
+    l2idx = lit1.get_peer_id(lit2)
+
+    msg = 'something' * 256
+    res = lit1.rpc.PingPeer(PeerIdx=l2idx, Msg=msg)
+    assert res['Err'] != '', 'response Err field non-null'

--- a/test/runtests.py
+++ b/test/runtests.py
@@ -4,6 +4,7 @@ import os
 import sys
 import time
 import importlib.util as imu
+import traceback
 
 import testlib
 
@@ -112,6 +113,7 @@ def run_test_list(tests):
             print('------------------------------')
             print('Failure:', name)
             print('\nError:', e)
+            traceback.print_exc()
             fail += 1
             if type(e) is KeyboardInterrupt:
                 break

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -108,7 +108,10 @@ class LitNode():
         other.update_peers()
 
     def get_peer_id(self, other):
-        return self.peer_mapping[other.lnid]
+        try:
+            return self.peer_mapping[other.lnid]
+        except KeyError as e:
+            raise Exception('peer not registered')
 
     def make_new_addr(self):
         res = self.rpc.Address(NumToMake=1, CoinType=REGTEST_COINTYPE)

--- a/test/tests.txt
+++ b/test/tests.txt
@@ -2,6 +2,8 @@
 testlib 1
 connect 2
 setgetfee 1
+peercall 2 succeed
+peercall 2 fail
 
 # Tx operations
 receive 1


### PR DESCRIPTION
This PR introduces a new concept of p2p function calls.  Currently uses msgids `0xC0`, `0xC1`, and `0xC2`.

Hopefully this will help us transition all of the msgids that are used to fake function-like calls to other peers to instead just be functions.  See below:

```go
MSGID_DLC_OFFER               = 0x90 // Offer a contract
MSGID_DLC_ACCEPTOFFER         = 0x91 // Accept the contract
MSGID_DLC_DECLINEOFFER        = 0x92 // Decline the contract
```

With this new system it's just a single 16-bit "function ID", and there's fewer barriers to having multiple operations in-progress since it operates with a system of callbacks.

```go
msg := ...
peer.InvokeAsyncCall(msg, func(resp PeerCallMessage, err error) (bool, error) {
    // handle message/error
    return true, nil
})
```

There's also support for (configurable) timeouts and a blocking version of the call interface, see the bottom of `lnp2p/peer.go`.

Currently, this PR strictly adds behavior, it doesn't remove or (significantly) change anything.

~~Still need to write some tests for this PR, as well.~~ Tests have been written.