### PR TITLE
Made some changes to peer init in lnp2p

### DIFF
--- a/db/lnbolt/peerdb.go
+++ b/db/lnbolt/peerdb.go
@@ -55,7 +55,13 @@ func (pdb *peerboltdb) GetPeerAddrs() ([]lncore.LnAddr, error) {
 			if k == nil {
 				break
 			}
-			atmp = append(atmp, lncore.LnAddr(string(k)))
+			lnaddr, err := lncore.ParseLnAddr(string(k))
+			if err != nil {
+				logging.Warnf("lnbolt/peerdb: found invalid key in DB as lnaddr: %s (error: %s)", string(k), err.Error())
+				continue
+			}
+
+			atmp = append(atmp, lnaddr)
 		}
 
 		// Now that we have the final array return it.
@@ -126,7 +132,11 @@ func (pdb *peerboltdb) GetPeerInfos() (map[lncore.LnAddr]lncore.PeerInfo, error)
 				return err2
 			}
 
-			ka := lncore.LnAddr(string(k))
+			ka, err2 := lncore.ParseLnAddr(string(k))
+			if err2 != nil {
+				logging.Warnf("lnbolt/peerdb: found invalid key in DB as lnaddr: %s (error: %s)", string(k), err.Error())
+				continue
+			}
 			mtmp[ka] = pi
 
 		}

--- a/litrpc/netcmds.go
+++ b/litrpc/netcmds.go
@@ -95,8 +95,13 @@ func (r *LitRPC) Connect(args ConnectArgs, reply *ConnectReply) error {
 		paddr = strings.SplitN(paddr, "@", 2)[0]
 	}
 
-	var pm *lnp2p.PeerManager = r.Node.PeerMan
-	p := pm.GetPeer(lncore.LnAddr(paddr))
+	pm := r.Node.PeerMan
+	lnaddr, err := lncore.ParseLnAddr(paddr)
+	if err != nil {
+		return err
+	}
+
+	p := pm.GetPeer(lnaddr)
 	if p == nil {
 		return fmt.Errorf("couldn't find peer in manager after connecting")
 	}

--- a/litrpc/netcmds.go
+++ b/litrpc/netcmds.go
@@ -8,7 +8,6 @@ import (
 	"github.com/mit-dci/lit/bech32"
 	"github.com/mit-dci/lit/crypto/koblitz"
 	"github.com/mit-dci/lit/lncore"
-	"github.com/mit-dci/lit/lnp2p"
 	"github.com/mit-dci/lit/lnutil"
 	"github.com/mit-dci/lit/logging"
 	"github.com/mit-dci/lit/qln"

--- a/lncore/peers.go
+++ b/lncore/peers.go
@@ -1,8 +1,45 @@
 package lncore
 
+import (
+	"fmt"
+
+	"github.com/mit-dci/lit/bech32"
+)
+
 // LnAddr is just a bech32-encoded pubkey.
 // TODO Move this to another package so it's more obviously not *just* IO-related.
 type LnAddr string
+
+// ParseLnAddr will verify that the string passed is a valid LN address, as in
+// ln1pmclh89haeswrw0unf8awuyqeu4t2uell58nea.
+func ParseLnAddr(m string) (LnAddr, error) {
+
+	prefix, raw, err := bech32.Decode(m)
+
+	// Check it's valid bech32.
+	if err != nil {
+		return "", err
+	}
+
+	// Check it has the right prefix.
+	if prefix != "ln" {
+		return "", fmt.Errorf("prefix is not 'ln'")
+	}
+
+	// Check the length of the content bytes is right.
+	if len(raw) > 20 {
+		return "", fmt.Errorf("address too long to be pubkey")
+	}
+
+	return LnAddr(m), nil // should be the only place we cast to this type
+
+}
+
+// ToString returns the LnAddr as a string.  Right now it just unwraps it but it
+// might do something more eventually.
+func (lnaddr LnAddr) ToString() string {
+	return string(lnaddr)
+}
 
 // LitPeerStorage is storage for peer data.
 type LitPeerStorage interface {

--- a/lnp2p/peermgr.go
+++ b/lnp2p/peermgr.go
@@ -156,7 +156,11 @@ func (pm *PeerManager) TryConnectAddress(addr string) (*Peer, error) {
 		where = fmt.Sprintf("%s:2448", ipv4)
 	}
 
-	lnwho := lncore.LnAddr(who)
+	lnwho, err := lncore.ParseLnAddr(who)
+	if err != nil {
+		return nil, err
+	}
+
 	x, y := pm.tryConnectPeer(where, &lnwho)
 	return x, y
 

--- a/lnp2p/peermgr.go
+++ b/lnp2p/peermgr.go
@@ -5,7 +5,6 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 	"net"
-	"strconv"
 	"sync"
 	"time"
 
@@ -31,10 +30,11 @@ const MaxNodeCount = 1024
 type PeerManager struct {
 
 	// Biographical.
-	idkey  privkey
-	peerdb lncore.LitPeerStorage
-	ebus   *eventbus.EventBus
-	mproc  MessageProcessor
+	idkey       privkey
+	peerdb      lncore.LitPeerStorage
+	ebus        *eventbus.EventBus
+	mproc       MessageProcessor
+	netsettings *NetSettings
 
 	// Peer tracking.
 	peers   []lncore.LnAddr // compatibility
@@ -66,7 +66,7 @@ type NetSettings struct {
 }
 
 // NewPeerManager creates a peer manager from a root key
-func NewPeerManager(rootkey *hdkeychain.ExtendedKey, pdb lncore.LitPeerStorage, trackerURL string, bus *eventbus.EventBus) (*PeerManager, error) {
+func NewPeerManager(rootkey *hdkeychain.ExtendedKey, pdb lncore.LitPeerStorage, trackerURL string, bus *eventbus.EventBus, ns *NetSettings) (*PeerManager, error) {
 	k, err := computeIdentKeyFromRoot(rootkey)
 	if err != nil {
 		return nil, err
@@ -77,6 +77,7 @@ func NewPeerManager(rootkey *hdkeychain.ExtendedKey, pdb lncore.LitPeerStorage, 
 		peerdb:         pdb,
 		ebus:           bus,
 		mproc:          NewMessageProcessor(),
+		netsettings:    ns,
 		peers:          make([]lncore.LnAddr, MaxNodeCount),
 		peerMap:        map[lncore.LnAddr]*Peer{},
 		listeningPorts: map[int]*listeningthread{},
@@ -128,7 +129,6 @@ func (pm *PeerManager) GetPeerIdx(peer *Peer) uint32 {
 // GetPeer returns the peer with the given lnaddr.
 func (pm *PeerManager) GetPeer(lnaddr lncore.LnAddr) *Peer {
 	p, ok := pm.peerMap[lnaddr]
-	logging.Errorf("%v -> %v (%t)\n", lnaddr, p, ok)
 	if !ok {
 		return nil
 	}
@@ -144,7 +144,7 @@ func (pm *PeerManager) GetPeerByIdx(id int32) *Peer {
 }
 
 // TryConnectAddress attempts to connect to the specified LN address.
-func (pm *PeerManager) TryConnectAddress(addr string, settings *NetSettings) (*Peer, error) {
+func (pm *PeerManager) TryConnectAddress(addr string) (*Peer, error) {
 
 	// Figure out who we're trying to connect to.
 	who, where := splitAdrString(addr)
@@ -157,54 +157,24 @@ func (pm *PeerManager) TryConnectAddress(addr string, settings *NetSettings) (*P
 	}
 
 	lnwho := lncore.LnAddr(who)
-	x, y := pm.tryConnectPeer(where, &lnwho, settings)
+	x, y := pm.tryConnectPeer(where, &lnwho)
 	return x, y
 
 }
 
-func (pm *PeerManager) tryConnectPeer(netaddr string, lnaddr *lncore.LnAddr, settings *NetSettings) (*Peer, error) {
+func (pm *PeerManager) tryConnectPeer(netaddr string, lnaddr *lncore.LnAddr) (*Peer, error) {
 
 	// lnaddr check, to make sure that we do the right thing.
 	if lnaddr == nil {
 		return nil, fmt.Errorf("connection to a peer with unknown lnaddr not supported yet")
 	}
 
-	// Do NAT setup stuff.
-	if settings != nil && settings.NatMode != nil {
-
-		// Do some type juggling.
-		x, err := strconv.Atoi(netaddr[1:])
-		if err != nil {
-			return nil, err
-		}
-		lisPort := uint16(x) // if only Atoi could infer which type we wanted to parse as!
-
-		// Actually figure out what we're going to do.
-		if *settings.NatMode == "upnp" {
-			// Universal Plug-n-Play
-			logging.Infof("Attempting port forwarding via UPnP...")
-			err = nat.SetupUpnp(lisPort)
-			if err != nil {
-				return nil, err
-			}
-		} else if *settings.NatMode == "pmp" {
-			// NAT Port Mapping Protocol
-			timeout := time.Duration(10 * time.Second)
-			logging.Infof("Attempting port forwarding via PMP...")
-			_, err = nat.SetupPmp(timeout, lisPort)
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			return nil, fmt.Errorf("invalid NAT type: %s", *settings.NatMode)
-		}
-	}
-
 	dialer := net.Dial
 
 	// Use a proxy server if applicable.
-	if settings != nil && settings.ProxyAddr != nil {
-		d, err := connectToProxyTCP(*settings.ProxyAddr, settings.ProxyAuth)
+	ns := pm.netsettings
+	if ns != nil && ns.ProxyAddr != nil {
+		d, err := connectToProxyTCP(*ns.ProxyAddr, ns.ProxyAuth)
 		if err != nil {
 			return nil, err
 		}
@@ -361,6 +331,34 @@ func (pm *PeerManager) DisconnectPeer(peer *Peer) error {
 // ListenOnPort attempts to start a goroutine lisening on the port.
 func (pm *PeerManager) ListenOnPort(port int) error {
 
+	// Do NAT setup stuff.
+	ns := pm.netsettings
+	if ns != nil && ns.NatMode != nil {
+
+		// Do some type juggling.
+		lisPort := uint16(port)
+
+		// Actually figure out what we're going to do.
+		if *ns.NatMode == "upnp" {
+			// Universal Plug-n-Play
+			logging.Infof("Attempting port forwarding via UPnP...")
+			err := nat.SetupUpnp(lisPort)
+			if err != nil {
+				return err
+			}
+		} else if *ns.NatMode == "pmp" {
+			// NAT Port Mapping Protocol
+			timeout := time.Duration(10 * time.Second)
+			logging.Infof("Attempting port forwarding via PMP...")
+			_, err := nat.SetupPmp(timeout, lisPort)
+			if err != nil {
+				return err
+			}
+		} else {
+			return fmt.Errorf("invalid NAT type: %s", *ns.NatMode)
+		}
+	}
+
 	threadobj := &listeningthread{
 		listener: nil,
 	}
@@ -375,9 +373,8 @@ func (pm *PeerManager) ListenOnPort(port int) error {
 		return fmt.Errorf("listen cancelled by event handler")
 	}
 
-	// TODO UPnP and PMP NAT traversal.
-
 	// Try to start listening.
+	// TODO Listen on proxy if possible?
 	logging.Info("PORT: ", port)
 	listener, err := lndc.NewListener(pm.idkey, port)
 	if err != nil {

--- a/lnp2p/util.go
+++ b/lnp2p/util.go
@@ -32,7 +32,15 @@ func splitAdrString(adr string) (string, string) {
 func convertPubkeyToLitAddr(pk pubkey) lncore.LnAddr {
 	b := (*koblitz.PublicKey)(pk).SerializeCompressed()
 	doubleSha := fastsha256.Sum256(b[:])
-	return lncore.LnAddr(bech32.Encode("ln", doubleSha[:20]))
+
+	lnaddr, e := lncore.ParseLnAddr(bech32.Encode("ln", doubleSha[:20]))
+
+	// Should never happen.
+	if e != nil {
+		panic("this should never happen, lit addr gen code has a bug: " + e.Error())
+	}
+
+	return lnaddr
 }
 
 func connectToProxyTCP(addr string, auth *string) (func(string, string) (net.Conn, error), error) {

--- a/qln/init.go
+++ b/qln/init.go
@@ -60,7 +60,7 @@ func NewLitNode(privKey *[32]byte, path string, trackerURL string, proxyURL stri
 	nd.Events = &ebus
 
 	// Peer manager
-	nd.PeerMan, err = lnp2p.NewPeerManager(rootPrivKey, nd.NewLitDB.GetPeerDB(), trackerURL, &ebus)
+	nd.PeerMan, err = lnp2p.NewPeerManager(rootPrivKey, nd.NewLitDB.GetPeerDB(), trackerURL, &ebus, nil) // TODO proxy/nat stuff
 	if err != nil {
 		return nil, err
 	}

--- a/qln/netio.go
+++ b/qln/netio.go
@@ -20,7 +20,12 @@ func (nd *LitNode) GetLisAddressAndPorts() (string, []string) {
 // TODO Remove this function.
 func (nd *LitNode) FindPeerIndexByAddress(lnAdr string) (uint32, error) {
 	pm := nd.PeerMan
-	p := pm.GetPeer(lncore.LnAddr(lnAdr))
+	lnaddr, err := lncore.ParseLnAddr(lnAdr)
+	if err != nil {
+		return 0, err
+	}
+
+	p := pm.GetPeer(lnaddr)
 	if p != nil {
 		return p.GetIdx(), nil
 	}

--- a/qln/netio.go
+++ b/qln/netio.go
@@ -80,7 +80,7 @@ func splitAdrString(adr string) (string, string) {
 // TODO Remove this.
 func (nd *LitNode) DialPeer(connectAdr string) error {
 
-	_, err := nd.PeerMan.TryConnectAddress(connectAdr, nil)
+	_, err := nd.PeerMan.TryConnectAddress(connectAdr)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This unifies the setup we do *after* we've established the connection.  I moved the peer init code from the functions for connecting to peers and for listening for new connections to another function so new connections get the same treatment regardless of how it was created.

I also did some changes to the NetSettings struct, it's passed to the peermgr on creation, so we don't have to provide it every time we connect to a peer.  Plus some other minor fixes there.

I also added a `lncore.ParseLnAddr` function that takes a string, verifies that it conforms to what we expect for a lit address, and returns it as a `LnAddr` or returns an error describing why it isn't valid.  I also replaced all of the direct casts to `lncore.LnAddr` across lit to calls to that function.  There's also a `.ToString()` function on it but there's not much interesting about that.