### PR TITLE
Accept pubkey connections in lit

### DIFF
--- a/cmd/lit-af/lit-af.go
+++ b/cmd/lit-af/lit-af.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"encoding/hex"
 
 	"github.com/chzyer/readline"
 	"github.com/fatih/color"
@@ -108,7 +109,11 @@ func (lc *litAfClient) litAfSetup(conf litAfConfig) {
 			logging.Fatal(err.Error())
 		}
 		key, _ := koblitz.PrivKeyFromBytes(koblitz.S256(), privKey[:])
-
+		pubkey := key.PubKey().SerializeCompressed() // this is in bytes
+		fmt.Println("The pubkey of this lit-af instance is:", hex.EncodeToString(pubkey))
+		var temp [33]byte
+		copy(temp[:], pubkey[33:])
+		fmt.Println("The pkh of this lit-af instance is:", lnutil.LitAdrFromPubkey(temp))
 		if adr != "" && strings.HasPrefix(adr, "ln1") && host == "" {
 			ipv4, _, err := lnutil.Lookup(adr, conf.Tracker, "")
 			if err != nil {

--- a/litrpc/netcmds.go
+++ b/litrpc/netcmds.go
@@ -66,6 +66,9 @@ func (r *LitRPC) Connect(args ConnectArgs, reply *ConnectReply) error {
 	// first, see if the peer to connect to is referenced by peer index.
 	var connectAdr string
 	// check if a peer number was supplied instead of a pubkeyhash
+	// accept either an string or a pubkey (raw)
+	// so args.LNAddr passed here contains blah@host:ip
+	fmt.Println("PASSED STUFF:", args.LNAddr)
 	peerIdxint, err := strconv.Atoi(args.LNAddr)
 	// number will mean no error
 	if err == nil {
@@ -83,7 +86,7 @@ func (r *LitRPC) Connect(args ConnectArgs, reply *ConnectReply) error {
 		connectAdr = args.LNAddr
 	}
 
-	err = r.Node.DialPeer(connectAdr)
+	err = r.Node.PeerMan.TryConnectAddress(connectAdr, nil)
 	if err != nil {
 		return err
 	}

--- a/litrpc/netcmds.go
+++ b/litrpc/netcmds.go
@@ -68,7 +68,6 @@ func (r *LitRPC) Connect(args ConnectArgs, reply *ConnectReply) error {
 	// check if a peer number was supplied instead of a pubkeyhash
 	// accept either an string or a pubkey (raw)
 	// so args.LNAddr passed here contains blah@host:ip
-	fmt.Println("PASSED STUFF:", args.LNAddr)
 	peerIdxint, err := strconv.Atoi(args.LNAddr)
 	// number will mean no error
 	if err == nil {

--- a/lndc/conn.go
+++ b/lndc/conn.go
@@ -81,7 +81,9 @@ func Dial(localPriv *koblitz.PrivateKey, ipAddr string, remotePKH string,
 	}
 
 	logging.Info("Received pubkey", s)
+	logging.Debug("Received pubkey: ", lnutil.LitAdrFromPubkey(s), "have pubkey", remotePKH)
 	if lnutil.LitAdrFromPubkey(s) != remotePKH {
+		fmt.Println("Received pubkey: ", lnutil.LitAdrFromPubkey(s), "have pubkey", remotePKH)
 		return nil, fmt.Errorf("Remote PKH doesn't match. Quitting!")
 	}
 	logging.Infof("Received PKH %s matches", lnutil.LitAdrFromPubkey(s))

--- a/lnp2p/peermgr.go
+++ b/lnp2p/peermgr.go
@@ -144,21 +144,21 @@ func (pm *PeerManager) GetPeerByIdx(id int32) *Peer {
 }
 
 // TryConnectAddress attempts to connect to the specified LN address.
-func (pm *PeerManager) TryConnectAddress(addr string, settings *NetSettings) (*Peer, error) {
+func (pm *PeerManager) TryConnectAddress(addr string, settings *NetSettings) (error) {
 
 	// Figure out who we're trying to connect to.
 	who, where := splitAdrString(addr)
 	if where == "" {
 		ipv4, _, err := lnutil.Lookup(addr, pm.trackerURL, "")
 		if err != nil {
-			return nil, err
+			return err
 		}
 		where = fmt.Sprintf("%s:2448", ipv4)
 	}
 
 	lnwho := lncore.LnAddr(who)
-	x, y := pm.tryConnectPeer(where, &lnwho, settings)
-	return x, y
+	_, y := pm.tryConnectPeer(where, &lnwho, settings)
+	return y
 
 }
 

--- a/qln/netio.go
+++ b/qln/netio.go
@@ -40,6 +40,7 @@ func (nd *LitNode) TCPListener(port int) (string, error) {
 
 	lnaddr := nd.PeerMan.GetExternalAddress()
 
+	logging.Infof("My raw hex Public Key is: %s", nd.PeerMan.GetExternalPubkeyString())
 	logging.Infof("Listening with ln address: %s \n", lnaddr)
 
 	// Don't announce on the tracker if we are communicating via SOCKS proxy

--- a/qln/netio.go
+++ b/qln/netio.go
@@ -80,7 +80,7 @@ func splitAdrString(adr string) (string, string) {
 // TODO Remove this.
 func (nd *LitNode) DialPeer(connectAdr string) error {
 
-	_, err := nd.PeerMan.TryConnectAddress(connectAdr, nil)
+	err := nd.PeerMan.TryConnectAddress(connectAdr, nil)
 	if err != nil {
 		return err
 	}

--- a/uspv/header.go
+++ b/uspv/header.go
@@ -312,6 +312,10 @@ func CheckHeaderChain(
 
 		// reorg is go, snip to attach height
 		reorgDepth := height - attachHeight
+		if reorgDepth > numheaders {
+			logging.Info("Reorg depth is greater than the number of headers received, exiting!")
+			return 0, fmt.Errorf("Reorg depth is greater than the number of headers received, exiting!")
+		}
 		oldHeaders = oldHeaders[:numheaders-reorgDepth]
 	}
 


### PR DESCRIPTION
Instead of just accepting raw pk hashes, accept pubkeys as well so that we can connect using them. A small precursor to the bigger pubkey revamp that's coming. Requires #432 and builds upon one of its commit.