### PR TITLE
Don't call litrpc.Balance each time ls is called

### DIFF
--- a/cmd/lit-af/shell.go
+++ b/cmd/lit-af/shell.go
@@ -318,14 +318,6 @@ func (lc *litAfClient) Ls(textArgs []string) error {
 		displayAllCommands = true
 	}
 
-	// Balance reply needed for bals and chans
-	if cmd == "chans" || cmd == "bals" || displayAllCommands {
-		err := lc.Call("LitRPC.Balance", nil, bReply)
-		if err != nil {
-			return err
-		}
-	}
-
 	if cmd == "conns" || displayAllCommands {
 		err := lc.Call("LitRPC.ListConnections", nil, pReply)
 		if err != nil {
@@ -343,28 +335,20 @@ func (lc *litAfClient) Ls(textArgs []string) error {
 		}
 	}
 
-	err = lc.Call("LitRPC.Balance", nil, bReply)
-	if err != nil {
-		return err
-	}
-
-	walHeights := map[uint32]int32{}
-	for _, b := range bReply.Balances {
-		walHeights[b.CoinType] = b.SyncHeight
-	}
-
-	err = lc.Call("LitRPC.ChannelList", nil, cReply)
-	if err != nil {
-		return err
-	}
-	if len(cReply.Channels) > 0 {
-		fmt.Fprintf(color.Output, "\t%s\n", lnutil.Header("Channels:"))
-	}
-
 	if cmd == "chans" || displayAllCommands {
 		err := lc.Call("LitRPC.ChannelList", nil, cReply)
 		if err != nil {
 			return err
+		}
+
+		err = lc.Call("LitRPC.Balance", nil, bReply)
+		if err != nil {
+			return err
+		}
+
+		walHeights := map[uint32]int32{}
+		for _, b := range bReply.Balances {
+			walHeights[b.CoinType] = b.SyncHeight
 		}
 
 		if len(cReply.Channels) > 0 {
@@ -553,6 +537,11 @@ func (lc *litAfClient) Ls(textArgs []string) error {
 	}
 
 	if cmd == "bals" || displayAllCommands {
+		err = lc.Call("LitRPC.Balance", nil, bReply)
+		if err != nil {
+			return err
+		}
+
 		if len(bReply.Balances) > 0 {
 			if displayAllCommands {
 				fmt.Fprintf(color.Output, "\t%s\n", lnutil.Header("Balances:"))


### PR DESCRIPTION
I guess this was a carry over of multiple rebases in the past, so we didn't really catch it.