### PR TITLE
Fix bug where any remote RPC call crashes lit

### DIFF
--- a/lnp2p/peermgr.go
+++ b/lnp2p/peermgr.go
@@ -137,7 +137,7 @@ func (pm *PeerManager) GetPeer(lnaddr lncore.LnAddr) *Peer {
 
 // GetPeerByIdx is a compatibility function for getting a peer by its "peer id".
 func (pm *PeerManager) GetPeerByIdx(id int32) *Peer {
-	if id <= 0 || id >= int32(len(pm.peers)) {
+	if id < 0 || id >= int32(len(pm.peers)) {
 		return nil
 	}
 	return pm.peerMap[pm.peers[id]]

--- a/qln/remotecontrol.go
+++ b/qln/remotecontrol.go
@@ -42,7 +42,7 @@ func (nd *LitNode) RemoteControlRequestHandler(msg lnutil.RemoteControlRpcReques
 		pubKey = msg.PubKey
 		transportAuthenticated = false
 	}
-	logging.Infof("Received remote control request [%s] from [%x]\n\n%s", msg.Method, pubKey, string(msg.Args))
+	logging.Infof("Received remote control request [%s] from [%x]\nArguments Passed: %s", msg.Method, pubKey, string(msg.Args))
 
 	// Fetch the remote control authorization based on the used public key
 	auth, err := nd.GetRemoteControlAuthorization(pubKey)


### PR DESCRIPTION
Still investigating why peerIds start from 0

ref: #414