### PR TITLE
lit-af fix for multiple lit instances on single computer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,13 @@ The below command will run Lit on the Bitcoin testnet3 network
 
 The words `yup, yes, y, true, 1, ok, enable, on` can be used to specify that Lit
 automatically connect to peers fetched from a list of DNS seeds. It can also be replaced by
-the address of the node you wish to connect to.
+the address of the node you wish to connect to. For example for the btc testnet3:
+
+```bash
+./lit --tn3=localhost
+```
+
+It will use default port for different nodes. See the "Command line arguments" section.
 
 ### Packaging
 

--- a/WALKTHROUGH.md
+++ b/WALKTHROUGH.md
@@ -41,7 +41,7 @@ Alice starts running lit (with `./lit --tn3 fullnode.net`) and syncs up to the b
 Alice connects to her full node, fullnode.net.  By default this is on testnet3, using port 18333.
 
 ```
-alice@pi2:~/anode$ ./lit --tn3 fullnode.net -v
+alice@pi2:~/anode$ ./lit --tn3=fullnode.net -v
 lit node v0.1
 -h for list of options.
 No file testkey.hex, generating.
@@ -57,36 +57,63 @@ Now in another window, alice connects to the lit node over RPC using `./lit-af`
 
 ```
 alice@pi2:~/anode$ ./lit-af
-lit-af# ls
-entered command: ls
-	Addresses:
-0 tb1q39stxtf6udwnjpatadylkgakf8q9und06we8ew (mt3LiAN4EjaHQGeHWLoTHgDUtafALwL6Zv)
-	Utxo: 0 Conf:0 Channel: 0
-Sync Height 1060000
+lit-af# ls -a
+entered command: ls -a
+        Peers:
+1 127.0.0.1:49958 (ln1wj3csaf6p6kgvj6zre6zqta7lnjms9zndkwc8d)
+        Listening Ports:
+Listening for connections on port(s) [[::]:2448] with key ln1akupazfterdadrywclht0s8kgvt3r3jga0lyez
+        Addresses:
+1 tb1qf77l4ja2kq6na0ffmekph6qv22puufqr5aatg0 (mnnbGE9dxHpNFuzBrTWUk5PZ9272JF2bkK)
+        Balances:
+Type: 1 Sync Height: 1481792    FeeRate: 80     Utxo: 0 WitConf: 0 Channel: 0
 
 ```
 
-ls shows how much money Alice has, which is none.  She can get some from a faucet. One such faucet you can find [here](https://testnet.manu.backend.hamburg/faucet).
+Buy default the lit-af utility use ~/.lit directory for litHomeDir and 2448 for autoListenPort.
+You can change this running:
 
-Bob can start a wallet in the same way; if Bob's node is running on the same computer, he'll have to run lit with -rpcport to listen on a different port, and start lit-af with -p to connect to that port.  Once Alice and Bob are both set up, they can connect to each other.
+```
+alice@pi2:~/gofolder/src/github.com/mit-dci/lit/cmd/lit-af/lit-af --litHomeDir=/path/to_alice/lit1 --autoListenPort=2448
+```
+
+
+ls -a shows how much money Alice has, which is none.  She can get some from a faucet. One such faucet you can find [here](https://testnet.manu.backend.hamburg/faucet).
+
+Bob can start a wallet in the same way; if Bob's node is running on the same computer, he'll have to run lit placing a lit.conf in to the ~/bnode folder:
+
+```
+tn3=1
+rpchost=0.0.0.0
+rpcport=8002
+tracker=http://hubris.media.mit.edu:46580
+autoListenPort=2449
+autoReconnect=true
+autoReconnectInterval=5
+```
+
+Then run lit as:
+
+```
+alice@pi2:~/gofolder/src/github.com/mit-dci/lit/lit --dir=~/bnode
+```
+
+Once Alice and Bob are both set up, they can connect to each other.
+
+If Bob is on the same computer he should run lit-af with the parameters:
+
+```
+./lit-af --litHomeDir=~/bnode --autoListenPort=2449
+```
+
 
 ### Step 3: Connect
-
-Alice sets her node to listen:
-
-```
-lit-af# lis
-entered command: lis
-listening on ln1pmclh89haeswrw0unf8awuyqeu4t2uell58nea@:2448
-```
-
-n1ozwFWDbZXKYjqwySv3VaTxNZvdVmQcam is Alice's node-ID (This format will change soon).  She's listening on port 2448, but any port can be specified with the `lis` command.
 
 Bob can connect to Alice using her node-ID:
 
 ```
-lit-af# con ln1pmclh89haeswrw0unf8awuyqeu4t2uell58nea@:2448@pi2
-entered command: con ln1pmclh89haeswrw0unf8awuyqeu4t2uell58nea@:2448@pi2
+lit-af# con ln1akupazfterdadrywclht0s8kgvt3r3jga0lyez@:2448@pi2
+entered command: con ln1akupazfterdadrywclht0s8kgvt3r3jga0lyez@:2448@pi2
 connected to peer 1
 lit-af# say 1 Hi Alice!
 entered command: say 1 Hi Alice!
@@ -99,8 +126,8 @@ Bob puts the pubkey@hostname for Alice and connects.  Then he says hi to Alice.
 Before Bob can make a channel, he needs to sweep his coins to make sure they are in his segwit address.
 
 ```
-lit-af# sweep tb1qrh7xpsmlgrd7lf4vv6yyn87j4n7pdjkra9jrr9 50000000
-entered command: sweep tb1qrh7xpsmlgrd7lf4vv6yyn87j4n7pdjkra9jrr9 50000000
+lit-af# sweep tb1qf77l4ja2kq6na0ffmekph6qv22puufqr5aatg0 50000000
+entered command: sweep tb1qf77l4ja2kq6na0ffmekph6qv22puufqr5aatg0 50000000
 Swept
 0 d297da04c43919e683ffc03539ee38e185425e8fa14d1ccae6577fbb35be575a
 ```

--- a/docs/test-setup.md
+++ b/docs/test-setup.md
@@ -46,7 +46,7 @@ reg=localhost
 rpchost=0.0.0.0
 rpcport=8001
 tracker=http://hubris.media.mit.edu:46580
-autoListenPort=:2448
+autoListenPort=2448
 autoReconnect=true
 autoReconnectInterval=5
 ```
@@ -58,30 +58,32 @@ Copy the file to both folders (`lit1` and `lit2`). Open the copy in the `lit2` f
 Open two terminal or command-line windows (`cmd.exe` on Windows, `xterm` on Linux, `Terminal` on MacOS) and `cd` to the directory where you put the LIT assemblies. In the first window, type this command to start up the first LIT node:
 
 (On Unix / MacOS:)
-```./lit --dir lit1``` 
+```./lit --dir=/path/to/lit1``` 
 
 (On Windows:)
-```lit.exe --dir lit1```
+```lit.exe --dir=/path/to/lit1```
 
 When starting up LIT will ask you for a passphrase to protect your wallet. You _can_ leave it empty in development/test scenarios but in general it's recommended to set a password.
 
 Then, similarly for the first node, use the second terminal window to start the second node:
 
 (On Unix / MacOS:)
-```./lit --dir lit2``` 
+```./lit --dir=/path/to/lit2``` 
 
 (On Windows:)
-```lit.exe --dir lit2```
+```lit.exe --dir=/path/to/lit2```
 
 ## Step 5: Fund the LIT wallets
 
-Now that the nodes are up, we should fund the wallets. Open another command line window, and go to the directory where you downloaded the binaries. We use the command line client `lit-af`. You can connect to the first LIT node using the following command:
+Now that the nodes are up, we should fund the wallets. Open another command line window, and go to the directory where you downloaded the binaries. We use the command line client `lit-af`. You can connect to the LIT nodes using the following commands:
 
 (On Unix / MacOS:)
-```./lit-af``` 
+```./lit-af --litHomeDir=/path/to/lit1 --autoListenPort=2448```
+```./lit-af --litHomeDir=/path/to/lit2 --autoListenPort=2449``` 
 
 (On Windows:)
-```lit-af.exe```
+```lit-af.exe --litHomeDir=/path/to/lit1 --autoListenPort=2448```
+```lit-af.exe --litHomeDir=/path/to/lit2 --autoListenPort=2449```
 
 Next, issue the `ls` command. You'll see your address printed out to the console:
 
@@ -115,13 +117,8 @@ Listening for connections on port(s) [:2448] with key ln1a9pp6jv4rgz0r7wh9tqcn89
 	Type: 257	Sync Height: 201	FeeRate: 80	Utxo: 1000000000	WitConf: 1000000000 Channel: 0
 ```
 
-Repeat the funding steps for the second node, only use an extra parameter to `lit-af` to connect to it (since it's running on another port):
+Repeat the funding steps for the second node.
 
-(On Unix / MacOS:)
-```./lit-af -p 8002``` 
-
-(On Windows:)
-```lit-af.exe -p 8002```
 
 ## Step 6: Connect the nodes together
 

--- a/lit.go
+++ b/lit.go
@@ -299,10 +299,13 @@ func main() {
 	rpcl.OffButton = make(chan bool, 1)
 	node.RPC = rpcl
 
+	// "conf.UnauthRPC" enables unauthenticated Websocket RPC. Default - false.
 	if conf.UnauthRPC {
 		go litrpc.RPCListen(rpcl, conf.Rpchost, conf.Rpcport)
 	}
 
+	// conf.AutoReconnect Attempts to automatically reconnect to known peers periodically. Default - true
+	// conf.NoAutoListen Don't automatically listen on any ports. Default - false
 	if conf.AutoReconnect && !conf.NoAutoListen {
 		node.AutoReconnect(conf.AutoListenPort, conf.AutoReconnectInterval, conf.AutoReconnectOnlyConnectedCoins)
 	}


### PR DESCRIPTION
Now you can run the lit-af for several instances of a lit on single machine as:

./lit-af --litHomeDir=/path/to/lit1 --autoListenPort=2448
./lit-af --litHomeDir=/path/to/lit2 --autoListenPort=2449