### PR TITLE
Address prefix fix

### DIFF
--- a/coinparam/vertcoin.go
+++ b/coinparam/vertcoin.go
@@ -115,7 +115,7 @@ var VertcoinRegTestParams = Params{
 	RelayNonStdTxs: true,
 
 	// Address encoding magics
-	PubKeyHashAddrID: 0x6f,
+	PubKeyHashAddrID: 0x4a, // starts with X or W
 	ScriptHashAddrID: 0xc4,
 	Bech32Prefix:     "rvtc",
 	PrivateKeyID:     0xef,


### PR DESCRIPTION
Another tiny fix, [from this line in vertcoin-core](https://github.com/vertcoin-project/vertcoin-core/blob/0f495ed667f04641a728b507fc8326fa9eb1d47b/src/chainparams.cpp#L329).