### PR TITLE
fix invalid pseudo-version of go-nat-pmp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/getlantern/deepcopy v0.0.0-20160317154340-7f45deb8130a
 	github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c
 	github.com/jackpal/gateway v1.0.5
-	github.com/jackpal/go-nat-pmp v0.0.0-20181021122511-d89d09f6f332 // latest release has issue, but go doesn't let you do head if there are releases.
+	github.com/jackpal/go-nat-pmp v0.0.0-20181021192511-d89d09f6f332 // latest release has issue, but go doesn't let you do head if there are releases.
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/mattn/go-colorable v0.1.1 // indirect
 	github.com/mattn/go-isatty v0.0.6 // indirect
@@ -24,3 +24,5 @@ require (
 	golang.org/x/sys v0.0.0-20190306171555-70f529850638 // indirect
 	golang.org/x/text v0.3.0 // indirect
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/jackpal/gateway v1.0.5 h1:qzXWUJfuMdlLMtt0a3Dgt+xkWQiA5itDEITVJtuSwMc
 github.com/jackpal/gateway v1.0.5/go.mod h1:lTpwd4ACLXmpyiCTRtfiNyVnUmqT9RivzCDQetPfnjA=
 github.com/jackpal/go-nat-pmp v0.0.0-20181021122511-d89d09f6f332 h1:taVnlVCxVFm9YTGyVhvCXxFii5jzI2HRRWvJzRTg+LY=
 github.com/jackpal/go-nat-pmp v0.0.0-20181021122511-d89d09f6f332/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
+github.com/jackpal/go-nat-pmp v0.0.0-20181021192511-d89d09f6f332 h1:a7NFNcFwp6ML57qUCGcryjr1G5Z5Mh3855uMfUgIIlU=
+github.com/jackpal/go-nat-pmp v0.0.0-20181021192511-d89d09f6f332/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
 github.com/jackpal/go-nat-pmp v1.0.1 h1:i0LektDkO1QlrTm/cSuP+PyBCDnYvjPLGl4LdWEMiaA=
 github.com/jackpal/go-nat-pmp v1.0.1/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
 github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=


### PR DESCRIPTION
20181021122511 is a local time (time zone -7) , so it will break my building using "go build"

go: github.com/jackpal/go-nat-pmp@v0.0.0-20181021122511-d89d09f6f332: invalid pseudo-version: does not match version-control timestamp (2018-10-21T19:25:11Z)