### PR TITLE
Tiny magic byte correction

### DIFF
--- a/coinparam/vertcoin.go
+++ b/coinparam/vertcoin.go
@@ -69,7 +69,7 @@ var VertcoinTestNetParams = Params{
 
 var VertcoinRegTestParams = Params{
 	Name:          "vtcreg",
-	NetMagicBytes: 0xdab5bffa,
+	NetMagicBytes: 0xdbb5befa,
 	DefaultPort:   "18444",
 	DNSSeeds:      []string{},
 


### PR DESCRIPTION
I changed the magic bytes for the Vertcoin RegTest params from `0xdab5bffa` to `0xdbb5befa`, now you don't get EOF whenever trying to connect to a regtest node.